### PR TITLE
Fix PyYaml load deprecation alert message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/pcmanus/ccm',
     packages=['ccmlib', 'ccmlib.cmds'],
     scripts=[ccmscript],
-    install_requires=['pyYaml', 'six >=1.4.1'],
+    install_requires=['pyYaml==3.13', 'six >=1.4.1'],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",


### PR DESCRIPTION
yaml.load has changed, and the simple yaml.load(<file>) generates alerts.
this commit fixes this alert (based on source [https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation](url)