### PR TITLE
node.py: Fail node.start() immediately if scylla process terminated

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -366,7 +366,7 @@ class Node(object):
             stderr = proc.communicate()[1]
         except ValueError:
             [stdout, stderr] = ['', '']
-        if stderr and len(stderr) > 1:
+        if stderr is None:
             stderr = ''
         if len(stderr) > 1:
             print_("[%s ERROR] %s" % (name, stderr.strip()))
@@ -436,8 +436,11 @@ class Node(object):
                             return None
                     else:
                         process.poll()
-                        if process.returncode == 0:
-                            return None
+                        if process.returncode is not None:
+                            if process.returncode == 0:
+                                return None
+                            else:
+                                raise RuntimeError("The process is dead, returncode={}".format(process.returncode))
 
     def watch_log_for_death(self, nodes, from_mark=None, timeout=600, filename='system.log'):
         """

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -218,7 +218,7 @@ class ScyllaNode(Node):
                 node.watch_log_for_alive(self, from_mark=mark)
 
         if wait_for_binary_proto:
-            self.wait_for_binary_interface(from_mark=self.mark)
+            self.wait_for_binary_interface(from_mark=self.mark, process=self._process_scylla)
         else:
             time.sleep(2)
 


### PR DESCRIPTION
In dtest, we use node.start(wait_for_binary_proto=True) to make sure the
node can be started with no problem. However, if the scylla process
terminated in the boot up process,
node.start(wait_for_binary_proto=True) will wait for
node.wait_for_binary_interface() to wait for the log saying cql server is
started but since the scylla process is killed, this log will never come
and watch_log_for() will time out in 10 minutes.

Such 10 minutes wait is unnecessary, with this patch
node.start(wait_for_binary_proto=True) will fail the test immediately
when scylla process is terminated.