### PR TITLE
Configure `GNUTLS_SYSTEM_PRIORITY_FILE` correctly when using relocatable

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -695,6 +695,7 @@ class ScyllaNode(Node):
             self.hard_link_or_copy(os.path.join(self.get_install_dir(), 'bin', 'scylla'),
                                    os.path.join(self.get_bin_dir(), 'scylla'),
                                    stat.S_IEXEC)
+            os.environ['GNUTLS_SYSTEM_PRIORITY_FILE'] = os.path.join(self.get_install_dir(), 'scylla-core-package/libreloc/gnutls.config')
         else:
             relative_repos_root = '..'
             src = os.path.join(self.get_install_dir(), 'build', scylla_mode, 'scylla')


### PR DESCRIPTION
`GNUTLS_SYSTEM_PRIORITY_FILE` defaults `/opt/scylladb/libreloc/gnutls.config`
by the relocatable scripts when replaceing scylla binary with a shell script
which was causing all SSL related tests in dtest to fail when using
relocatable packages

Fixes scylladb/scylla-dtest#1150