### PR TITLE
Add support for using scylla relocatable packages

### DIFF
--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -44,7 +44,7 @@ class ClusterFactory():
             if 'use_vnodes' in data:
                 cluster.use_vnodes = data['use_vnodes']
         except KeyError as k:
-            raise common.LoadError("Error Loading " + filename + ", missing property:" + k)
+            raise common.LoadError("Error Loading " + filename + ", missing property:" + str(k))
 
         for node_name in node_list:
             cluster.nodes[node_name] = Node.load(cluster_path, node_name, cluster)

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -123,6 +123,16 @@ class ClusterCreateCmd(Cmd):
                           help="Supports 'org.apache.cassandra.locator.PropertyFileSnitch','org.apache.cassandra.locator.GossipingPropertyFileSnitch' used only in multidc clusters")
         parser.add_option("--id", type="int", dest="id",
                           help="Allows running multiple clusters in paralell (up to 100) each must have a unique id value 0-99, this will set the ipprefix value if one was not set to 127.0.<id>.")
+
+        parser.add_option('--scylla-package-uri', type="string", dest="scylla_package_uri",
+                          help="The path scylla relocatable package", default=None)
+
+        parser.add_option('--scylla-java-tools-package-uri', type="string", dest="scylla_java_tools_package_uri",
+                          help="The path scylla java tools relocatable package", default=None)
+
+        parser.add_option('--scylla-jmx-package-uri', type="string", dest="scylla_jmx_package_uri",
+                          help="The path scylla jmx relocatable package", default=None)
+
         return parser
 
     def validate(self, parser, options, args):
@@ -156,6 +166,14 @@ class ClusterCreateCmd(Cmd):
             print_("""WARN: c:\windows\system32\java.exe exists.
                 This may cause registry issues, and jre7 to be used, despite jdk8 being installed.
                 """)
+
+        if options.scylla_package_uri:
+            os.environ['SCYLLA_PACKAGE'] = options.scylla_package_uri
+        if options.scylla_java_tools_package_uri:
+            os.environ['SCYLLA_JAVA_TOOLS_PACKAGE'] = options.scylla_java_tools_package_uri
+        if options.scylla_jmx_package_uri:
+            os.environ['SCYLLA_JMX_PACKAGE'] = options.scylla_jmx_package_uri
+
 
     def run(self):
         try:
@@ -297,7 +315,6 @@ class ClusterAddCmd(Cmd):
             print_("This JMX port is already in use. Choose another.", file=sys.stderr)
             parser.print_help()
             sys.exit(1)
-
 
         self.jmx_port = options.jmx_port
         self.remote_debug_port = options.remote_debug_port

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -7,7 +7,7 @@ from six import print_
 from ccmlib import common, repository
 from ccmlib.cluster import Cluster
 from ccmlib.cluster_factory import ClusterFactory
-from ccmlib.cmds.command import Cmd
+from ccmlib.cmds.command import Cmd, PlainHelpFormatter
 from ccmlib.common import ArgumentError
 from ccmlib.dse_cluster import DseCluster
 from ccmlib.scylla_cluster import ScyllaCluster
@@ -60,7 +60,6 @@ def parse_populate_count(v):
     else:
         return [int(t) for t in tmp]
 
-
 class ClusterCreateCmd(Cmd):
 
     def description(self):
@@ -68,7 +67,7 @@ class ClusterCreateCmd(Cmd):
 
     def get_parser(self):
         usage = "usage: ccm create [options] cluster_name"
-        parser = self._get_default_parser(usage, self.description())
+        parser = self._get_default_parser(usage, self.description(), formatter=PlainHelpFormatter())
         parser.add_option('--no-switch', action="store_true", dest="no_switch",
                           help="Don't switch to the newly created cluster", default=False)
         parser.add_option('-p', '--partitioner', type="string", dest="partitioner",
@@ -132,6 +131,20 @@ class ClusterCreateCmd(Cmd):
 
         parser.add_option('--scylla-jmx-package-uri', type="string", dest="scylla_jmx_package_uri",
                           help="The path scylla jmx relocatable package", default=None)
+
+        parser.epilog = """
+        
+        Examples of using relocatable packages:
+        
+        # create cluster from version uploaded to s3 (of the daily/nightly as example)
+        ccm create fruch --scylla --version unstable/master:239
+        
+        # create cluster with own versions of each package
+        ccm create fruch --scylla --version temp \\
+            --scylla-package-uri=../scylla/temp.tar.gz \\ 
+            --scylla-java-tools-package-uri=../scylla-tools-java/temp.tar.gz \\
+            --scylla-jmx-package-uri=../scylla-jmx/temp.tar.gz
+        """
 
         return parser
 

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -123,7 +123,7 @@ class ClusterCreateCmd(Cmd):
         parser.add_option("--id", type="int", dest="id",
                           help="Allows running multiple clusters in paralell (up to 100) each must have a unique id value 0-99, this will set the ipprefix value if one was not set to 127.0.<id>.")
 
-        parser.add_option('--scylla-package-uri', type="string", dest="scylla_package_uri",
+        parser.add_option('--scylla-core-package-uri', type="string", dest="scylla_core_package_uri",
                           help="The path scylla relocatable package", default=None)
 
         parser.add_option('--scylla-java-tools-package-uri', type="string", dest="scylla_java_tools_package_uri",
@@ -180,8 +180,8 @@ class ClusterCreateCmd(Cmd):
                 This may cause registry issues, and jre7 to be used, despite jdk8 being installed.
                 """)
 
-        if options.scylla_package_uri:
-            os.environ['SCYLLA_PACKAGE'] = options.scylla_package_uri
+        if options.scylla_core_package_uri:
+            os.environ['SCYLLA_CORE_PACKAGE'] = options.scylla_core_package_uri
         if options.scylla_java_tools_package_uri:
             os.environ['SCYLLA_JAVA_TOOLS_PACKAGE'] = options.scylla_java_tools_package_uri
         if options.scylla_jmx_package_uri:

--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -1,10 +1,18 @@
 import sys
-from optparse import BadOptionError, Option, OptionParser
+from optparse import BadOptionError, Option, OptionParser, IndentedHelpFormatter
 
 from six import print_
 
 from ccmlib import common
 from ccmlib.cluster_factory import ClusterFactory
+
+
+class PlainHelpFormatter(IndentedHelpFormatter):
+    def format_epilog(self, epilog):
+        if epilog:
+            return epilog + "\n"
+        else:
+            return ""
 
 
 # This is fairly fragile, but handy for now
@@ -76,11 +84,11 @@ class Cmd(object):
     def run(self):
         pass
 
-    def _get_default_parser(self, usage, description, ignore_unknown_options=False):
+    def _get_default_parser(self, usage, description, ignore_unknown_options=False, formatter=None):
         if ignore_unknown_options:
-            parser = ForgivingParser(usage=usage, description=description)
+            parser = ForgivingParser(usage=usage, description=description, formatter=formatter)
         else:
-            parser = OptionParser(usage=usage, description=description)
+            parser = OptionParser(usage=usage, description=description, formatter=formatter)
         parser.add_option('--config-dir', type="string", dest="config_dir",
                           help="Directory for the cluster files [default to {0}]".format(common.get_default_path_display_name()))
         return parser

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -320,6 +320,7 @@ def get_stress_bin(install_dir):
         os.path.join(install_dir, 'tools', 'stress', 'bin', 'stress'),
         os.path.join(install_dir, 'tools', 'bin', 'stress'),
         os.path.join(install_dir, 'tools', 'bin', 'cassandra-stress'),
+        os.path.join(install_dir, 'scylla-java-tools', 'tools', 'bin', 'cassandra-stress'),
         os.path.join(install_dir, 'resources', 'cassandra', 'tools', 'bin', 'cassandra-stress')
     ]
     candidates = [platform_binary(s) for s in candidates]

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -371,7 +371,8 @@ def isScylla(install_dir):
     return (os.path.exists(os.path.join(install_dir, 'scylla')) or
             os.path.exists(os.path.join(install_dir, 'build', 'debug', 'scylla')) or
             os.path.exists(os.path.join(install_dir, 'build', 'dev', 'scylla')) or
-            os.path.exists(os.path.join(install_dir, 'build', 'release', 'scylla')))
+            os.path.exists(os.path.join(install_dir, 'build', 'release', 'scylla')) or
+            os.path.exists(os.path.join(install_dir, 'bin', 'scylla')))
 
 
 def isOpscenter(install_dir):
@@ -398,6 +399,8 @@ def scylla_extract_install_dir_and_mode(install_dir):
     elif install_dir.endswith('build/release') or install_dir.endswith('build/release/'):
         scylla_mode = 'release'
         install_dir = str(os.path.join(install_dir, os.pardir, os.pardir))
+    elif os.path.exists(os.path.join(install_dir, 'libreloc')):
+        scylla_mode = 'reloc'
     return install_dir, scylla_mode
 
 
@@ -567,9 +570,11 @@ def get_version_from_build(install_dir=None, node_path=None):
 
 
 def get_scylla_version(install_dir):
-    # FIXME
     if isScylla(install_dir):
-        return '2.2'
+        scylla_version_file = os.path.join(install_dir, 'SCYLLA-VERSION-FILE')
+        if os.path.exists(scylla_version_file):
+            return open(scylla_version_file).read().strip()
+        return '3.0'
     else:
         return None
 

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -25,7 +25,7 @@ class ScyllaCluster(Cluster):
         install_func = common.scylla_extract_install_dir_and_mode
 
         cassandra_version = kwargs.get('cassandra_version', version)
-        if kwargs.get('cassandra_version', version):
+        if cassandra_version:
             self.scylla_mode = 'reloc'
         else:
             install_dir, self.scylla_mode = install_func(install_dir)

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -563,6 +563,11 @@ class ScyllaNode(Node):
     def copy_config_files_dse(self):
         raise NotImplementedError('ScyllaNode.copy_config_files_dse')
 
+    def hard_link_or_copy_dir(self, src_dir, dst_dir):
+        os.makedirs(dst_dir)
+        for f in os.listdir(src_dir):
+            self.hard_link_or_copy(os.path.join(src_dir, f), os.path.join(dst_dir, f))
+
     def hard_link_or_copy(self, src, dst):
         try:
             os.link(src, dst)
@@ -603,10 +608,10 @@ class ScyllaNode(Node):
             self.hard_link_or_copy(os.path.join(self.get_install_dir(), 'bin', 'scylla'),
                                    os.path.join(self.get_bin_dir(), 'scylla'))
 
-            os.symlink(os.path.join(self.get_install_dir(), 'libexec'),
+            self.hard_link_or_copy_dir(os.path.join(self.get_install_dir(), 'libexec'),
                        os.path.join(self.get_path(), 'libexec'))
 
-            os.symlink(os.path.join(self.get_install_dir(), 'libreloc'),
+            self.hard_link_or_copy_dir(os.path.join(self.get_install_dir(), 'libreloc'),
                        os.path.join(self.get_path(), 'libreloc'))
 
         else:

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -42,11 +42,6 @@ def setup(version, verbose=True):
         cdir = directory_name(version)
 
         shutil.move(tmp_download, cdir)
-        # hack to make the relocatable tools work
-        # https://github.com/scylladb/scylla-tools-java/issues/104
-        scylla_java_tools_dir = os.path.join(cdir, 'scylla-java-tools')
-        for jar_file in glob.glob(scylla_java_tools_dir + "/*.jar"):
-            shutil.copy(jar_file, os.path.join(scylla_java_tools_dir, "lib"))
 
     return cdir, version
 

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -15,9 +15,7 @@ from ccmlib.repository import __download
 
 GIT_REPO = "http://github.com/scylladb/scylla.git"
 
-RELOCATABLE_URLS = {
-    'unstable/master': 'https://s3.amazonaws.com/downloads.scylladb.com/relocatable/unstable/master/'
-}
+RELOCATABLE_URLS_BASE = 'https://s3.amazonaws.com/downloads.scylladb.com/relocatable/{0}/{1}'
 
 
 def setup(version, verbose=True):
@@ -25,7 +23,7 @@ def setup(version, verbose=True):
     type_n_version = version.split(':')
     if len(type_n_version) == 2:
         s3_version = type_n_version[1]
-        s3_url = "{0}{1}".format(RELOCATABLE_URLS[type_n_version[0]], s3_version)
+        s3_url = RELOCATABLE_URLS_BASE.format(type_n_version[0], s3_version)
         version = os.path.join(*type_n_version)
 
     cdir = version_directory(version)

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -1,0 +1,170 @@
+from __future__ import with_statement
+
+import os
+import tarfile
+import tempfile
+import time
+import shutil
+import glob
+
+from six import print_
+from six.moves import urllib
+
+from ccmlib.common import (ArgumentError, CCMError, get_default_path, rmdirs, validate_install_dir)
+
+GIT_REPO = "http://github.com/scylladb/scylla.git"
+
+RELOCATABLE_URLS = {
+    'unstable/master': 'https://s3.amazonaws.com/downloads.scylladb.com/relocatable/unstable/master/'
+}
+
+
+def setup(version, verbose=True):
+    s3_url = 'https://s3.amazonaws.com/downloads.scylladb.com/relocatable/unstable/master/latest'
+    type_n_version = version.split(':')
+    if len(type_n_version) == 2:
+        s3_version = type_n_version[1]
+        s3_url = "{0}{1}".format(RELOCATABLE_URLS[type_n_version[0]], s3_version)
+        version = os.path.join(*type_n_version)
+
+    cdir = version_directory(version)
+    if cdir is None:
+        url = os.environ.get('SCYLLA_PACKAGE', os.path.join(s3_url, 'scylla-package.tar.gz'))
+        download_version(version, verbose=verbose, url=url)
+
+        url = os.environ.get('SCYLLA_JAVA_TOOLS_PACKAGE', os.path.join(s3_url, 'scylla-tools-package.tar.gz'))
+        download_version(os.path.join(version, 'scylla-java-tools'), verbose=verbose, url=url)
+
+        # hack to make the relocatable tools work
+        cdir = version_directory(version)
+        scylla_java_tools_dir = os.path.join(cdir, 'scylla-java-tools')
+        for jar_file in glob.glob(scylla_java_tools_dir + "/*.jar"):
+            shutil.copy(jar_file, os.path.join(scylla_java_tools_dir, "lib"))
+
+        url = os.environ.get('SCYLLA_JMX_PACKAGE', os.path.join(s3_url, 'scylla-jmx-package.tar.gz'))
+        download_version(os.path.join(version, 'jmx'), verbose=verbose, url=url)
+
+        cdir = version_directory(version)
+    return cdir, version
+
+
+min_attributes = ('scheme', 'netloc')
+
+
+def is_valid(url, qualifying=None):
+    qualifying = min_attributes if qualifying is None else qualifying
+    token = urllib.parse.urlparse(url)
+    return all([getattr(token, qualifying_attr)
+                for qualifying_attr in qualifying])
+
+
+def download_version(version, url=None, verbose=False):
+    """Download, extract, and build Cassandra tarball.
+
+    if binary == True, download precompiled tarball, otherwise build from source tarball.
+    """
+    target_dir = None
+    try:
+        if os.path.exists(url) and url.endswith('.tar.gz'):
+            target = url
+        elif is_valid(url):
+            _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
+            __download(url, target, show_progress=verbose)
+        else:
+            raise ArgumentError("unsupported url={}".format(url))
+
+        if verbose:
+            print_("Extracting %s as version %s ..." % (target, version))
+        tar = tarfile.open(target)
+        tar.extractall(path=os.path.join(__get_dir(), version))
+        tar.close()
+
+    except urllib.error.URLError as e:
+        msg = "Invalid version %s" % version if url is None else "Invalid url %s" % url
+        msg = msg + " (underlying error is: %s)" % str(e)
+        raise ArgumentError(msg)
+    except tarfile.ReadError as e:
+        raise ArgumentError("Unable to uncompress downloaded file: %s" % str(e))
+    except CCMError as e:
+        if target_dir:
+            # wipe out the directory if anything goes wrong. Otherwise we will assume it has been compiled the next time it runs.
+            try:
+                rmdirs(target_dir)
+                print_("Deleted %s due to error" % target_dir)
+            except:
+                raise CCMError("Building C* version %s failed. Attempted to delete %s but failed. This will need to be manually deleted" % (version, target_dir))
+        raise e
+
+
+def directory_name(version):
+    return os.path.join(__get_dir(), version)
+
+
+def version_directory(version):
+    dir = directory_name(version)
+    if os.path.exists(dir):
+        try:
+            validate_install_dir(dir)
+            return dir
+        except ArgumentError:
+            rmdirs(dir)
+            return None
+    else:
+        return None
+
+
+def clean_all():
+    rmdirs(__get_dir())
+
+
+def __download(url, target, username=None, password=None, show_progress=False):
+    if username is not None:
+        password_mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+        password_mgr.add_password(None, url, username, password)
+        handler = urllib.request.HTTPBasicAuthHandler(password_mgr)
+        opener = urllib.request.build_opener(handler)
+        urllib.request.install_opener(opener)
+
+    u = urllib.request.urlopen(url)
+    f = open(target, 'wb')
+    meta = u.info()
+    file_size = int(meta.get("Content-Length"))
+    if show_progress:
+        print_("Downloading %s to %s (%.3fMB)" % (url, target, float(file_size) / (1024 * 1024)))
+
+    file_size_dl = 0
+    block_sz = 8192
+    attempts = 0
+    while file_size_dl < file_size:
+        buffer = u.read(block_sz)
+        if not buffer:
+            attempts = attempts + 1
+            if attempts >= 5:
+                raise CCMError("Error downloading file (nothing read after %i attempts, downloded only %i of %i bytes)" % (attempts, file_size_dl, file_size))
+            time.sleep(0.5 * attempts)
+            continue
+        else:
+            attempts = 0
+
+        file_size_dl += len(buffer)
+        f.write(buffer)
+        if show_progress:
+            status = r"%10d  [%3.2f%%]" % (file_size_dl, file_size_dl * 100. / file_size)
+            status = chr(8) * (len(status) + 1) + status
+            print_(status, end='')
+
+    if show_progress:
+        print_("")
+    f.close()
+    u.close()
+
+
+def __get_dir():
+    repo = os.path.join(get_default_path(), 'scylla-repository')
+    if not os.path.exists(repo):
+        os.mkdir(repo)
+    return repo
+
+
+def lastlogfilename():
+    return os.path.join(__get_dir(), "last.log")


### PR DESCRIPTION
Also added optinal JAVA_TOOLS_DIR, so we don't need to create symlink to inside resources/cassandra to the java tools.

building java-tools:
```bash
./reloc/build_reloc.sh
./scripts/create-relocatable-package.py --version 3.11.3-SNAPSHOT scylla-java-tools-3.0.5.tar.gz
```
building jmx:
```bash
mvn package
./scripts/create-relocatable-package.py scylla-jmx-3.0.5.tar.gz
```
Inside dbuild we can build like that:
```bash
   python3 scripts/create-relocatable-package.py --mode release scylla-3.0.5.tar.gz
   mkdir scylla-3.0.5
   tar xvvf temp.tar.gz -C scylla-3.0.5
```

And then use CCM like those options:
```bash
   # from specific directory, after extracting 
   export JAVA_TOOLS_DIR=/home/fruch/Projects/scylla-java-tools
   ccm create fruch --install-dir=/home/fruch/Projects/scylla-next/scylla-3.0.5
   ccm populate -n 1
   ccm node1 start

   # from specific version downloading from s3
   ccm create fruch --scylla --version unstable/master:239
   ccm populate -n 1
   ccm node1 start

   # from specific version overriding specific tarfiles locally or from remote server
   export SCYLLA_PACKAGE="/home/fruch/Projects/scylla-next/temp.tar.gz"
   export SCYLLA_JAVA_TOOLS_PACKAGE="https://s3.amazonaws.com/downloads.scylladb.com/relocatable/unstable/master/239/scylla-tools-package.tar.gz"
   ccm create fruch --scylla --version 3.0.5
   ccm populate -n 1
   ccm node1 start

```

Note:
For running dtest it would be better if we open the relocatable package into a scylla repo,
so it won't break dtest git depended functionality

Fixes #151 