### PR TITLE
Fix scylla-dtest#854, make c* env thread safe

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -74,6 +74,7 @@ class ScyllaNode(Node):
         self._process_scylla_waiter = None
         self._smp = 1
         self._smp_set_during_test = False
+        self.__conf_updated = False
 
     def set_smp(self, smp):
         self._smp =  smp

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -100,8 +100,11 @@ class ScyllaNode(Node):
         raise NotImplementedError('ScyllaNode.get_tool_args')
 
     def get_env(self):
+        update_conf = not self.__conf_updated
+        if update_conf:
+            self.__conf_updated = True
         return common.make_cassandra_env(self.get_install_cassandra_root(),
-                                         self.get_node_cassandra_root())
+                                         self.get_node_cassandra_root(), update_conf=update_conf)
 
     def get_cassandra_version(self):
         # TODO: Handle versioning


### PR DESCRIPTION
seem like the cassandra node.py had a safe guard in place, that wasn't ported into scylla_node.py
I think this should do the trick