### PR TITLE
enable_internode_ssl: support to assign internode_encryption

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -569,11 +569,11 @@ class Cluster(object):
         self._config_options['client_encryption_options'] = ssl_options
         self._update_config()
 
-    def enable_internode_ssl(self, node_ssl_path):
+    def enable_internode_ssl(self, node_ssl_path, internode_encryption='all'):
         shutil.copyfile(os.path.join(node_ssl_path, 'keystore.jks'), os.path.join(self.get_path(), 'internode-keystore.jks'))
         shutil.copyfile(os.path.join(node_ssl_path, 'truststore.jks'), os.path.join(self.get_path(), 'internode-truststore.jks'))
         node_ssl_options = {
-            'internode_encryption': 'all',
+            'internode_encryption': internode_encryption,
             'keystore': os.path.join(self.get_path(), 'internode-keystore.jks'),
             'keystore_password': 'cassandra',
             'truststore': os.path.join(self.get_path(), 'internode-truststore.jks'),

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -156,12 +156,12 @@ class ScyllaCluster(Cluster):
     def get_scylla_mode(self):
         return self.scylla_mode
 
-    def enable_internode_ssl(self, node_ssl_path):
+    def enable_internode_ssl(self, node_ssl_path, internode_encryption='all'):
         shutil.copyfile(os.path.join(node_ssl_path, 'trust.pem'), os.path.join(self.get_path(), 'internode-trust.pem'))
         shutil.copyfile(os.path.join(node_ssl_path, 'ccm_node.pem'), os.path.join(self.get_path(), 'internode-ccm_node.pem'))
         shutil.copyfile(os.path.join(node_ssl_path, 'ccm_node.key'), os.path.join(self.get_path(), 'internode-ccm_node.key'))
         node_ssl_options = {
-            'internode_encryption': 'all',
+            'internode_encryption': internode_encryption,
             'certificate': os.path.join(self.get_path(), 'internode-ccm_node.pem'),
             'keyfile': os.path.join(self.get_path(), 'internode-ccm_node.key'),
             'truststore': os.path.join(self.get_path(), 'internode-trust.pem'),


### PR DESCRIPTION
Currently we always use default 'all' for internode_encryption parameter.
This patch made this configurable, we will use it to cover more configuration in dtest.
