### PR TITLE
Missing comma in `node.stress()`

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1106,7 +1106,7 @@ class Node(object):
         if has_limit or has_throttle:
             args = [stress, 'version']
             p = subprocess.Popen(args, cwd=common.parse_path(stress),
-                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True,
                                  **kwargs)
             stdout, stderr = p.communicate()
 


### PR DESCRIPTION
was breaking tests that was using limit or throttle in the stress command
with the following error:
```
  ======================================================================
  ERROR: add_50_nodes_test (update_cluster_layout_tests.TestLargeScaleCluster)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/jenkins/workspace/scylla-master/debug-jobs/byo_build_tests_dtest/scylla-dtest/update_cluster_layout_tests.py", line 1602, in add_50_nodes_test
      t.result()

...

    File "/jenkins/workspace/scylla-master/debug-jobs/byo_build_tests_dtest/scylla-ccm/ccmlib/node.py", line 1110, in stress
      **kwargs)
  TypeError: unsupported operand type(s) for ** or pow(): 'bool' and 'dict'
```