### PR TITLE
node cleanups: update_config, new_node, update_pid

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -111,6 +111,8 @@ class Node(object):
             self.import_bin_files()
             if common.is_win():
                 self.__clean_bat()
+        else:
+            self._create_directory()
 
     @staticmethod
     def load(path, name, cluster):
@@ -1264,6 +1266,7 @@ class Node(object):
         self.nodetool("removenode " + str(hid))
 
     def import_config_files(self):
+        self._create_directory()
         self._update_config()
         self.copy_config_files()
         self.__update_yaml()
@@ -1349,13 +1352,17 @@ class Node(object):
         self.__update_envfile()
         self._update_config()
 
-    def _update_config(self):
+    def _create_directory(self):
         dir_name = self.get_path()
         if not os.path.exists(dir_name):
             os.mkdir(dir_name)
             for dir in self._get_directories():
                 os.mkdir(os.path.join(dir_name, dir))
 
+    def _update_config(self):
+        dir_name = self.get_path()
+        if not os.path.exists(dir_name):
+            return
         filename = os.path.join(dir_name, 'node.conf')
         values = {
             'name': self.name,

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1678,7 +1678,11 @@ class Node(object):
         start = time.time()
         while not (os.path.isfile(pidfile) and os.stat(pidfile).st_size > 0):
             if (time.time() - start > 30.0):
-                print_("Timed out waiting for pidfile to be filled (current time is %s)" % (datetime.now()))
+                print_("Timed out waiting for pidfile {} to be filled (current time is %s): File {} size={}".format(
+                        pidfile,
+                        datetime.now(),
+                        'exists' if os.path.isfile(pidfile) else 'does not exist' if not os.path.exists(pidfile) else 'is not a file',
+                        os.stat(pidfile).st_size if os.path.exists(pidfile) else -1))
                 break
             else:
                 time.sleep(0.1)

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -278,10 +278,14 @@ class ScyllaManager:
             return
 
         start = time.time()
-        while not (os.path.isfile(self._get_pid_file()) and os.stat(self._get_pid_file()).st_size > 0):
+        pidfile = self._get_pid_file()
+        while not (os.path.isfile(pidfile) and os.stat(pidfile).st_size > 0):
             if time.time() - start > 30.0:
-                print_("Timed out waiting for pidfile to be filled "
-                       "(current time is %s)" % (datetime.datetime.now()))
+                print_("Timed out waiting for pidfile {} to be filled (current time is %s): File {} size={}".format(
+                        pidfile,
+                        datetime.now(),
+                        'exists' if os.path.isfile(pidfile) else 'does not exist' if not os.path.exists(pidfile) else 'is not a file',
+                        os.stat(pidfile).st_size if os.path.exists(pidfile) else -1))
                 break
             else:
                 time.sleep(0.1)

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1,7 +1,7 @@
 # ccm node
 from __future__ import with_statement
 
-import datetime
+from datetime import datetime
 import errno
 import os
 import signal
@@ -506,9 +506,12 @@ class ScyllaNode(Node):
         start = time.time()
         while not (os.path.isfile(pidfile) and os.stat(pidfile).st_size > 0):
             if time.time() - start > 30.0 or not wait:
-                print_("Timed out waiting for pidfile to be filled "
-                       "(current time is %s)" % (datetime.datetime.now()))
-                return
+                print_("Timed out waiting for pidfile {} to be filled (after {} seconds): File {} size={}".format(
+                        pidfile,
+                        0 if not wait else time.time() - start,
+                        'exists' if os.path.isfile(pidfile) else 'does not exist' if not os.path.exists(pidfile) else 'is not a file',
+                        os.stat(pidfile).st_size if os.path.exists(pidfile) else -1))
+                break
             else:
                 time.sleep(0.1)
 
@@ -525,8 +528,11 @@ class ScyllaNode(Node):
         start = time.time()
         while not (os.path.isfile(pidfile) and os.stat(pidfile).st_size > 0):
             if time.time() - start > 30.0:
-                print_("Timed out waiting for pidfile to be filled "
-                       "(current time is %s)" % (datetime.datetime.now()))
+                print_("Timed out waiting for pidfile {} to be filled (current time is %s): File {} size={}".format(
+                        pidfile,
+                        datetime.now(),
+                        'exists' if os.path.isfile(pidfile) else 'does not exist' if not os.path.exists(pidfile) else 'is not a file',
+                        os.stat(pidfile).st_size if os.path.exists(pidfile) else -1))
                 break
             else:
                 time.sleep(0.1)

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -515,6 +515,10 @@ class ScyllaNode(Node):
             else:
                 time.sleep(0.1)
 
+        if not wait:
+            self.jmx_pid = None
+            return
+
         try:
             with open(pidfile, 'r') as f:
                 self.jmx_pid = int(f.readline().strip())

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -85,6 +85,7 @@ class ScyllaNode(Node):
         self.scylla_manager = scylla_manager
         self.jmx_pid = None
         self.agent_pid = None
+        self._create_directory()
 
     def set_smp(self, smp):
         self._smp =  smp
@@ -626,6 +627,7 @@ class ScyllaNode(Node):
 
     def import_config_files(self):
         # TODO: override node - enable logging
+        self._create_directory()
         self._update_config()
         self.copy_config_files()
         self.__update_yaml()


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-dtest/issues/1189

We hit the following path:
```
Stacktrace
Traceback (most recent call last):
  File "/usr/lib64/python2.7/unittest/case.py", line 422, in doCleanups
    function(*args, **kwargs)
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-dtest/update_cluster_layout_tests.py", line 234, in stop_node3
    node3.stop()
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-ccm/ccmlib/scylla_node.py", line 602, in stop
    if not self.wait_until_stopped(wait_seconds):
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-ccm/ccmlib/scylla_node.py", line 543, in wait_until_stopped
    if not self.is_running():
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-ccm/ccmlib/node.py", line 294, in is_running
    self.__update_status()
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-ccm/ccmlib/node.py", line 1563, in __update_status
    self._update_config()
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-ccm/ccmlib/node.py", line 1349, in _update_config
    os.mkdir(dir_name)
OSError: [Errno 2] No such file or directory: '/jenkins/workspace/scylla-master/dtest-release/scylla/.dtest/dtest-3MjM7K/test/node3'

Standard Output
Timed out waiting for pidfile to be filled (current time is 2019-12-06 03:53:35.094448)
```

This patchset fixes several issues related to https://github.com/scylladb/scylla-dtest/issues/1189:
1. do not call mkdir in update_config, but rather explicitly, when needed.
2. introduce cluster.new_node interface so that dtests won't second guess the args for create_node (ipaddr/port interfaces in particular)
3. print more information when timed out waiting for pidfile
    and bail out early if not waiting in `ScyllaNode._update_jmx_pid`

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>