### PR TITLE
Small fixes: remove file during teardown or search for the errors just if the file/folder exists

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -257,15 +257,16 @@ class Cluster(object):
     def remove_dir_with_retry(self, path):
         tries = 0
         removed = False
-        while removed is False:
-            try:
-                common.rmdirs(path)
-                removed = True
-            except Exception as e:
-                tries = tries + 1
-                time.sleep(.1)
-                if tries == 5:
-                    raise e
+        if os.path.exists(path):
+            while not removed:
+                try:
+                    common.rmdirs(path)
+                    removed = True
+                except:
+                    tries = tries + 1
+                    time.sleep(.1)
+                    if tries == 5:
+                        raise
 
     def clear(self):
         self.stop()

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -332,7 +332,11 @@ class Node(object):
         if search_str:
             search_str = search_str if case_sensitive else search_str.lower()
 
-        with open(os.path.join(self.get_path(), 'logs', filename)) as f:
+        log_file = os.path.join(self.get_path(), 'logs', filename)
+        if not os.path.exists(log_file):
+            return []
+
+        with open(log_file) as f:
             if hasattr(self, 'error_mark'):
                 f.seek(self.error_mark)
             return _grep_log_for_errors(f.read(), distinct_errors=distinct_errors, search_str=search_str, case_sensitive=case_sensitive)


### PR DESCRIPTION
We need this fix for the case, when Cassadra cluster is created within the test after the Scylla cluster and KEEP_DIR=False