### PR TITLE
Use IPs instead of localhost for nodetool commands

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -704,8 +704,12 @@ class Node(object):
         if capture_output and not wait:
             raise common.ArgumentError("Cannot set capture_output while wait is False.")
         env = self.get_env()
+        if self.is_scylla():
+            host = self.address()
+        else:
+            host = 'localhost'
         nodetool = self.get_tool('nodetool')
-        args = [nodetool, '-h', 'localhost', '-p', str(self.jmx_port)]
+        args = [nodetool, '-h', host, '-p', str(self.jmx_port)]
         args += cmd.split()
         if capture_output:
             p = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
ONLY for scylla instances

reiteration of https://github.com/scylladb/scylla-ccm/pull/170
but now with cassandra instances in mind