### PR TITLE
add support for scylla-mgmt

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -21,10 +21,12 @@ CASSANDRA_CONF_DIR = "conf"
 DSE_CASSANDRA_CONF_DIR = "resources/cassandra/conf"
 OPSCENTER_CONF_DIR = "conf"
 SCYLLA_CONF_DIR = "conf"
+SCYLLAMGMT_DIR = "scylla-mgmt"
 
 
 CASSANDRA_CONF = "cassandra.yaml"
 SCYLLA_CONF = "scylla.yaml"
+SCYLLAMGMT_CONF = "scylla-mgmt.yaml"
 LOG4J_CONF = "log4j-server.properties"
 LOG4J_TOOL_CONF = "log4j-tools.properties"
 LOGBACK_CONF = "logback.xml"


### PR DESCRIPTION
a scylla cluster now supports scylla-mgmt

To define a cluster that will start scylla-mgmt process:

ccm create <name> --scylla ... --install-dir=... --scylla-mgmt=<path to
mermaid dir>

example:
ccm create ... --scylla-mgmt=/home/shlomi/go/src/github.com/scylladb/mermaid

it requires to find in that directory scylla-mgmt, sctool executables

Once the cluster is created an additional directory will be added
(parallel to the nodes) scylla-mgmt - it will hold: configuration,
executables, log

sctool is the command line tool that interacts with scylla-mgmt process

sample
ccm sctool cluster add --hosts 127.0.0.1 --name test1 --shard-count 1
ccm sctool repair unit  add --keyspace keyspace1  --cluster test1 --name repair1
ccm sctool repair start --unit repair1 --cluster test1

Signed-off-by: Shlomi Livne <shlomi@scylladb.com>