### PR TITLE
ScyllaNode: Add pause and resume support

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -234,6 +234,12 @@ class ScyllaNode(Node):
 
         return java_up
 
+    def pause(self):
+        self._process_scylla.send_signal(signal.SIGSTOP)
+
+    def resume(self):
+        self._process_scylla.send_signal(signal.SIGCONT)
+
     # Scylla Overload start
     def start(self, join_ring=True, no_wait=False, verbose=False,
               update_pid=True, wait_other_notice=False, replace_token=None,


### PR DESCRIPTION
Use SIGSTOP to pause a scylla process and use SIGCONT to resume. They
are useful to simulate a node down faster than acutally to kill a node and
restart later.