### PR TITLE
Split the scylla-jmx boot and the scylla boot into two steps

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -100,7 +100,7 @@ class ScyllaCluster(Cluster):
         if wait_for_binary_proto and self.version() >= '1.2':
             for node, _, mark in started:
                 node.watch_log_for("Starting listening for CQL clients",
-                                   process=p, verbose=verbose, from_mark=mark)
+                                   verbose=verbose, from_mark=mark)
             time.sleep(0.2)
 
         return started

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -250,6 +250,13 @@ class ScyllaNode(Node):
             # protocol server
             time.sleep(0.2)
 
+        launch_bin = common.join_bin(self.get_path(), 'bin', 'run_jmx.sh')
+        os.chmod(launch_bin, os.stat(launch_bin).st_mode | stat.S_IEXEC)
+        args[0] = launch_bin
+        FNULL = open(os.devnull, 'w')
+        process_jmx = subprocess.Popen(args, stdout=FNULL,
+                                   stderr=FNULL,
+                                   close_fds=True)
         java_up = False
         iteration = 0
         while not java_up and iteration < 30:

--- a/resources/bin/run.sh
+++ b/resources/bin/run.sh
@@ -10,16 +10,6 @@ echo "" >> $1/logs/system.log
 export SCYLLA_HOME=$1
 shift
 exec $SCYLLA_HOME/bin/scylla --options-file $SCYLLA_HOME/conf/scylla.yaml "$@" <&- 2>&1 | tee -a "$SCYLLA_HOME/logs/system.log" &
-pid=$!
-sleep 2
-# FIXME workaround for starting scylla-jmx - should use run script
-pkill -f com.sun.management.jmxremote.port=$jmx_port || true
-sleep 2
-count=0
-tmp=/tmp/run.$$
-echo "while kill -0 $pid && [[ ($count < 10) ]] ; do let count+1 ; java -Dapiaddress=$ip -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=$jmx_port -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -jar $SCYLLA_HOME/bin/scylla-jmx-1.0.jar <&- 2>&1 | tee -a $SCYLLA_HOME/logs/system.log.jmx; done" > $tmp
-chmod 777 $tmp
-exec $tmp &
-rm $tmp
+pkill -9 -f com.sun.management.jmxremote.port=$jmx_port || true
 
 sleep 6

--- a/resources/bin/run_jmx.sh
+++ b/resources/bin/run_jmx.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -x
+
+# 1 - root path of node
+# 3 - args
+
+i=0
+ip=`cat $1/conf/cassandra.yaml | grep 'listen_address' | cut -f2 -d' '`
+jmx_port=`cat $1/node.conf | grep 'jmx_port' | cut -f2 -d"'"`
+export SCYLLA_HOME=$1
+shift
+pkill -9 -f com.sun.management.jmxremote.port=$jmx_port || true
+sleep 2
+count=0
+tmp=/tmp/run.$$
+echo "while kill -0 `cat $SCYLLA_HOME/cassandra.pid` && [[ ($count < 10) ]] ; do let count+1 ; java -Dapiaddress=$ip -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=$jmx_port -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -jar $SCYLLA_HOME/bin/scylla-jmx-1.0.jar <&- 2>&1 | tee -a $SCYLLA_HOME/logs/system.log.jmx; sleep 1; done ; rm $tmp" > $tmp
+chmod 777 $tmp
+exec $tmp &


### PR DESCRIPTION
The current attempts to start the scylla-jmx in the same script as
scylla (run.sh) have not prevaled. In some cases this has failed.

Till we have the http starting in scylla at the start (allowing the jmx
to start immediatly after scylla is started) spliting the boot into two
steps. run.sh will start scylla, run_jmx will start scylla_jmx. run_jmx
is executed after all other validations have been done
(wait_other_notice/waito_for_binary_proto).

Signed-off-by: Shlomi Livne shlomi@scylladb.com
