### PR TITLE
Revert of PR #116

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -431,8 +431,7 @@ class Cluster(object):
             else:
                 self._config_options["commitlog_sync"] = "periodic"
                 self._config_options["commitlog_sync_period_in_ms"] = 10000
-                # Commented because of Cassandra fails on None value. It expects "NaN".
-                # self._config_options["commitlog_sync_batch_window_in_ms"] = None
+                self._config_options["commitlog_sync_batch_window_in_ms"] = None
 
 
         self._update_config()


### PR DESCRIPTION
Uncomment commitlog_sync_batch_window_in_ms parameter configuration for Cassandra cluster. We don't need to use this parameter