### PR TITLE
Standardize on sleep time of 0.1 second.

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -288,7 +288,7 @@ class Cluster(object):
                     removed = True
                 except:
                     tries = tries + 1
-                    time.sleep(.1)
+                    time.sleep(0.1)
                     if tries == 5:
                         raise
 
@@ -337,7 +337,7 @@ class Cluster(object):
                 started.append((node, p, mark))
 
         if no_wait and not verbose:
-            time.sleep(2)  # waiting 2 seconds to check for early errors and for the pid to be set
+            time.sleep(0.1)  # waiting 0.1 seconds to check for early errors and for the pid to be set
         else:
             for node, p, mark in started:
                 try:

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -126,7 +126,7 @@ class ClusterCreateCmd(Cmd):
         parser.add_option('--scylla-core-package-uri', type="string", dest="scylla_core_package_uri",
                           help="The path scylla relocatable package", default=None)
 
-        parser.add_option('--scylla-java-tools-package-uri', type="string", dest="scylla_java_tools_package_uri",
+        parser.add_option('--scylla-tools-java-package-uri', type="string", dest="scylla_tools_java_package_uri",
                           help="The path scylla java tools relocatable package", default=None)
 
         parser.add_option('--scylla-jmx-package-uri', type="string", dest="scylla_jmx_package_uri",
@@ -142,7 +142,7 @@ class ClusterCreateCmd(Cmd):
         # create cluster with own versions of each package
         ccm create scylla-reloc-1 -n 1 --scylla --version temp \\
             --scylla-core-package-uri=../scylla/build/release/scylla-package.tar.gz \\ 
-            --scylla-java-tools-package-uri=../scylla-tools-java/temp.tar.gz \\
+            --scylla-tools-java-package-uri=../scylla-tools-java/temp.tar.gz \\
             --scylla-jmx-package-uri=../scylla-jmx/temp.tar.gz
 
         # create cluster with overwriting only one package
@@ -188,8 +188,8 @@ class ClusterCreateCmd(Cmd):
 
         if options.scylla_core_package_uri:
             os.environ['SCYLLA_CORE_PACKAGE'] = options.scylla_core_package_uri
-        if options.scylla_java_tools_package_uri:
-            os.environ['SCYLLA_JAVA_TOOLS_PACKAGE'] = options.scylla_java_tools_package_uri
+        if options.scylla_tools_java_package_uri:
+            os.environ['SCYLLA_TOOLS_JAVA_PACKAGE'] = options.scylla_tools_java_package_uri
         if options.scylla_jmx_package_uri:
             os.environ['SCYLLA_JMX_PACKAGE'] = options.scylla_jmx_package_uri
 

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -469,8 +469,8 @@ def check_socket_listening(itf, timeout=60):
             sock.close()
             return True
         except socket.error:
-            # Try again in another 200ms
-            time.sleep(.2)
+            # Try again in another 100ms
+            time.sleep(0.1)
             continue
 
     return False

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -313,15 +313,19 @@ def parse_bin(executable):
     tokens = re.split(os.sep, executable)
     return tokens[-1]
 
+def get_tools_java_dir(install_dir):
+    if 'scylla-repository' in install_dir:
+        return os.path.join(install_dir, 'scylla-tools-java')
+    else:
+        return os.environ.get('TOOLS_JAVA_DIR', os.path.join(install_dir, 'resources', 'cassandra'))
 
 def get_stress_bin(install_dir):
     candidates = [
+        os.path.join(get_tools_java_dir(install_dir), 'tools', 'bin', 'cassandra-stress'),
         os.path.join(install_dir, 'contrib', 'stress', 'bin', 'stress'),
         os.path.join(install_dir, 'tools', 'stress', 'bin', 'stress'),
         os.path.join(install_dir, 'tools', 'bin', 'stress'),
         os.path.join(install_dir, 'tools', 'bin', 'cassandra-stress'),
-        os.path.join(install_dir, 'scylla-tools-java', 'tools', 'bin', 'cassandra-stress'),
-        os.path.join(install_dir, 'resources', 'cassandra', 'tools', 'bin', 'cassandra-stress')
     ]
     candidates = [platform_binary(s) for s in candidates]
 

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -320,7 +320,7 @@ def get_stress_bin(install_dir):
         os.path.join(install_dir, 'tools', 'stress', 'bin', 'stress'),
         os.path.join(install_dir, 'tools', 'bin', 'stress'),
         os.path.join(install_dir, 'tools', 'bin', 'cassandra-stress'),
-        os.path.join(install_dir, 'scylla-java-tools', 'tools', 'bin', 'cassandra-stress'),
+        os.path.join(install_dir, 'scylla-tools-java', 'tools', 'bin', 'cassandra-stress'),
         os.path.join(install_dir, 'resources', 'cassandra', 'tools', 'bin', 'cassandra-stress')
     ]
     candidates = [platform_binary(s) for s in candidates]

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -395,7 +395,7 @@ class Node(object):
 
         log_file = os.path.join(self.get_path(), 'logs', filename)
         while not os.path.exists(log_file):
-            time.sleep(.1)
+            time.sleep(0.1)
             if process:
                 process.poll()
                 if process.returncode is not None:
@@ -436,9 +436,9 @@ class Node(object):
                             break
                 else:
                     # yep, it's ugly
-                    time.sleep(0.01)
-                    elapsed = elapsed + 1
-                    if elapsed > 100 * timeout:
+                    time.sleep(0.1)
+                    elapsed = elapsed + 0.1
+                    if elapsed > timeout:
                         raise TimeoutError(time.strftime("%d %b %Y %H:%M:%S", time.gmtime()) + " [" + self.name + "] Missing: " + str(
                             [e.pattern for e in tofind]) + ":\n" + reads[:50] + ".....\nSee {} for remainder".format(filename))
 
@@ -671,15 +671,15 @@ class Node(object):
                 for node, mark in marks:
                     node.watch_log_for_death(self, from_mark=mark)
             else:
-                time.sleep(.1)
+                time.sleep(0.1)
 
             still_running = self.is_running()
             if still_running and wait:
                 # The sum of 7 sleeps starting at 1 and doubling each time
                 # is 2**7-1 (=127). So to sleep an arbitrary wait_seconds
                 # we need the first sleep to be wait_seconds/(2**7-1).
-                wait_time_sec = wait_seconds/(2**7-1.0)
-                for i in xrange(0, 7):
+                wait_time_sec = 0.1
+                while wait_time_sec <= wait_seconds + 0.1:
                     # we'll double the wait time each try and cassandra should
                     # not take more than 1 minute to shutdown
                     time.sleep(wait_time_sec)
@@ -701,7 +701,7 @@ class Node(object):
             output, err = self.nodetool("compactionstats", capture_output=True)
             if pattern.search(output):
                 break
-            time.sleep(10)
+            time.sleep(0.1)
 
     def nodetool(self, cmd, capture_output=True, wait=True):
         """
@@ -1619,7 +1619,7 @@ class Node(object):
                 if (now - start > 15000):
                     raise Exception('Timed out waiting for pid file.')
                 else:
-                    time.sleep(.001)
+                    time.sleep(0.1)
             # Spin for up to 10s waiting for .bat to fill the pid file
             start = common.now_ms()
             while (os.stat(pidfile).st_size == 0):
@@ -1627,7 +1627,7 @@ class Node(object):
                 if (now - start > 10000):
                     raise Exception('Timed out waiting for pid file to be filled.')
                 else:
-                    time.sleep(.001)
+                    time.sleep(0.1)
         else:
             try:
                 # Spin for 500ms waiting for .bat to write the dirty_pid file
@@ -1636,7 +1636,7 @@ class Node(object):
                     if (now - start > 500):
                         raise Exception('Timed out waiting for dirty_pid file.')
                     else:
-                        time.sleep(.001)
+                        time.sleep(0.1)
 
                 with open(self.get_path() + "/dirty_pid.tmp", 'r') as f:
                     found = False
@@ -1657,7 +1657,7 @@ class Node(object):
                                     found = True
                                     pidfile.write(win_pid)
                         else:
-                            time.sleep(.001)
+                            time.sleep(0.1)
                         readEnd = common.now_ms()
                     if not found:
                         raise Exception('Node: %s  Failed to find pid in ' +

--- a/ccmlib/resources/bin/run.sh
+++ b/ccmlib/resources/bin/run.sh
@@ -11,5 +11,3 @@ export SCYLLA_HOME=$1
 shift
 exec $SCYLLA_HOME/bin/scylla --options-file $SCYLLA_HOME/conf/scylla.yaml "$@" <&- 2>&1 | tee -a "$SCYLLA_HOME/logs/system.log" &
 pkill -9 -f com.sun.management.jmxremote.port=$jmx_port || true
-
-sleep 6

--- a/ccmlib/resources/bin/run_jmx.sh
+++ b/ccmlib/resources/bin/run_jmx.sh
@@ -9,9 +9,8 @@ jmx_port=`cat $1/node.conf | grep 'jmx_port' | cut -f2 -d"'"`
 export SCYLLA_HOME=$1
 shift
 pkill -9 -f com.sun.management.jmxremote.port=$jmx_port || true
-sleep 2
 count=0
 tmp=/tmp/run.$$
-echo "while kill -0 `cat $SCYLLA_HOME/cassandra.pid` && [[ (\$count < 10) ]] ; do let count+1 ; $SCYLLA_HOME/bin/scylla-jmx -r -a $ip -jp $jmx_port -l $SCYLLA_HOME/bin/ <&- 2>&1 | tee -a $SCYLLA_HOME/logs/system.log.jmx; sleep 1; done ; rm $tmp" > $tmp
+echo "while kill -0 `cat $SCYLLA_HOME/cassandra.pid` && [[ (\$count < 10) ]] ; do let count+1 ; $SCYLLA_HOME/bin/scylla-jmx -r -a $ip -jp $jmx_port -l $SCYLLA_HOME/bin/ <&- 2>&1 | tee -a $SCYLLA_HOME/logs/system.log.jmx; sleep 0.1; done ; rm $tmp" > $tmp
 chmod 777 $tmp
 exec $tmp &

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -96,13 +96,13 @@ class ScyllaCluster(Cluster):
                                profile_options=profile_options)
                 # Let's ensure the nodes start at different times to avoid
                 # race conditions while creating system tables
-                time.sleep(1)
+                time.sleep(0.1)
                 started.append((node, p, mark))
 
         if no_wait and not verbose:
             # waiting 2 seconds to check for early errors and for the
             # pid to be set
-            time.sleep(2)
+            time.sleep(0.1)
         else:
             for node, p, mark in started:
                 start_message = "Starting listening for CQL clients"
@@ -141,7 +141,6 @@ class ScyllaCluster(Cluster):
             for node, _, mark in started:
                 node.watch_log_for("Starting listening for CQL clients",
                                    verbose=verbose, from_mark=mark)
-            time.sleep(0.2)
 
         if self._scylla_manager:
             self._scylla_manager.start()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -668,10 +668,7 @@ class ScyllaNode(Node):
         self.__copy_logback_files()
 
     def get_tools_java_dir(self):
-        if 'scylla-repository' in self.get_install_dir():
-            return os.path.join(self.get_install_dir(), 'scylla-tools-java')
-        else:
-            return os.environ.get('TOOLS_JAVA_DIR', os.path.join(self.get_install_dir(), 'resources', 'cassandra'))
+        return common.get_tools_java_dir(self.get_install_dir())
 
     def get_jmx_dir(self, relative_repos_root):
         return os.environ.get('SCYLLA_JMX_DIR', os.path.join(self.get_install_dir(), relative_repos_root, 'scylla-jmx'))

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -97,7 +97,7 @@ class ScyllaNode(Node):
         self._mem_set_during_test = True
 
     def get_install_cassandra_root(self):
-        return self.get_tool_java_dir()
+        return self.get_tools_java_dir()
 
     def get_node_cassandra_root(self):
         return os.path.join(self.get_path())
@@ -109,7 +109,7 @@ class ScyllaNode(Node):
         return os.path.join(self.get_path(), 'conf')
 
     def get_tool(self, toolname):
-        return common.join_bin(self.get_tool_java_dir(), 'bin', toolname)
+        return common.join_bin(self.get_tools_java_dir(), 'bin', toolname)
 
     def get_tool_args(self, toolname):
         raise NotImplementedError('ScyllaNode.get_tool_args')
@@ -667,9 +667,9 @@ class ScyllaNode(Node):
         self.__update_yaml()
         self.__copy_logback_files()
 
-    def get_tool_java_dir(self):
+    def get_tools_java_dir(self):
         if 'scylla-repository' in self.get_install_dir():
-            return os.path.join(self.get_install_dir(), 'scylla-java-tools')
+            return os.path.join(self.get_install_dir(), 'scylla-tools-java')
         else:
             return os.environ.get('TOOLS_JAVA_DIR', os.path.join(self.get_install_dir(), 'resources', 'cassandra'))
 
@@ -677,7 +677,7 @@ class ScyllaNode(Node):
         return os.environ.get('SCYLLA_JMX_DIR', os.path.join(self.get_install_dir(), relative_repos_root, 'scylla-jmx'))
 
     def __copy_logback_files(self):
-        shutil.copy(os.path.join(self.get_tool_java_dir(), 'conf', 'logback-tools.xml'),
+        shutil.copy(os.path.join(self.get_tools_java_dir(), 'conf', 'logback-tools.xml'),
                     os.path.join(self.get_conf_dir(), 'logback-tools.xml'))
 
     def import_dse_config_files(self):
@@ -707,7 +707,7 @@ class ScyllaNode(Node):
         os.makedirs(os.path.join(self.get_path(), 'resources', 'cassandra', 'bin'))
 
         for name in files:
-            self.hard_link_or_copy(os.path.join(self.get_tool_java_dir(),
+            self.hard_link_or_copy(os.path.join(self.get_tools_java_dir(),
                                                 'bin', name),
                                    os.path.join(self.get_path(),
                                                 'resources', 'cassandra',
@@ -719,7 +719,7 @@ class ScyllaNode(Node):
         os.makedirs(os.path.join(self.get_path(), 'resources', 'cassandra',
                                  'tools', 'bin'))
         for name in files:
-            self.hard_link_or_copy(os.path.join(self.get_tool_java_dir(),
+            self.hard_link_or_copy(os.path.join(self.get_tools_java_dir(),
                                                 'tools', 'bin', name),
                                    os.path.join(self.get_path(),
                                                 'resources', 'cassandra',

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -25,7 +25,7 @@ from ccmlib.node import Node
 from ccmlib.node import NodeError
 
 
-def wait_for(func, timeout, first=0.0, step=1.0, text=None):
+def wait_for(func, timeout, first=0.0, step=0.1, text=None):
     """
     Wait until func() evaluates to True.
 
@@ -246,7 +246,7 @@ class ScyllaNode(Node):
         if wait_for_binary_proto:
             self.wait_for_binary_interface(from_mark=self.mark, process=self._process_scylla)
         else:
-            time.sleep(2)
+            time.sleep(0.1)
 
         return self._process_scylla
 
@@ -305,7 +305,7 @@ class ScyllaNode(Node):
     def _wait_java_up(self, data):
         java_up = False
         iteration = 0
-        while not java_up and iteration < 30:
+        while not java_up and iteration < 300:
             iteration += 1
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:
@@ -318,7 +318,7 @@ class ScyllaNode(Node):
                 s.close()
             except:
                 pass
-            time.sleep(1)
+            time.sleep(0.1)
 
         return java_up
 
@@ -574,7 +574,7 @@ class ScyllaNode(Node):
 
     def wait_until_stopped(self, wait_seconds=127):
         start_time = time.time()
-        wait_time_sec = 1
+        wait_time_sec = 0.1
         while True:
             if not self.is_running():
                 return True

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -49,10 +49,10 @@ def setup(version, verbose=True):
         download_version(version, verbose=verbose, url=url, target_dir=os.path.join(
             tmp_download, 'scylla-core-package'))
 
-        url = os.environ.get('SCYLLA_JAVA_TOOLS_PACKAGE', os.path.join(
+        url = os.environ.get('SCYLLA_TOOLS_JAVA_PACKAGE', os.path.join(
             s3_url, 'scylla-tools-package.tar.gz'))
         download_version(version, verbose=verbose, url=url, target_dir=os.path.join(
-            tmp_download, 'scylla-java-tools'))
+            tmp_download, 'scylla-tools-java'))
 
         url = os.environ.get('SCYLLA_JMX_PACKAGE', os.path.join(
             s3_url, 'scylla-jmx-package.tar.gz'))


### PR DESCRIPTION
Remove too long and too short sleeps. Remove unchecked sleeps.
This change speeds up dtest by ~20%.