### PR TITLE
For each node use a single appended log file for all the test

### DIFF
--- a/resources/bin/run.sh
+++ b/resources/bin/run.sh
@@ -6,8 +6,7 @@
 i=0
 ip=`cat $1/conf/cassandra.yaml | grep 'listen_address' | cut -f2 -d' '`
 jmx_port=`cat $1/node.conf | grep 'jmx_port' | cut -f2 -d"'"`
-rm -Rf $1/logs/system.log
-echo "" > $1/logs/system.log
+echo "" >> $1/logs/system.log
 export SCYLLA_HOME=$1
 shift
 exec $SCYLLA_HOME/bin/scylla --options-file $SCYLLA_HOME/conf/scylla.yaml "$@" <&- 2>&1 | tee -a "$SCYLLA_HOME/logs/system.log" &


### PR DESCRIPTION
When stopping and starting a node continue using the same log file
appending new log messages to the end of the log file

Asias detected this difference in behaviour

Signed-off-by: Shlomi Livne shlomi@scylladb.com
