### PR TITLE
Overload flush

### DIFF
--- a/ccmlib/urchin_node.py
+++ b/ccmlib/urchin_node.py
@@ -634,3 +634,8 @@ class UrchinNode(Node):
     # Overload
     def watch_log_for_alive(self, nodes, from_mark=None, timeout=120):
         return True
+
+    # Overload - FIXME - urchin flush is aynch - so it returns immediatly
+    def flush(self):
+        self.nodetool("flush")
+        time.sleep(2)


### PR DESCRIPTION
Urchin flush command is asynch - it returns immedialty when called. In
origin the command returns after the flush has completed. Till we
resolve this issue 154 in urchin is fixed

Signed-off-by: Shlomi Livne shlomi@cloudius-systems.com
