### PR TITLE
fix yaml load warning

### DIFF
--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -17,7 +17,7 @@ class ClusterFactory():
         cluster_path = os.path.join(path, name)
         filename = os.path.join(cluster_path, 'cluster.conf')
         with open(filename, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.full_load(f)
         try:
             install_dir = None
             if 'install_dir' in data:

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -94,7 +94,7 @@ def get_config():
         return {}
 
     with open(config_path, 'r') as f:
-        return yaml.load(f)
+        return yaml.full_load(f)
 
 
 def now_ms():
@@ -610,7 +610,7 @@ def is_dse_cluster(path):
             cluster_path = os.path.join(path, name)
             filename = os.path.join(cluster_path, 'cluster.conf')
             with open(filename, 'r') as f:
-                data = yaml.load(f)
+                data = yaml.full_load(f)
             if 'dse_dir' in data:
                 return True
     except IOError:

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -209,7 +209,7 @@ class ScyllaManager:
     def _update_config(self,dir=None):
         conf_file = os.path.join(self._get_path(), common.SCYLLAMANAGER_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.full_load(f)
         data['http'] = self._get_api_address() 
         if not 'database' in data:
             data['database'] = {}

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -337,7 +337,7 @@ class ScyllaNode(Node):
         # from config file scylla#59
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.full_load(f)
         jvm_args = jvm_args + ['--api-address', data['api_address']]
         jvm_args = jvm_args + ['--collectd-hostname',
                                '%s.%s' % (socket.gethostname(), self.name)]
@@ -611,7 +611,7 @@ class ScyllaNode(Node):
         # TODO: copied from node.py
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.full_load(f)
 
         data['cluster_name'] = self.cluster.name
         data['auto_bootstrap'] = self.auto_bootstrap


### PR DESCRIPTION
Address following warning:
    YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated
    
Please read https://msg.pyyaml.org/load for full details.
    
Fixes #142
