### PR TITLE
treewide: use yaml.load(f, Loader=yaml.FullLoader)

### DIFF
--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -1,7 +1,5 @@
 import os
 
-import yaml
-
 from ccmlib import common, repository
 from ccmlib.cluster import Cluster
 from ccmlib.dse_cluster import DseCluster
@@ -17,7 +15,7 @@ class ClusterFactory():
         cluster_path = os.path.join(path, name)
         filename = os.path.join(cluster_path, 'cluster.conf')
         with open(filename, 'r') as f:
-            data = yaml.load(f)
+            data = common.load_config(f)
         try:
             install_dir = None
             if 'install_dir' in data:

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -87,14 +87,20 @@ def get_user_home():
     else:
         return os.path.expanduser('~')
 
+def load_config(f):
+    if isinstance(f, str):
+        f = open(f, 'r')
+    try:
+        return yaml.load(f, Loader=yaml.FullLoader)
+    except AttributeError as e:
+        return yaml.load(f)
+
 
 def get_config():
     config_path = os.path.join(get_default_path(), CONFIG_FILE)
     if not os.path.exists(config_path):
         return {}
-
-    with open(config_path, 'r') as f:
-        return yaml.load(f)
+    return load_config(config_path)
 
 
 def now_ms():
@@ -608,9 +614,7 @@ def is_dse_cluster(path):
         with open(os.path.join(path, 'CURRENT'), 'r') as f:
             name = f.readline().strip()
             cluster_path = os.path.join(path, name)
-            filename = os.path.join(cluster_path, 'cluster.conf')
-            with open(filename, 'r') as f:
-                data = yaml.load(f)
+            data = load_config(os.path.join(cluster_path, 'cluster.conf'))
             if 'dse_dir' in data:
                 return True
     except IOError:

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -121,7 +121,7 @@ class Node(object):
         node_path = os.path.join(path, name)
         filename = os.path.join(node_path, 'node.conf')
         with open(filename, 'r') as f:
-            data = yaml.load(f)
+            data = common.load_config(f)
         try:
             itf = data['interfaces']
             initial_token = None

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -209,7 +209,7 @@ class ScyllaManager:
     def _update_config(self,dir=None):
         conf_file = os.path.join(self._get_path(), common.SCYLLAMANAGER_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = common.load_config(f)
         data['http'] = self._get_api_address() 
         if not 'database' in data:
             data['database'] = {}

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -337,7 +337,7 @@ class ScyllaNode(Node):
         # from config file scylla#59
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = common.load_config(f)
         jvm_args = jvm_args + ['--api-address', data['api_address']]
         jvm_args = jvm_args + ['--collectd-hostname',
                                '%s.%s' % (socket.gethostname(), self.name)]
@@ -611,7 +611,7 @@ class ScyllaNode(Node):
         # TODO: copied from node.py
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = common.load_config(f)
 
         data['cluster_name'] = self.cluster.name
         data['auto_bootstrap'] = self.auto_bootstrap


### PR DESCRIPTION
Address following warning:
    YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated

Please read https://msg.pyyaml.org/load for full details.

Fixes #142

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>