### PR TITLE
stress_object should ignore the jmx connection worning

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1115,7 +1115,7 @@ class Node(object):
 
     def stress_object(self, stress_options=[], **kwargs):
         out, err = self.stress(stress_options, True, **kwargs)
-        if err != "":
+        if err != "" and not err.startswith("Failed to connect over JMX; not collecting these stats"):
             return err
         p = re.compile('^\s*([^:]+)\s*:\s*(\S.*)\s*$')
         res = {}


### PR DESCRIPTION
The stress_object method check for errors before creating an object
from the stress result.

When running against cassandra the jmx error should be ignore.

Signed-off-by: Amnon Heiman amnon@scylladb.com
