### PR TITLE
Use hard linke when possible fall back to copy when its not possible

### DIFF
--- a/ccmlib/urchin_node.py
+++ b/ccmlib/urchin_node.py
@@ -407,23 +407,32 @@ class UrchinNode(Node):
                     common.rmdirs(dst_webapps)
                 shutil.copytree(src_webapps, dst_webapps)
 
+    def hard_link_or_copy(self,src,dst):
+        try:
+            os.link(src,dst)
+        except OSError as oserror:
+            if oserror.errno == errno.EXDEV or oserror.errno == errno.EMLINK:
+                shutil.copy(src,dst)
+            else:
+                raise oserror
+
     def import_bin_files(self):
         # selectivly copying files to reduce risk of using unintended items
         files = ['cassandra.in.sh','nodetool']
         os.makedirs(os.path.join(self.get_path(), 'resources', 'cassandra', 'bin'))
         for name in files:
-            os.link(os.path.join(self.get_install_dir(), 'resources', 'cassandra', 'bin',name), os.path.join(self.get_path(), 'resources', 'cassandra', 'bin',name))
+            self.hard_link_or_copy(os.path.join(self.get_install_dir(), 'resources', 'cassandra', 'bin',name), os.path.join(self.get_path(), 'resources', 'cassandra', 'bin',name))
 
         # selectivly copying files to reduce risk of using unintended items
         files = ['sstable2json']
         os.makedirs(os.path.join(self.get_path(), 'resources', 'cassandra', 'tools','bin'))
         for name in files:
-            os.link(os.path.join(self.get_install_dir(), 'resources', 'cassandra', 'tools','bin',name), os.path.join(self.get_path(), 'resources', 'cassandra', 'tools','bin',name))
+            self.hard_link_or_copy(os.path.join(self.get_install_dir(), 'resources', 'cassandra', 'tools','bin',name), os.path.join(self.get_path(), 'resources', 'cassandra', 'tools','bin',name))
 
         # FIXME - currently no scripts only executable - copying exec
         urchin_mode = self.cluster.get_urchin_mode();
-        os.link(os.path.join(self.get_install_dir(), 'build', urchin_mode, 'scylla'), os.path.join(self.get_bin_dir(),'scylla'))
-        os.link(os.path.join(self.get_install_dir(), '../urchin-jmx', 'target', 'urchin-mbean-1.0.jar'), os.path.join(self.get_bin_dir(),'urchin-mbean-1.0.jar'))
+        self.hard_link_or_copy(os.path.join(self.get_install_dir(), 'build', urchin_mode, 'scylla'), os.path.join(self.get_bin_dir(),'scylla'))
+        self.hard_link_or_copy(os.path.join(self.get_install_dir(), '../urchin-jmx', 'target', 'urchin-mbean-1.0.jar'), os.path.join(self.get_bin_dir(),'urchin-mbean-1.0.jar'))
 
         resources_bin_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'resources', 'bin')
         for name in os.listdir(resources_bin_dir):


### PR DESCRIPTION
Use hard links for files copied into a node bin directory. If  hard link
is not possible (e.g. different devices or to many links) copy files.

Signed-off-by: Shlomi Livne shlomi@cloudius-systems.com
