### PR TITLE
ccmlib.scylla_node: Pass developer mode

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -169,6 +169,8 @@ class ScyllaNode(Node):
             id = int(data['listen_address'].split('.')[3]) - 1
             cpuset = self.cpuset(id, smp)
             args += ['--cpuset', ','.join(cpuset)]
+        if '--developer-mode' not in args:
+            args += ['--developer-mode', 'true']
         if replace_address:
             args += ['--replace-address', replace_address]
 


### PR DESCRIPTION
In order to help production users to use scylla with
more optimal settings for performance and stability,
some strict environment checks are in place, such as
the use of XFS and setting rlimit to 200k. It's possible
to override those restrictions with --developer-mode,
so let's pass it to scylla when using CCM.

Signed-off-by: Lucas Meneghel Rodrigues lmr@scylladb.com
