### PR TITLE
Add `api_address` and `api_port for the scylla manager agent

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -255,6 +255,8 @@ class ScyllaNode(Node):
         data['tls_cert_file'] = os.path.join(ssl_dir, 'scylla-manager-agent.crt')
         data['tls_key_file'] = os.path.join(ssl_dir, 'scylla-manager-agent.key')
         data['logger'] = dict(level='debug')
+        data['scylla'] = {'api_address': "{}".format(self.address()),
+                          'api_port': 10000 }
 
         with open(conf_file, 'w') as f:
             yaml.safe_dump(data, f, default_flow_style=False)


### PR DESCRIPTION
agent configuration has change from using the path of scylla yaml
to need to specify the api address and port of scylla