### PR TITLE
do not translate args in case they do match a cassandra arg

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -120,7 +120,7 @@ class ScyllaNode(Node):
                                            value]
                 # Otherwise, just pass it as is
                 else:
-                    new_jvm_args += split_option
+                    new_jvm_args.append(jvm_arg)
             else:
                 new_jvm_args.append(jvm_arg)
         jvm_args = new_jvm_args


### PR DESCRIPTION
cassandra jvm args are translated to scylla command line args. In case
trsnaltion fails append the arg as is.

This allow supporting of scylla args with = sign such as:
'--logger-log-level','storage_service=trace'

Signed-off-by: Shlomi Livne shlomi@scylladb.com
