### PR TITLE
Collecting stress stdout/stderr and printing when error

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1116,20 +1116,19 @@ class Node(object):
                 stress_options.extend(['-port', 'jmx=' + self.jmx_port])
         args = [stress] + stress_options
         try:
-            if capture_output:
-                p = subprocess.Popen(args, cwd=common.parse_path(stress),
-                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                     **kwargs)
-                stdout, stderr = p.communicate()
-            else:
-                p = subprocess.Popen(args, cwd=common.parse_path(stress),
-                                     **kwargs)
-                stdout, stderr = None, None
+            p = subprocess.Popen(args, cwd=common.parse_path(stress),
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                 **kwargs)
+            stdout, stderr = p.communicate()
             return_code = p.wait()
             assert return_code == 0, "Stress command exited with error code: {return_code}\n" \
                                      "stdout: {stdout}\n" \
                                      "stderr: {stderr}\n".format(**locals())
-            return stdout, stderr
+            if capture_output:
+                return stdout, stderr
+            else:
+                return None, None
+
         except KeyboardInterrupt:
             pass
 


### PR DESCRIPTION
Addressing issue: https://github.com/scylladb/scylla/issues/4259
Collecting stdout/stderr of the stress process and printing them when we have an error.
Current stress method behavior isn't changed.