### PR TITLE
scylla_node: start: wait_other_notice only for live nodes

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -328,7 +328,7 @@ class ScyllaNode(Node):
         marks = []
         if wait_other_notice:
             marks = [(node, node.mark_log()) for node in
-                     list(self.cluster.nodes.values()) if node.is_running()]
+                     list(self.cluster.nodes.values()) if node.is_live()]
 
         self.mark = self.mark_log()
 


### PR DESCRIPTION
is_running includes also decommissioned nodes that won't notice
that the new node is running.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>

Test: concurrent_schema_changes_test.py:TestConcurrentSchemaChanges.decommission_node_test using `wait_other_notice=True` when starting new node after decommission.