### PR TITLE
scylla_node.py: Add view_hints_directory option

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -605,6 +605,7 @@ class ScyllaNode(Node):
         data['hints_directory'] = os.path.join(self.get_path(), 'hints')
         data['saved_caches_directory'] = os.path.join(self.get_path(),
                                                       'saved_caches')
+        data['view_hints_directory'] = os.path.join(self.get_path(), 'view_hints')
 
         if self.cluster.partitioner:
             data['partitioner'] = self.cluster.partitioner
@@ -763,7 +764,7 @@ class ScyllaNode(Node):
 
     def _get_directories(self):
         dirs = {}
-        for i in ['data', 'commitlogs', 'bin', 'conf', 'logs','hints']:
+        for i in ['data', 'commitlogs', 'bin', 'conf', 'logs', 'hints', 'view_hints']:
             dirs[i] = os.path.join(self.get_path(), i)
         return dirs
 


### PR DESCRIPTION
Otherwise, all nodes will use the default /var/lib/scylla/view_hints.