### PR TITLE
node or cluster stop: make timeout configurable

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -347,10 +347,10 @@ class Cluster(object):
 
         return started
 
-    def stop(self, wait=True, gently=True, wait_other_notice=False):
+    def stop(self, wait=True, gently=True, wait_other_notice=False, wait_seconds=127):
         not_running = []
         for node in list(self.nodes.values()):
-            if not node.stop(wait, gently=gently, wait_other_notice=wait_other_notice):
+            if not node.stop(wait, gently=gently, wait_other_notice=wait_other_notice, wait_seconds=wait_seconds):
                 not_running.append(node)
         return not_running
 

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -139,10 +139,10 @@ class ScyllaCluster(Cluster):
 
         return started
 
-    def stop(self, wait=True, gently=True, wait_other_notice=False):
+    def stop(self, wait=True, gently=True, wait_other_notice=False, wait_seconds=127):
         if self._scylla_manager:
             self._scylla_manager.stop(gently)
-        Cluster.stop(self,wait,gently)
+        Cluster.stop(self,wait,gently,wait_seconds=wait_seconds)
 
     def version(self):
         return self.cassandra_version()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -415,11 +415,14 @@ class ScyllaNode(Node):
             raise NodeError('Problem starting node %s scylla-jmx due to %s' %
                             (self.name, e))
 
-    def stop(self, wait=True, wait_other_notice=False, gently=True):
+    def stop(self, wait=True, wait_other_notice=False, gently=True, wait_seconds=127):
         """
         Stop the node.
           - wait: if True (the default), wait for the Scylla process to be
             really dead. Otherwise return after having sent the kill signal.
+            stop() will wait up to wait_seconds, by default 127 seconds, for
+            the Cassandra process to die. After this wait, it will throw an
+            exception stating it couldn't stop the node.
           - wait_other_notice: return only when the other live nodes of the
             cluster have marked this node has dead.
           - gently: Let Scylla and Scylla JMX clean up and shut down properly.
@@ -468,7 +471,10 @@ class ScyllaNode(Node):
 
             still_running = self.is_running()
             if still_running and wait:
-                wait_time_sec = 1
+                # The sum of 7 sleeps starting at 1 and doubling each time
+                # is 2**7-1 (=127). So to sleep an arbitrary wait_seconds
+                # we need the first sleep to be wait_seconds/(2**7-1).
+                wait_time_sec = wait_seconds/(2**7-1.0)
                 for i in xrange(0, 7):
                     time.sleep(wait_time_sec)
                     if not self.is_running():


### PR DESCRIPTION
Currently, node.stop(), and cluster.stop() which uses it, are hard-coded
to allow Scylla 127 seconds (=2^7-1), just a bit over two minutes, to
shutdown before failing. In some tests, see for example
https://github.com/scylladb/scylla/issues/4019, we know that we need more
than that time for the shutdown to complete.

So this patch makes the waiting time configurable, via an optional parameter
"wait_seconds" which defaults to the previously hard-coded 127 seconds and
can now be set to any number of seconds.

Signed-off-by: Nadav Har'El <nyh@scylladb.com>