### PR TITLE
Support urchin command line args

### DIFF
--- a/ccmlib/urchin_node.py
+++ b/ccmlib/urchin_node.py
@@ -137,7 +137,9 @@ class UrchinNode(Node):
 
         pidfile = os.path.join(self.get_path(), 'cassandra.pid')
         # FIXME we do not support this forcing specific settings
-        args = [launch_bin, os.path.join(self.get_path(), 'bin', 'seastar'), '--options-file', os.path.join(self.get_path(), 'conf', 'cassandra.yaml'),'--smp','1']
+        args = [launch_bin, os.path.join(self.get_path(), 'bin', 'seastar'), '--options-file', os.path.join(self.get_path(), 'conf', 'cassandra.yaml')] + jvm_args
+        if '--smp' not in args:
+           args += ['--smp', '1']
         #args = [launch_bin, '-p', pidfile, '-Dcassandra.join_ring=%s' % str(join_ring)]
         #if replace_token is not None:
         #    args.append('-Dcassandra.replace_token=%s' % str(replace_token))


### PR DESCRIPTION
Support urchin command line args via jvm_args option. The name jvm_args
is "bad" yet it is supported for cassandra/dse and as such its simple to
use it for passing command line args

Currently testing for --smp flag, if not passed setting --smp 1

Signed-off-by: Shlomi Livne shlomi@cloudius-systems.com
