### PR TITLE
scylla-jmx run script change from running java

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -386,6 +386,11 @@ class ScyllaNode(Node):
                                os.path.join(self.get_bin_dir(),
                                             'scylla-jmx'))
 
+        os.makedirs(os.path.join(self.get_bin_dir(), 'symlinks'))
+        os.symlink('/usr/bin/java', os.path.join(self.get_bin_dir(),
+                                                 'symlinks',
+                                                 'scylla-jmx'))
+
         parent_dir = os.path.dirname(os.path.realpath(__file__))
         resources_bin_dir = os.path.join(parent_dir, '..', 'resources', 'bin')
         for name in os.listdir(resources_bin_dir):


### PR DESCRIPTION
scylladb/scylla-jmx@f6710465ef06dfa62029dd31fde24e90e97e847e
changed the scylla-jmx script to use the symlink.

creating the symlink as well for ccm

Signed-off-by: Shlomi Livne shlomi@scylladb.com
