### PR TITLE
node.py::watch_for_log(): make sure a single log line matches not mor…

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -423,9 +423,15 @@ class Node(object):
                         m = e.search(line)
                         if m:
                             matchings.append((line, m))
+
+                            # This is bogus! - One should not modify the list from inside the loop which iterates on
+                            # that list.
+                            # However since we are going to break from the loop a few lines below that should be ok.
                             tofind.remove(e)
+
                             if len(tofind) == 0:
                                 return matchings[0] if isinstance(exprs, string_types) else matchings
+                            break
                 else:
                     # yep, it's ugly
                     time.sleep(0.01)


### PR DESCRIPTION
…e than a single pattern

This single liner fixes two issue at the same time.

First of all the code in question deletes from the list it iterates on which make lead to
very unexpected results.

Second, the code has a logic error as well: even if there wasn't for the bug above
the function would attempt to match the same log line to more than a single pattern
and if it matched - create multiple match results for the same log line.

It's unlikely that this was the original intention and it's likely that the idea was to
match a sinle log line at most once and the author simply forgot to put that "break".

This patch restores the sanity and the integrity of this code part.

Fixes #197

Signed-off-by: Vlad Zolotarov <vladz@scylladb.com>