### PR TITLE
scylla_node: _update_jmx_pid: don't throw exception if scylla-jmx.pid not found

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -502,15 +502,15 @@ class ScyllaNode(Node):
             jvm_args = []
         raise NotImplementedError('ScyllaNode.start_dse')
 
-    def _update_jmx_pid(self):
+    def _update_jmx_pid(self, wait=True):
         pidfile = os.path.join(self.get_path(), 'scylla-jmx.pid')
 
         start = time.time()
         while not (os.path.isfile(pidfile) and os.stat(pidfile).st_size > 0):
-            if time.time() - start > 30.0:
+            if time.time() - start > 30.0 or not wait:
                 print_("Timed out waiting for pidfile to be filled "
                        "(current time is %s)" % (datetime.datetime.now()))
-                break
+                return
             else:
                 time.sleep(0.1)
 
@@ -561,7 +561,7 @@ class ScyllaNode(Node):
                 marks = [(node, node.mark_log()) for node in
                          other_nodes if
                          node.is_live() and node is not self]
-            self._update_jmx_pid()
+            self._update_jmx_pid(wait=False)
             if self.scylla_manager and self.scylla_manager.is_agent_available:
                 self._update_scylla_agent_pid()
             for proc in [self._process_jmx, self._process_scylla, self._process_agent]:


### PR DESCRIPTION
This method is called from node.stop() and we've seen cases where
this file was not found.

Move the call to a more specific place where we want to kill scylla-jmx
And since this is not critical at this point do not throw exception
if the file not found (we should have the pid from when starting
scylla-jmx).

See [cql_tests/TruncateTester/truncate_after_restart_test](https://jenkins.scylladb.com/view/master/job/scylla-master/job/manual-and-scheduled-tests/job/byo_build_tests_dtest/278/testReport/cql_tests/TruncateTester/truncate_after_restart_test/):

Note that the exception message is misleading as we're stopping the node and the exception mentions starting node scylla-jmx, I guess for historical reasons.

```
Problem starting node node2 scylla-jmx due to [Errno 2] No such file or directory: '/jenkins/workspace/scylla-master/manual-and-scheduled-tests/byo_build_tests_dtest/scylla/.dtest/dtest-ENWvf2/test/node2/scylla-jmx.pid'
```
