### PR TITLE
Revert "node: use overprovisioned flag if no cpuset"

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -331,7 +331,10 @@ class ScyllaNode(Node):
         if '--collectd' not in args:
             args += ['--collectd', '0']
         if '--cpuset' not in args:
-            args += ['--overprovisioned']
+            smp = int(args[args.index('--smp') + 1])
+            id = int(data['listen_address'].split('.')[3]) - 1
+            cpuset = self.cpuset(id, smp, self.cluster.id)
+            args += ['--cpuset', ','.join(cpuset)]
         if '--prometheus-address' not in args:
             args += ['--prometheus-address', data['api_address']]
         if replace_address:


### PR DESCRIPTION
This reverts commit b2c9bf66bb814ef69b4237e27882f0e09f6f0e3e.