### PR TITLE
Add support for defining an urchin cluster using debug or release mode

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -311,13 +311,8 @@ def isUrchin(install_dir):
     if install_dir is None:
         raise ArgumentError('Undefined installation directory')
 
-    bin_dir = os.path.join(install_dir, os.path.join('build','release'))
-
-    if not os.path.exists(bin_dir):
-        return False
-
-    urchin_exec = os.path.join(bin_dir, 'scylla')
-    return os.path.exists(urchin_exec)
+    return (os.path.exists(os.path.join(install_dir,'scylla')) or
+        os.path.exists(os.path.join(install_dir,'build','release','scylla')))
 
 def isOpscenter(install_dir):
     if install_dir is None:
@@ -331,6 +326,16 @@ def isOpscenter(install_dir):
     opscenter_script = os.path.join(bin_dir, 'opscenter')
     return os.path.exists(opscenter_script)
 
+def urchin_extract_install_dir_and_mode(install_dir):
+    urchin_mode='release'
+    if install_dir.endswith('build/debug') or install_dir.endswith('build/debug/'):
+       urchin_mode='debug'
+       install_dir = str(os.path.join(install_dir,os.pardir,os.pardir))
+    if install_dir.endswith('build/release') or install_dir.endswith('build/release/'):
+       urchin_mode='release'
+       install_dir = str(os.path.join(install_dir,os.pardir,os.pardir))
+    return install_dir,urchin_mode;
+
 def validate_install_dir(install_dir):
     if install_dir is None:
         raise ArgumentError('Undefined installation directory')
@@ -342,7 +347,8 @@ def validate_install_dir(install_dir):
 
     bin_dir = os.path.join(install_dir, BIN_DIR)
     if isUrchin(install_dir):
-        bin_dir = os.path.join(install_dir, os.path.join('build','release'))
+        install_dir,mode = urchin_extract_install_dir_and_mode(install_dir)
+        bin_dir = install_dir
         conf_dir = os.path.join(install_dir, URCHIN_CONF_DIR)
     elif isDse(install_dir):
         conf_dir = os.path.join(install_dir, DSE_CASSANDRA_CONF_DIR)

--- a/ccmlib/urchin_cluster.py
+++ b/ccmlib/urchin_cluster.py
@@ -11,7 +11,8 @@ from ccmlib.urchin_node import UrchinNode
 from ccmlib import common
 
 class UrchinCluster(Cluster):
-    def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, verbose=False, **kwargs):
+    def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, verbose=False):
+        install_dir, self.urchin_mode=common.urchin_extract_install_dir_and_mode(install_dir)
         super(UrchinCluster, self).__init__(path, name, partitioner, install_dir, create_directory, version, verbose)
 
     def load_from_repository(self, version, verbose):
@@ -29,3 +30,6 @@ class UrchinCluster(Cluster):
     def cassandra_version(self):
         # FIXME
         return '2.1'
+
+    def get_urchin_mode(self):
+        return self.urchin_mode;

--- a/ccmlib/urchin_node.py
+++ b/ccmlib/urchin_node.py
@@ -401,7 +401,8 @@ class UrchinNode(Node):
             shutil.copy(os.path.join(self.get_install_dir(), 'resources', 'cassandra', 'tools','bin',name), os.path.join(self.get_path(), 'resources', 'cassandra', 'tools','bin',name))
 
         # FIXME - currently no scripts only executable - copying exec
-        shutil.copy(os.path.join(self.get_install_dir(), 'build', 'release', 'scylla'), self.get_bin_dir())
+        urchin_mode = self.cluster.get_urchin_mode();
+        shutil.copy(os.path.join(self.get_install_dir(), 'build', urchin_mode, 'scylla'), self.get_bin_dir())
         shutil.copy(os.path.join(self.get_install_dir(), '../urchin-jmx', 'target', 'urchin-mbean-1.0.jar'), self.get_bin_dir())
 
         resources_bin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'resources', 'bin')


### PR DESCRIPTION
install_dir can now point to:
- root directory of urchin in which case build/release/scylla will be
  used
- <urchin>/build/release of urchin in which case build/release/scylla
  will be used
- <urchin>/build/debug of urchin in which case build/debug/scylla will
  be used

Signed-off-by: Shlomi Livne shlomi@cloudius-systems.com
