### PR TITLE
Remove pause() and resume() from ScyllaNode

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -313,11 +313,6 @@ class ScyllaNode(Node):
 
         return java_up
 
-    def pause(self):
-        self._process_scylla.send_signal(signal.SIGSTOP)
-
-    def resume(self):
-        self._process_scylla.send_signal(signal.SIGCONT)
 
     # Scylla Overload start
     def start(self, join_ring=True, no_wait=False, verbose=False,


### PR DESCRIPTION
Those are broken, and works better with the functions in Node

It's rarly used in dtest, but some java-driver tests are using this