### PR TITLE
Remove workaround log message of CQL startup

### DIFF
--- a/resources/bin/run.sh
+++ b/resources/bin/run.sh
@@ -6,9 +6,6 @@
 i=0
 ip=`cat $1/conf/cassandra.yaml | grep 'listen_address' | cut -f2 -d' '`
 jmx_port=`cat $1/node.conf | grep 'jmx_port' | cut -f2 -d"'"`
-# FIXME workaround for log message
-echo "Starting listening for CQL clients" >> $1/logs/system.log
-echo "end facked message" >> $1
 exec $1/bin/scylla --options-file $1/conf/scylla.yaml "${@:2}" <&- 2>&1 | tee -a "$1/logs/system.log" &
 sleep 2
 # FIXME workaround for starting urchin-jmx - should use run script


### PR DESCRIPTION
Urchin commit 2e6dd2f5854f1b18944181371ea7a2455106a775 fixed the issue

Signed-off-by: Shlomi Livne shlomi@cloudius-systems.com
