### PR TITLE
Use replace address

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -162,9 +162,6 @@ class ScyllaNode(Node):
             # TODO: Support same cmdline options
             process = subprocess.Popen(args, stdout=FNULL, stderr=FNULL,
                                        close_fds=True)
-            # TODO: workaround create pid file
-            pidfile = os.path.join(self.get_path(), 'cassandra.pid')
-            f = open(pidfile, "w")
             # we are waiting for the run script to have time to
             # run scylla process
             time.sleep(1)
@@ -172,11 +169,11 @@ class ScyllaNode(Node):
             child_p = p.children()
             if child_p[0].name() != 'scylla':
                 raise NodeError("Error starting scylla node")
-            f.write(str(child_p[0].pid))
-            f.flush()
-            os.fsync(f)
-            f.close
-            os.fsync(f)
+
+            pid_filename = os.path.join(self.get_path(),
+                                        'cassandra.pid')
+            with open(pid_filename, 'w') as pid_file:
+                pid_file.write(str(child_p[0].pid))
 
             # we are waiting to make sure the java process is up
             # by connecting to the port


### PR DESCRIPTION
A couple of changes to `ScyllaNode.start()` required by the recent `replace_address_test`.
