### PR TITLE
Use urchin conf file instead of copy a cassandra.yaml file

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -23,6 +23,7 @@ URCHIN_CONF_DIR= "conf"
 
 
 CASSANDRA_CONF = "cassandra.yaml"
+URCHIN_CONF = "scylla.yaml"
 LOG4J_CONF = "log4j-server.properties"
 LOG4J_TOOL_CONF = "log4j-tools.properties"
 LOGBACK_CONF = "logback.xml"
@@ -349,7 +350,9 @@ def validate_install_dir(install_dir):
         conf_dir = os.path.join(install_dir, CASSANDRA_CONF_DIR)
     cnd = os.path.exists(bin_dir)
     cnd = cnd and os.path.exists(conf_dir)
-    if isUrchin(install_dir) or not isOpscenter(install_dir):
+    if isUrchin(install_dir):
+        cnd = os.path.exists(os.path.join(conf_dir, URCHIN_CONF))
+    elif not isOpscenter(install_dir):
         cnd = cnd and os.path.exists(os.path.join(conf_dir, CASSANDRA_CONF))
     if not cnd:
         raise ArgumentError('%s does not appear to be a cassandra or dse installation directory' % install_dir)

--- a/ccmlib/urchin_node.py
+++ b/ccmlib/urchin_node.py
@@ -343,6 +343,8 @@ class UrchinNode(Node):
         # FIXME override node - enable logging
         self._update_config()
         self.copy_config_files()
+        # FIXME - for now moving scylla.yaml to cassandra.yaml
+        os.rename(os.path.join(self.get_conf_dir(),"scylla.yaml"),os.path.join(self.get_conf_dir(),"cassandra.yaml"))
         self.__update_yaml()
         ## loggers changed > 2.1
         #if self.get_base_cassandra_version() < 2.1:


### PR DESCRIPTION
- code uses urchin code file
- to simplify coding (as all the rest of the code assumes a specific
  name) it renames the file to cassandra.yaml after it has been copied to
  the node conf directory

Signed-off-by: Shlomi Livne shlomi@cloudius-systems.com
