### PR TITLE
Standardize on sleep time of 0.1 second.

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -288,7 +288,7 @@ class Cluster(object):
                     removed = True
                 except:
                     tries = tries + 1
-                    time.sleep(.1)
+                    time.sleep(0.1)
                     if tries == 5:
                         raise
 

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -469,8 +469,8 @@ def check_socket_listening(itf, timeout=60):
             sock.close()
             return True
         except socket.error:
-            # Try again in another 200ms
-            time.sleep(.2)
+            # Try again in another 100ms
+            time.sleep(0.1)
             continue
 
     return False

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -395,7 +395,7 @@ class Node(object):
 
         log_file = os.path.join(self.get_path(), 'logs', filename)
         while not os.path.exists(log_file):
-            time.sleep(.1)
+            time.sleep(0.1)
             if process:
                 process.poll()
                 if process.returncode is not None:
@@ -436,9 +436,9 @@ class Node(object):
                             break
                 else:
                     # yep, it's ugly
-                    time.sleep(0.01)
-                    elapsed = elapsed + 1
-                    if elapsed > 100 * timeout:
+                    time.sleep(0.1)
+                    elapsed = elapsed + 0.1
+                    if elapsed > timeout:
                         raise TimeoutError(time.strftime("%d %b %Y %H:%M:%S", time.gmtime()) + " [" + self.name + "] Missing: " + str(
                             [e.pattern for e in tofind]) + ":\n" + reads[:50] + ".....\nSee {} for remainder".format(filename))
 
@@ -671,20 +671,19 @@ class Node(object):
                 for node, mark in marks:
                     node.watch_log_for_death(self, from_mark=mark)
             else:
-                time.sleep(.1)
+                time.sleep(0.1)
 
             still_running = self.is_running()
             if still_running and wait:
-                # The sum of 7 sleeps starting at 1 and doubling each time
-                # is 2**7-1 (=127). So to sleep an arbitrary wait_seconds
-                # we need the first sleep to be wait_seconds/(2**7-1).
-                wait_time_sec = wait_seconds/(2**7-1.0)
-                for i in xrange(0, 7):
+                wait_time_sec = 0.1
+                elapsed = 0.0
+                while elapsed <= wait_seconds:
                     # we'll double the wait time each try and cassandra should
                     # not take more than 1 minute to shutdown
                     time.sleep(wait_time_sec)
                     if not self.is_running():
                         return True
+                    elapsed += wait_time_sec
                     wait_time_sec = wait_time_sec * 2
                 raise NodeError("Problem stopping node %s" % self.name)
             else:
@@ -1619,7 +1618,7 @@ class Node(object):
                 if (now - start > 15000):
                     raise Exception('Timed out waiting for pid file.')
                 else:
-                    time.sleep(.001)
+                    time.sleep(0.1)
             # Spin for up to 10s waiting for .bat to fill the pid file
             start = common.now_ms()
             while (os.stat(pidfile).st_size == 0):
@@ -1627,7 +1626,7 @@ class Node(object):
                 if (now - start > 10000):
                     raise Exception('Timed out waiting for pid file to be filled.')
                 else:
-                    time.sleep(.001)
+                    time.sleep(0.1)
         else:
             try:
                 # Spin for 500ms waiting for .bat to write the dirty_pid file
@@ -1636,7 +1635,7 @@ class Node(object):
                     if (now - start > 500):
                         raise Exception('Timed out waiting for dirty_pid file.')
                     else:
-                        time.sleep(.001)
+                        time.sleep(0.1)
 
                 with open(self.get_path() + "/dirty_pid.tmp", 'r') as f:
                     found = False
@@ -1657,7 +1656,7 @@ class Node(object):
                                     found = True
                                     pidfile.write(win_pid)
                         else:
-                            time.sleep(.001)
+                            time.sleep(0.1)
                         readEnd = common.now_ms()
                     if not found:
                         raise Exception('Node: %s  Failed to find pid in ' +

--- a/ccmlib/resources/bin/run.sh
+++ b/ccmlib/resources/bin/run.sh
@@ -11,5 +11,3 @@ export SCYLLA_HOME=$1
 shift
 exec $SCYLLA_HOME/bin/scylla --options-file $SCYLLA_HOME/conf/scylla.yaml "$@" <&- 2>&1 | tee -a "$SCYLLA_HOME/logs/system.log" &
 pkill -9 -f com.sun.management.jmxremote.port=$jmx_port || true
-
-sleep 6

--- a/ccmlib/resources/bin/run_jmx.sh
+++ b/ccmlib/resources/bin/run_jmx.sh
@@ -9,9 +9,8 @@ jmx_port=`cat $1/node.conf | grep 'jmx_port' | cut -f2 -d"'"`
 export SCYLLA_HOME=$1
 shift
 pkill -9 -f com.sun.management.jmxremote.port=$jmx_port || true
-sleep 2
 count=0
 tmp=/tmp/run.$$
-echo "while kill -0 `cat $SCYLLA_HOME/cassandra.pid` && [[ (\$count < 10) ]] ; do let count+1 ; $SCYLLA_HOME/bin/scylla-jmx -r -a $ip -jp $jmx_port -l $SCYLLA_HOME/bin/ <&- 2>&1 | tee -a $SCYLLA_HOME/logs/system.log.jmx; sleep 1; done ; rm $tmp" > $tmp
+echo "while kill -0 `cat $SCYLLA_HOME/cassandra.pid` && [[ (\$count < 10) ]] ; do let count+1 ; $SCYLLA_HOME/bin/scylla-jmx -r -a $ip -jp $jmx_port -l $SCYLLA_HOME/bin/ <&- 2>&1 | tee -a $SCYLLA_HOME/logs/system.log.jmx; sleep 0.1; done ; rm $tmp" > $tmp
 chmod 777 $tmp
 exec $tmp &

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -141,7 +141,6 @@ class ScyllaCluster(Cluster):
             for node, _, mark in started:
                 node.watch_log_for("Starting listening for CQL clients",
                                    verbose=verbose, from_mark=mark)
-            time.sleep(0.2)
 
         if self._scylla_manager:
             self._scylla_manager.start()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -25,7 +25,7 @@ from ccmlib.node import Node
 from ccmlib.node import NodeError
 
 
-def wait_for(func, timeout, first=0.0, step=1.0, text=None):
+def wait_for(func, timeout, first=0.0, step=0.1, text=None):
     """
     Wait until func() evaluates to True.
 
@@ -305,7 +305,7 @@ class ScyllaNode(Node):
     def _wait_java_up(self, data):
         java_up = False
         iteration = 0
-        while not java_up and iteration < 30:
+        while not java_up and iteration < 300:
             iteration += 1
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:
@@ -318,7 +318,7 @@ class ScyllaNode(Node):
                 s.close()
             except:
                 pass
-            time.sleep(1)
+            time.sleep(0.1)
 
         return java_up
 
@@ -574,7 +574,7 @@ class ScyllaNode(Node):
 
     def wait_until_stopped(self, wait_seconds=127):
         start_time = time.time()
-        wait_time_sec = 1
+        wait_time_sec = 0.1
         while True:
             if not self.is_running():
                 return True


### PR DESCRIPTION
Remove too long and too short sleeps in any kind
of a loop.

For now, preserve most of unchecked sleeps at their
current values for backward compatibility.