### PR TITLE
node: use overprovisioned flag if no cpuset

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -354,11 +354,7 @@ class ScyllaNode(Node):
         if '--collectd' not in args:
             args += ['--collectd', '0']
         if '--cpuset' not in args:
-            # Code above guarantees --smp is always in the args list
-            smp = int(args[args.index('--smp') + 1])
-            id = int(data['listen_address'].split('.')[3]) - 1
-            cpuset = self.cpuset(id, smp, self.cluster.id)
-            args += ['--cpuset', ','.join(cpuset)]
+            args += ['--overprovisioned']
         if '--prometheus-address' not in args:
             args += ['--prometheus-address', data['api_address']]
         if replace_address:


### PR DESCRIPTION
Allow different nodes to share cpus without a performance penalty. This allows increasing utilization when running mulitple test clusters in parallel.

Commit 6a3225e28701cff3a0b098212baddfb1761e04bd reverted it, but forgot to explain why. If there are problems, we should fix them.