### PR TITLE
scylla_cluster: enlarge start timeout

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -101,7 +101,7 @@ class ScyllaCluster(Cluster):
                     # updated code, scylla starts CQL only by default
                     # process should not be checked for scylla as the
                     # process is a boot script (that ends after boot)
-                    node.watch_log_for(start_message, timeout=300,
+                    node.watch_log_for(start_message, timeout=600,
                                        verbose=verbose, from_mark=mark)
                 except RuntimeError:
                     raise Exception("Not able to find start "


### PR DESCRIPTION
As seen on the lab machines, when running a number of tests
in parallel (5) and using a spinning disk, 5 minutes are not
enough for clusters to start.  Seen normal times in the order of
8 minutes, so enlarge the timeout to 10 minutes to provide
additional slack.
