### PR TITLE
Move the test of scylla-jmx after cql start

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -224,22 +224,6 @@ class ScyllaNode(Node):
             # we are waiting to make sure the java process is up
             # by connecting to the port
             time.sleep(2)
-            java_up = False
-            iteration = 0
-            while not java_up and iteration < 10:
-                iteration += 1
-                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                try:
-                    s.settimeout(1.0)
-                    s.connect((data['listen_address'], int(self.jmx_port)))
-                    java_up = True
-                except:
-                    java_up = False
-                try:
-                    s.close()
-                except:
-                    pass
-            time.sleep(1)
 
         # Our modified batch file writes a dirty output with more than
         # just the pid - clean it to get in parity
@@ -265,6 +249,26 @@ class ScyllaNode(Node):
             # more because the msg is logged just before starting the binary
             # protocol server
             time.sleep(0.2)
+
+        java_up = False
+        iteration = 0
+        while not java_up and iteration < 30:
+           iteration += 1
+           s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+           try:
+               s.settimeout(1.0)
+               s.connect((data['listen_address'], int(self.jmx_port)))
+               java_up = True
+           except:
+               java_up = False
+           try:
+               s.close()
+           except:
+               pass
+           time.sleep(1)
+
+        if java_up == False:
+            raise NodeError("Error starting node %s" % self.name, process)
 
         self.is_running()
         return process


### PR DESCRIPTION
Test of scylla-jmx being up was placed after starting the process. As
xyll-jmx is dependent on scylla http api being up. This may delayed due
to bootstrap procedures (streaming of data, replaying of commitlog etc).

Move the test of scylla-jmx after other tests have been completed (CQL
interface being up / other nodes identifying that the node is up).

If scylla-jmx is not up - then node startup has failed. Updated the
number of iterations as well from 10 to 30

This fixes some tests failing inconsistently on nodeool not able to
connect.

Signed-off-by: Shlomi Livne shlomi@scylladb.com
