### PR TITLE
Remove workround for overloading watch_log_for_alive

### DIFF
--- a/ccmlib/urchin_node.py
+++ b/ccmlib/urchin_node.py
@@ -631,10 +631,6 @@ class UrchinNode(Node):
             f.write('log4j.appender.R.File=./log/agent.log\n')
             f.close()
 
-    # Overload
-    def watch_log_for_alive(self, nodes, from_mark=None, timeout=120):
-        return True
-
     # Overload - FIXME - urchin flush is aynch - so it returns immediatly
     def flush(self):
         self.nodetool("flush")


### PR DESCRIPTION
We are compatible in printouts for node state - so we can search the log
for the state

Signed-off-by: Shlomi Livne shlomi@cloudius-systems.com
