### PR TITLE
Added class ScyllaREST for REST API operations, and ScyllaNode.api() method

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -19,6 +19,7 @@ from six import print_
 from ccmlib import common
 from ccmlib.node import Node
 from ccmlib.node import NodeError
+from ccmlib.scylla_rest import ScyllaREST
 
 
 def wait_for(func, timeout, first=0.0, step=1.0, text=None):
@@ -796,3 +797,7 @@ class ScyllaNode(Node):
     def flush(self):
         self.nodetool("flush")
         self._wait_no_pending_flushes()
+
+    def api(self):
+        ip = self.network_interfaces['binary'][0]
+        return ScyllaREST(ip)

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -73,6 +73,7 @@ class ScyllaNode(Node):
         self._process_jmx_waiter = None
         self._process_scylla = None
         self._process_scylla_waiter = None
+        self._rest_api = ScyllaREST(self.network_interfaces['binary'][0])
 
     def get_install_cassandra_root(self):
         return os.path.join(self.get_install_dir(), 'resources', 'cassandra')
@@ -798,6 +799,6 @@ class ScyllaNode(Node):
         self.nodetool("flush")
         self._wait_no_pending_flushes()
 
-    def api(self):
-        ip = self.network_interfaces['binary'][0]
-        return ScyllaREST(ip)
+    @property
+    def rest_api(self):
+        return self._rest_api

--- a/ccmlib/scylla_rest.py
+++ b/ccmlib/scylla_rest.py
@@ -1,0 +1,27 @@
+
+import json
+import requests
+
+class ScyllaREST():
+    def __init__(self, ip = '127.0.0.1', port = 10000):
+        self.ip = ip
+        self.port = port
+        self.url = 'http://{}:{}'.format(ip, port)
+
+    def post(self, item, params):
+        headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        }
+    
+        response = requests.post('{}/{}'.format(self.url, item), headers=headers, params=params)
+        return response
+    
+    def get(self, item, params):
+        headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        }
+        
+        response = requests.get('{}/{}'.format(self.url, item), headers=headers, params=params)
+        return response

--- a/ccmlib/scylla_rest.py
+++ b/ccmlib/scylla_rest.py
@@ -3,25 +3,19 @@ import json
 import requests
 
 class ScyllaREST():
-    def __init__(self, ip = '127.0.0.1', port = 10000):
+    def __init__(self, ip='127.0.0.1', port=10000):
         self.ip = ip
         self.port = port
         self.url = 'http://{}:{}'.format(ip, port)
-
-    def post(self, item, params):
-        headers = {
+        self.headers = {
             'Content-Type': 'application/json',
             'Accept': 'application/json',
         }
-    
-        response = requests.post('{}/{}'.format(self.url, item), headers=headers, params=params)
+
+    def post(self, item, params):
+        response = requests.post('{}/{}'.format(self.url, item), headers=self.headers, params=params)
         return response
     
     def get(self, item, params):
-        headers = {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-        }
-        
-        response = requests.get('{}/{}'.format(self.url, item), headers=headers, params=params)
+        response = requests.get('{}/{}'.format(self.url, item), headers=self.headers, params=params)
         return response


### PR DESCRIPTION
Usage example:
resp = node.api().get('column_family/toppartitions/ks:t1', {'duration': '1000'})
# use resp.text or resp.json()
