### PR TITLE
ccmlib.cmds.cluster_cmds: Fix incorrect call to splitlines()

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -578,7 +578,7 @@ class ClusterStartCmd(Cmd):
             if e.process is not None:
                 if e.process.stderr is not None:
                     print_("Standard error output is:", file=sys.stderr)
-                    for line in e.process.stderr.splitlines():
+                    for line in e.process.stderr:
                         print_(line.rstrip('\n'), file=sys.stderr)
                 else:
                     print_("Process died prematurely and doesn't have "


### PR DESCRIPTION
I've evaluated incorrectly the .stderr object, thinking
it was a string. It's not, it's a file pointing to the
subprocess stdout, so let's remove the call to splitlines().

Signed-off-by: Lucas Meneghel Rodrigues lmr@scylladb.com
