### PR TITLE
Add support for prometheus

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -153,6 +153,7 @@ class ScyllaNode(Node):
         with open(conf_file, 'r') as f:
             data = yaml.load(f)
         jvm_args = jvm_args + ['--api-address', data['api_address']]
+        jvm_args = jvm_args + ['--prometheus-address', data['api_address']]
         jvm_args = jvm_args + ['--collectd-hostname',
                                '%s.%s' % (socket.gethostname(), self.name)]
 


### PR DESCRIPTION
Promotheus support was added and currently there is no way to disable it
as such we must specify a unique listen address to each instance running
using the api-address as the promotheus-address

Signed-off-by: Shlomi Livne shlomi@scylladb.com
