### PR TITLE
YAML load isn't safe, opt to use safe_load

### DIFF
--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -17,7 +17,7 @@ class ClusterFactory():
         cluster_path = os.path.join(path, name)
         filename = os.path.join(cluster_path, 'cluster.conf')
         with open(filename, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
         try:
             install_dir = None
             if 'install_dir' in data:

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -94,7 +94,7 @@ def get_config():
         return {}
 
     with open(config_path, 'r') as f:
-        return yaml.load(f)
+        return yaml.safe_load(f)
 
 
 def now_ms():
@@ -610,7 +610,7 @@ def is_dse_cluster(path):
             cluster_path = os.path.join(path, name)
             filename = os.path.join(cluster_path, 'cluster.conf')
             with open(filename, 'r') as f:
-                data = yaml.load(f)
+                data = yaml.safe_load(f)
             if 'dse_dir' in data:
                 return True
     except IOError:

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -294,7 +294,7 @@ class DseNode(Node):
     def __update_yaml(self):
         conf_file = os.path.join(self.get_path(), 'resources', 'dse', 'conf', 'dse.yaml')
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
 
         data['system_key_directory'] = os.path.join(self.get_path(), 'keys')
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -121,7 +121,7 @@ class Node(object):
         node_path = os.path.join(path, name)
         filename = os.path.join(node_path, 'node.conf')
         with open(filename, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
         try:
             itf = data['interfaces']
             initial_token = None
@@ -1374,7 +1374,7 @@ class Node(object):
     def __update_yaml(self):
         conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
 
         with open(conf_file, 'r') as f:
             yaml_text = f.read()
@@ -1732,7 +1732,7 @@ class Node(object):
     def get_conf_option(self, option):
         conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
 
         if option in data:
             return data[option]

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -209,8 +209,8 @@ class ScyllaManager:
     def _update_config(self,dir=None):
         conf_file = os.path.join(self._get_path(), common.SCYLLAMANAGER_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
-        data['http'] = self._get_api_address() 
+            data = yaml.safe_load(f)
+        data['http'] = self._get_api_address()
         if not 'database' in data:
             data['database'] = {}
         data['database']['hosts'] = [self.scylla_cluster.get_node_ip(1)]

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -337,7 +337,7 @@ class ScyllaNode(Node):
         # from config file scylla#59
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
         jvm_args = jvm_args + ['--api-address', data['api_address']]
         jvm_args = jvm_args + ['--collectd-hostname',
                                '%s.%s' % (socket.gethostname(), self.name)]
@@ -613,7 +613,7 @@ class ScyllaNode(Node):
         # TODO: copied from node.py
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
 
         data['cluster_name'] = self.cluster.name
         data['auto_bootstrap'] = self.auto_bootstrap

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -92,6 +92,6 @@ class TestCCMCreate(TestCCMCmd):
         self.validate_output(self.create_cmd(args))
         yaml_path = os.path.join(common.get_default_path(), 'test', 'node1', 'conf', 'cassandra.yaml')
         with open(yaml_path, 'r') as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
 
         self.assertEqual(256, data['num_tokens'])


### PR DESCRIPTION
YAML docs mention straight in the beginning:

> Warning: It is not safe to call yaml.load with any data received from
> an untrusted source! yaml.load is as powerful as pickle.load and so may
> call any Python function. Check the yaml.safe_load function though.

Many developers choose to use `yaml.load`. Probably, the result of people
using IDEs which offer completions in alphabetical order. It's easy to
do:

  import yaml

  yaml.(here comes a drop down list of options)
        add_constructor
	...
	...
        load
	....
	....
	#safe_load is hidding here ...

It's easy to use without ever knowing how dangerous this could be.
This commit replaces all occurences of `yaml.load` with
`yaml.safe_load`.