### PR TITLE
scylla_node: print offending processes when socket is unavailable

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -302,7 +302,14 @@ class ScyllaNode(Node):
 
         for itf in list(self.network_interfaces.values()):
             if itf is not None and replace_address is None:
-                common.check_socket_available(itf)
+                try:
+                    common.check_socket_available(itf)
+                except Exception as msg:
+                    print("{}. Looking for offending processes...".format(msg))
+                    for proc in psutil.process_iter():
+                        if any(self.cluster.ipprefix in cmd for cmd in proc.cmdline()):
+                            print("name={} pid={} cmdline={}".format(proc.name(), proc.pid, proc.cmdline()));
+                    raise msg
 
         marks = []
         if wait_other_notice:


### PR DESCRIPTION
We're trying to understand why the socket is not available.
It might be in use by a stale scylla process so try to find
any running scylla process using the cluster ip prefix.
Its path includes the cluster test directory that could help
understand which test case started it.

Ref #145