### PR TITLE
Fix relocatable packages to work with master version

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -217,7 +217,7 @@ def run_scylla_install_script(install_dir, target_dir):
     # FIXME: remove this hack once scylladb/scylla#4949 is fixed and merged
     run('''sed 's|"$prefix|"$root/$prefix|' -i install.sh''', cwd=install_dir)
 
-    run('''{0}/install.sh --root {1} --target  centos --disttype redhat --pkg server'''.format(
+    run('''{0}/install.sh --root {1} --prefix {1} --prefix /opt/scylladb --nonroot'''.format(
         install_dir, scylla_target_dir), cwd=install_dir)
     run('''mkdir -p {0}/conf; cp ./conf/scylla.yaml {0}/conf'''.format(
         scylla_target_dir), cwd=install_dir)


### PR DESCRIPTION
install.sh command line arguments has been change recently
and broke ccm relocatable support