### PR TITLE
remove sstableofflinerelevel

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -509,7 +509,7 @@ class ScyllaNode(Node):
 
         # selectively copying files to reduce risk of using unintended items
         files = ['sstable2json', 'json2sstable', 'sstablelevelreset', 'sstablemetadata',
-                 'sstableofflinerelevel', 'sstablerepairedset', 'sstablesplit']
+                 'sstablerepairedset', 'sstablesplit']
         os.makedirs(os.path.join(self.get_path(), 'resources', 'cassandra',
                                  'tools', 'bin'))
         for name in files:


### PR DESCRIPTION
The sstableofflinerelelvel tool was removed as such we can not link or
copy it. Removing it from the tools that are setup when a node is
created.

Signed-off-by: Shlomi Livne shlomi@scylladb.com
