### PR TITLE
add support for env SCYlLA_EXT_OPTS

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -155,6 +155,21 @@ class ScyllaNode(Node):
 
         # Let's add jvm_args and the translated args
         args = [launch_bin, self.get_path()] + jvm_args + translated_args
+        
+        # Lets search for default overrides in SCYLLA_EXT_OPTS
+        scylla_ext_opts = os.getenv('SCYLLA_EXT_OPTS', "").split()
+        opts_i = 0
+        while (opts_i < len(scylla_ext_opts)):
+            if scylla_ext_opts[opts_i].startswith('-'):
+               add = False
+               if scylla_ext_opts[opts_i] not in args:
+                  add = True
+               args.append(scylla_ext_opts[opts_i])
+               opts_i = opts_i + 1
+               while opts_i < len(scylla_ext_opts) and not scylla_ext_opts[opts_i].startswith('-'):
+                  if add: args.append(scylla_ext_opts[opts_i])
+                  opts_i = opts_i + 1
+            
 
         if '--developer-mode' not in args:
             args += ['--developer-mode', 'true']


### PR DESCRIPTION
SCYLLA_EXT_OPTS allows overriding defaults such as --smp 1,
--default-log-level info.

Signed-off-by: Shlomi Livne shlomi@scylladb.com
