### PR TITLE
Support logging

### DIFF
--- a/ccmlib/urchin_node.py
+++ b/ccmlib/urchin_node.py
@@ -166,10 +166,6 @@ class UrchinNode(Node):
             # FIXME
             process = subprocess.Popen(args,stdout=FNULL,stderr=FNULL,close_fds=True)
             #process = subprocess.Popen(args, stdout=FNULL, stderr=subprocess.PIPE)
-            # FIXME workaround create empty system.log
-            l = open(os.path.join(self.get_path(), 'logs','system.log'),"w")
-            l.write("Starting listening for CQL clients")
-            l.close
             # FIXME workaround create pid file
             pidfile = os.path.join(self.get_path(), 'cassandra.pid')
             f = open(pidfile,"w")

--- a/resources/bin/run.sh
+++ b/resources/bin/run.sh
@@ -11,7 +11,10 @@ do
 done
 let i=$i+1
 ip=`cat ${!i} | grep 'listen_address' | cut -f2 -d' '`
-exec "$2" "${@:3}" <&- 2>&1 | tee "$1" &
+# FIXME workaround for log message
+echo "Starting listening for CQL clients" >> $1
+echo "end facked message" >> $1
+exec "$2" "${@:3}" <&- 2>&1 | tee -a "$1" &
 sleep 2
 
 sleep 8


### PR DESCRIPTION
Add support for writing urchin loggin unto the logs/system.log file
currently the stdout+stderr are written to it. To change the default
logging settings on ccm start --jvm_arg options can be passed and those
are propagated to urchin command line. For exmaple to change
default-log-level to trace "ccm start --jvm_arg=--default-log-level
--jvm_arg=trace" should be executed.
