### PR TITLE
cassandra stress: Picked up JAVA_TOOL_OPTIONS is not an error

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1115,7 +1115,7 @@ class Node(object):
 
     def stress_object(self, stress_options=[], **kwargs):
         out, err = self.stress(stress_options, True, **kwargs)
-        if err != "" and not err.startswith("Failed to connect over JMX; not collecting these stats"):
+        if err != "" and not err.startswith("Failed to connect over JMX; not collecting these stats") and not err.startswith("Picked up JAVA_TOOL_OPTIONS"):
             return err
         p = re.compile('^\s*([^:]+)\s*:\s*(\S.*)\s*$')
         res = {}


### PR DESCRIPTION
The cassnadra stress prints the warning: Picked up JAVA_TOOL_OPTIONS.
This is not an error and should be ignored.

Signed-off-by: Amnon Heiman amnon@scylladb.com
