### PR TITLE
Add support for nodetool

### DIFF
--- a/ccmlib/urchin_node.py
+++ b/ccmlib/urchin_node.py
@@ -141,7 +141,7 @@ class UrchinNode(Node):
              data = yaml.load(f)
         jvm_args = jvm_args + ['--api-address',data['api_address']]
 
-        args = [launch_bin, os.path.join(self.get_path(), 'logs', 'system.log'), os.path.join(self.get_path(), 'bin', 'scylla'), '--options-file', os.path.join(self.get_path(), 'conf', 'cassandra.yaml')] + jvm_args
+        args = [launch_bin, self.get_path()] + jvm_args
         if '--smp' not in args:
            args += ['--smp', '1']
         if '--memory' not in args:

--- a/resources/bin/run.sh
+++ b/resources/bin/run.sh
@@ -1,23 +1,17 @@
 #!/bin/sh -x
 
-# 1 - log file to write output
-# 2 - executable
+# 1 - root path of node
 # 3 - args
 
 i=0
-until [ ${!i} == '--options-file' ];
-do
-   let i=$i+1
-done
-let i=$i+1
-ip=`cat ${!i} | grep 'listen_address' | cut -f2 -d' '`
+ip=`cat $1/conf/cassandra.yaml | grep 'listen_address' | cut -f2 -d' '`
+jmx_port=`cat $1/node.conf | grep 'jmx_port' | cut -f2 -d"'"`
 # FIXME workaround for log message
 echo "Starting listening for CQL clients" >> $1
 echo "end facked message" >> $1
-exec "$2" "${@:3}" <&- 2>&1 | tee -a "$1" &
+exec $1/bin/scylla --options-file $1/conf/cassandra.yaml "${@:2}" <&- 2>&1 | tee -a "$1/logs/system.log" &
 sleep 2
 # FIXME workaround for starting urchin-jmx - should use run script
-exec_dir=$(dirname $2)
-exec java -Dapiaddress=$ip -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=7100 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -jar $exec_dir/urchin-mbean-1.0.jar <&- 2>$1.jmx &
+exec java -Dapiaddress=$ip -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=$jmx_port -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -jar $1/bin/urchin-mbean-1.0.jar <&- 2>$1.jmx &
 
 sleep 8


### PR DESCRIPTION
Move urchin command line start into run.sh instead from being from
command line - this may need to be reveresed once urchin script can be
used

Extract jmx_port from node.conf

Signed-off-by: Shlomi Livne shlomi@cloudius-systems.com
