### PR TITLE
node::stress_object: ignore WARNING messages from cassandra-stress

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1124,7 +1124,7 @@ class Node(object):
 
     def stress_object(self, stress_options=[], **kwargs):
         out, err = self.stress(stress_options, True, **kwargs)
-        if err != "" and not err.startswith("Failed to connect over JMX; not collecting these stats") and not err.startswith("Picked up JAVA_TOOL_OPTIONS"):
+        if err != "" and not err.startswith("Failed to connect over JMX; not collecting these stats") and not err.startswith("Picked up JAVA_TOOL_OPTIONS") and not err.startswith("WARNING:"):
             return err
         p = re.compile('^\s*([^:]+)\s*:\s*(\S.*)\s*$')
         res = {}


### PR DESCRIPTION
Ignore messages printed by cassandra-stress to stderr that start with
"WARNING:". These messages are not critical (e.g. "WARNING: An illegal reflective access operation has occurred") and the tool may complete the test just fine despite the problem that caused this kind
of a message.

Signed-off-by: Vlad Zolotarov <vladz@scylladb.com>