### PR TITLE
cluster, node: support optional other_nodes for wait_other_notice

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -237,7 +237,7 @@ class Cluster(object):
         tokens.extend(new_tokens)
         return tokens
 
-    def remove(self, node=None, wait_other_notice=False):
+    def remove(self, node=None, wait_other_notice=False, other_nodes=None):
         if node is not None:
             if node.name not in self.nodes:
                 return
@@ -246,10 +246,10 @@ class Cluster(object):
             if node in self.seeds:
                 self.seeds.remove(node)
             self._update_config()
-            node.stop(gently=False, wait_other_notice=wait_other_notice)
+            node.stop(gently=False, wait_other_notice=wait_other_notice, other_nodes=other_nodes)
             self.remove_dir_with_retry(node.get_path())
         else:
-            self.stop(gently=False, wait_other_notice=wait_other_notice)
+            self.stop(gently=False, wait_other_notice=wait_other_notice, other_nodes=other_nodes)
             self.remove_dir_with_retry(self.get_path())
 
     # We can race w/shutdown on Windows and get Access is denied attempting to delete node logs.
@@ -348,10 +348,10 @@ class Cluster(object):
 
         return started
 
-    def stop(self, wait=True, gently=True, wait_other_notice=False, wait_seconds=127):
+    def stop(self, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=127):
         not_running = []
         for node in list(self.nodes.values()):
-            if not node.stop(wait, gently=gently, wait_other_notice=wait_other_notice, wait_seconds=wait_seconds):
+            if not node.stop(wait, gently=gently, wait_other_notice=wait_other_notice, other_nodes=other_nodes, wait_seconds=wait_seconds):
                 not_running.append(node)
         return not_running
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -614,7 +614,7 @@ class Node(object):
 
         return process
 
-    def stop(self, wait=True, wait_other_notice=False, gently=True, wait_seconds=127):
+    def stop(self, wait=True, wait_other_notice=False, other_nodes=None, gently=True, wait_seconds=127):
         """
         Stop the node.
           - wait: if True (the default), wait for the Cassandra process to be
@@ -629,7 +629,9 @@ class Node(object):
         """
         if self.is_running():
             if wait_other_notice:
-                marks = [(node, node.mark_log()) for node in list(self.cluster.nodes.values()) if node.is_live() and node is not self]
+                if not other_nodes:
+                    other_nodes = list(self.cluster.nodes.values())
+                marks = [(node, node.mark_log()) for node in other_nodes if node.is_live() and node is not self]
 
             if common.is_win():
                 # Just taskkill the instance, don't bother trying to shut it down gracefully.

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -139,10 +139,10 @@ class ScyllaCluster(Cluster):
 
         return started
 
-    def stop(self, wait=True, gently=True, wait_other_notice=False, wait_seconds=127):
+    def stop(self, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=127):
         if self._scylla_manager:
             self._scylla_manager.stop(gently)
-        Cluster.stop(self,wait,gently,wait_seconds=wait_seconds)
+        Cluster.stop(self,wait,gently,wait_seconds=wait_seconds, wait_other_notice=wait_other_notice, other_nodes=other_nodes)
 
     def version(self):
         return self.cassandra_version()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -450,7 +450,7 @@ class ScyllaNode(Node):
             raise NodeError('Problem starting node %s scylla-jmx due to %s' %
                             (self.name, e))
 
-    def stop(self, wait=True, wait_other_notice=False, gently=True, wait_seconds=127):
+    def stop(self, wait=True, wait_other_notice=False, other_nodes=None, gently=True, wait_seconds=127):
         """
         Stop the node.
           - wait: if True (the default), wait for the Scylla process to be
@@ -466,8 +466,10 @@ class ScyllaNode(Node):
         marks = []
         if self.is_running():
             if wait_other_notice:
+                if not other_nodes:
+                    other_nodes = list(self.cluster.nodes.values())
                 marks = [(node, node.mark_log()) for node in
-                         list(self.cluster.nodes.values()) if
+                         other_nodes if
                          node.is_live() and node is not self]
             self._update_jmx_pid()
 


### PR DESCRIPTION
When stopping more than one node in parallel and waiting for other to notice
we want to skip nodes that may be stopping concurrently.

Provide an optional other_nodes parameter for the caller to pass
only those nodes that require noticing.
