### PR TITLE
Fix relocatable to use install.sh (fixes #169)

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -137,14 +137,20 @@ class ClusterCreateCmd(Cmd):
         Examples of using relocatable packages:
         
         # create cluster from version uploaded to s3 (of the daily/nightly as example)
-        ccm create fruch --scylla --version unstable/master:239
+        ccm create scylla-reloc-1 -n 1 --scylla --version unstable/master:380
         
         # create cluster with own versions of each package
-        ccm create fruch --scylla --version temp \\
-            --scylla-package-uri=../scylla/temp.tar.gz \\ 
+        ccm create scylla-reloc-1 -n 1 --scylla --version temp \\
+            --scylla-core-package-uri=../scylla/build/release/scylla-package.tar.gz \\ 
             --scylla-java-tools-package-uri=../scylla-tools-java/temp.tar.gz \\
             --scylla-jmx-package-uri=../scylla-jmx/temp.tar.gz
+
+        # create cluster with overwriting only one package
+        ccm create scylla-reloc-1 -n 1 --scylla --version unstable/master:380 \\
+            --scylla-core-package-uri=../scylla/build/dev/scylla-package.tar.gz
+
         """
+
 
         return parser
 

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -400,7 +400,7 @@ def scylla_extract_install_dir_and_mode(install_dir):
     elif install_dir.endswith('build/release') or install_dir.endswith('build/release/'):
         scylla_mode = 'release'
         install_dir = str(os.path.join(install_dir, os.pardir, os.pardir))
-    elif os.path.exists(os.path.join(install_dir, 'libreloc')):
+    elif os.path.exists(os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-RELOCATABLE-FILE')):
         scylla_mode = 'reloc'
     return install_dir, scylla_mode
 

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -563,11 +563,6 @@ class ScyllaNode(Node):
     def copy_config_files_dse(self):
         raise NotImplementedError('ScyllaNode.copy_config_files_dse')
 
-    def hard_link_or_copy_dir(self, src_dir, dst_dir):
-        os.makedirs(dst_dir)
-        for f in os.listdir(src_dir):
-            self.hard_link_or_copy(os.path.join(src_dir, f), os.path.join(dst_dir, f))
-
     def hard_link_or_copy(self, src, dst):
         try:
             os.link(src, dst)
@@ -607,13 +602,6 @@ class ScyllaNode(Node):
             relative_repos_root = '../..'
             self.hard_link_or_copy(os.path.join(self.get_install_dir(), 'bin', 'scylla'),
                                    os.path.join(self.get_bin_dir(), 'scylla'))
-
-            self.hard_link_or_copy_dir(os.path.join(self.get_install_dir(), 'libexec'),
-                       os.path.join(self.get_path(), 'libexec'))
-
-            self.hard_link_or_copy_dir(os.path.join(self.get_install_dir(), 'libreloc'),
-                       os.path.join(self.get_path(), 'libreloc'))
-
         else:
             relative_repos_root = '..'
             self.hard_link_or_copy(os.path.join(self.get_install_dir(),
@@ -621,9 +609,9 @@ class ScyllaNode(Node):
                                    os.path.join(self.get_bin_dir(), 'scylla'))
 
         if 'scylla-repository' in self.get_install_dir():
-            self.hard_link_or_copy(os.path.join(self.get_install_dir(), 'jmx', 'scylla-jmx-1.0.jar'),
+            self.hard_link_or_copy(os.path.join(self.get_install_dir(), 'scylla-jmx', 'scylla-jmx-1.0.jar'),
                                    os.path.join(self.get_bin_dir(), 'scylla-jmx-1.0.jar'))
-            self.hard_link_or_copy(os.path.join(self.get_install_dir(), 'jmx', 'scylla-jmx'),
+            self.hard_link_or_copy(os.path.join(self.get_install_dir(), 'scylla-jmx', 'scylla-jmx'),
                                    os.path.join(self.get_bin_dir(), 'scylla-jmx'))
         else:
             self.hard_link_or_copy(os.path.join(self.get_jmx_dir(relative_repos_root), 'target', 'scylla-jmx-1.0.jar'),

--- a/scylla_ccm_env.sh
+++ b/scylla_ccm_env.sh
@@ -27,3 +27,7 @@ echo
 
 echo "=== Stop and remove"
 echo "ccm remove"
+
+
+echo "=== Create scylla cluster with single node [relocatable]"
+echo "ccm create scylla-reloc-1 -n 1 --scylla --version unstable/master:380 --scylla-core-package-uri=../scylla/build/dev/scylla-package.tar.gz"


### PR DESCRIPTION
since https://github.com/scylladb/scylla/commit/698b72b5018868df6a839d08fd24c642db97ffcd#diff-3fbb47e318cd8802bd325e7da9aaabe8 
relocatable usage in ccm is broken, this PR should address it