### PR TITLE
node or cluster stop: make timeout configurable

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -347,10 +347,10 @@ class Cluster(object):
 
         return started
 
-    def stop(self, wait=True, gently=True, wait_other_notice=False):
+    def stop(self, wait=True, gently=True, wait_other_notice=False, wait_iterations=7):
         not_running = []
         for node in list(self.nodes.values()):
-            if not node.stop(wait, gently=gently, wait_other_notice=wait_other_notice):
+            if not node.stop(wait, gently=gently, wait_other_notice=wait_other_notice, wait_iterations=wait_iterations):
                 not_running.append(node)
         return not_running
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -603,11 +603,14 @@ class Node(object):
 
         return process
 
-    def stop(self, wait=True, wait_other_notice=False, gently=True):
+    def stop(self, wait=True, wait_other_notice=False, gently=True, wait_iterations=7):
         """
         Stop the node.
           - wait: if True (the default), wait for the Cassandra process to be
             really dead. Otherwise return after having sent the kill signal.
+            stop() will wait up to 2^wait_iterations-1 seconds, by default
+            127 seconds, for the Cassandra process to die. After this wait,
+            it will throw an exception stating it couldn't stop the node.
           - wait_other_notice: return only when the other live nodes of the
             cluster have marked this node has dead.
           - gently: Let Cassandra clean up and shut down properly. Otherwise do
@@ -652,7 +655,7 @@ class Node(object):
             still_running = self.is_running()
             if still_running and wait:
                 wait_time_sec = 1
-                for i in xrange(0, 7):
+                for i in xrange(0, wait_iterations):
                     # we'll double the wait time each try and cassandra should
                     # not take more than 1 minute to shutdown
                     time.sleep(wait_time_sec)

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -139,10 +139,10 @@ class ScyllaCluster(Cluster):
 
         return started
 
-    def stop(self, wait=True, gently=True, wait_other_notice=False):
+    def stop(self, wait=True, gently=True, wait_other_notice=False, wait_iterations=7):
         if self._scylla_manager:
             self._scylla_manager.stop(gently)
-        Cluster.stop(self,wait,gently)
+        Cluster.stop(self,wait,gently,wait_iterations=wait_iterations)
 
     def version(self):
         return self.cassandra_version()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -415,11 +415,14 @@ class ScyllaNode(Node):
             raise NodeError('Problem starting node %s scylla-jmx due to %s' %
                             (self.name, e))
 
-    def stop(self, wait=True, wait_other_notice=False, gently=True):
+    def stop(self, wait=True, wait_other_notice=False, gently=True, wait_iterations=7):
         """
         Stop the node.
           - wait: if True (the default), wait for the Scylla process to be
             really dead. Otherwise return after having sent the kill signal.
+            stop() will wait up to 2^wait_iterations-1 seconds, by default
+            127 seconds, for the Cassandra process to die. After this wait,
+            it will throw an exception stating it couldn't stop the node.
           - wait_other_notice: return only when the other live nodes of the
             cluster have marked this node has dead.
           - gently: Let Scylla and Scylla JMX clean up and shut down properly.
@@ -469,7 +472,7 @@ class ScyllaNode(Node):
             still_running = self.is_running()
             if still_running and wait:
                 wait_time_sec = 1
-                for i in xrange(0, 7):
+                for i in xrange(0, wait_iterations):
                     time.sleep(wait_time_sec)
                     if not self.is_running():
                         return True


### PR DESCRIPTION
Currently, node.stop(), and cluster.stop() which uses it, are hard-coded
to allow Scylla 127 seconds (2^7-1), just a bit over two minutes, to
shutdown before failing. In some tests, see for example
https://github.com/scylladb/scylla/issues/4019, we know that it will
take more than that for the shutdown to complete.

So this patch makes the waiting time configurable, via an optional parameter
"wait_iterations" defaulting to 7. The timeout will be 2^wait_iterations-1
seconds.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>