### PR TITLE
Restart scylla_jmx if scylla is running

### DIFF
--- a/resources/bin/run.sh
+++ b/resources/bin/run.sh
@@ -10,10 +10,16 @@ echo "" >> $1/logs/system.log
 export SCYLLA_HOME=$1
 shift
 exec $SCYLLA_HOME/bin/scylla --options-file $SCYLLA_HOME/conf/scylla.yaml "$@" <&- 2>&1 | tee -a "$SCYLLA_HOME/logs/system.log" &
+pid=$!
 sleep 2
 # FIXME workaround for starting scylla-jmx - should use run script
 pkill -f com.sun.management.jmxremote.port=$jmx_port || true
 sleep 2
-exec java -Dapiaddress=$ip -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=$jmx_port -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -jar $SCYLLA_HOME/bin/scylla-jmx-1.0.jar <&- 2>&1 | tee -a "$SCYLLA_HOME/logs/system.log.jmx" &
+count=0
+tmp=/tmp/run.$$
+echo "while kill -0 $pid && [[ ($count < 10) ]] ; do let count+1 ; java -Dapiaddress=$ip -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=$jmx_port -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -jar $SCYLLA_HOME/bin/scylla-jmx-1.0.jar <&- 2>&1 | tee -a $SCYLLA_HOME/logs/system.log.jmx; done" > $tmp
+chmod 777 $tmp
+exec $tmp &
+rm $tmp
 
 sleep 6


### PR DESCRIPTION
scylla_jmx is setup to kill it self if it is unable to connect to scylla
after a number of attempts. Since the http interface of scylla is
started only at the last step, it could be that the cylla-jmx will fail
although at the end scylla boots succesfully.

The cases of http start being delayed are not uncommon, as an example
when bootstrapping a new node - http will be started only after the
node receives all the data it owns.

Once http is started earlier in scylla boot this workaround can be
reverted

Signed-off-by: Shlomi Livne shlomi@scylladb.com
