### PR TITLE
node: watch_log_for_death: fix regex

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -465,7 +465,7 @@ class Node(object):
         the log is watched from the beginning.
         """
         tofind = nodes if isinstance(nodes, list) else [nodes]
-        tofind = ["%s is now [dead|DOWN]" % node.address() for node in tofind]
+        tofind = ["%s is now (dead|DOWN)" % node.address() for node in tofind]
         self.watch_log_for(tofind, from_mark=from_mark, timeout=timeout, filename=filename)
 
     def watch_log_for_alive(self, nodes, from_mark=None, timeout=120, filename='system.log'):


### PR DESCRIPTION
`[dead|DOWN]` matches any letter in the brackets.
The correct regular expression is `(dead|DOWN)` that
matches either of the strings `dead` or `DOWN`.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>