### PR TITLE
Increase debug blocked reactor notify ms

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -411,8 +411,8 @@ def scylla_extract_install_dir_and_mode(install_dir):
     elif install_dir.endswith('build/release') or install_dir.endswith('build/release/'):
         scylla_mode = 'release'
         install_dir = str(os.path.join(install_dir, os.pardir, os.pardir))
-    elif os.path.exists(os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-RELOCATABLE-FILE')):
-        scylla_mode = 'reloc'
+    elif os.path.exists(os.path.join(install_dir, 'scylla-core-package')):
+        scylla_mode = None
     return install_dir, scylla_mode
 
 

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -28,10 +28,12 @@ class ScyllaCluster(Cluster):
 
         cassandra_version = kwargs.get('cassandra_version', version)
         if cassandra_version:
-            self.scylla_mode = 'reloc'
+            self.scylla_reloc = True
+            self.scylla_mode = None
         else:
+            self.scylla_reloc = False
             install_dir, self.scylla_mode = install_func(install_dir)
-            
+
         self.started = False
         self.force_wait_for_cluster_start = force_wait_for_cluster_start
         super(ScyllaCluster, self).__init__(path, name, partitioner,
@@ -155,6 +157,9 @@ class ScyllaCluster(Cluster):
 
     def get_scylla_mode(self):
         return self.scylla_mode
+
+    def is_scylla_reloc(self):
+        return self.scylla_reloc
 
     def enable_internode_ssl(self, node_ssl_path, internode_encryption='all'):
         shutil.copyfile(os.path.join(node_ssl_path, 'trust.pem'), os.path.join(self.get_path(), 'internode-trust.pem'))

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -56,7 +56,9 @@ class ScyllaCluster(Cluster):
             self._scylla_manager = ScyllaManager(self,manager)
 
     def load_from_repository(self, version, verbose):
-        return scylla_repository.setup(version, verbose)
+        install_dir, version = scylla_repository.setup(version, verbose)
+        install_dir, self.scylla_mode = common.scylla_extract_install_dir_and_mode(install_dir)
+        return install_dir, version
 
     def create_node(self, name, auto_bootstrap, thrift_interface,
                     storage_interface, jmx_port, remote_debug_port,

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -88,6 +88,12 @@ class ScyllaNode(Node):
         self.agent_pid = None
         self._create_directory()
 
+    def scylla_mode(self):
+        return self.cluster.get_scylla_mode()
+
+    def is_scylla_reloc(self):
+        return self.cluster.is_scylla_reloc()
+
     def set_smp(self, smp):
         self._smp =  smp
         self._smp_set_during_test = True
@@ -723,8 +729,7 @@ class ScyllaNode(Node):
                                                 'tools', 'bin', name))
 
         # TODO: - currently no scripts only executable - copying exec
-        scylla_mode = self.cluster.get_scylla_mode()
-        if scylla_mode == 'reloc':
+        if self.is_scylla_reloc():
             relative_repos_root = '../..'
             self.hard_link_or_copy(os.path.join(self.get_install_dir(), 'bin', 'scylla'),
                                    os.path.join(self.get_bin_dir(), 'scylla'),
@@ -732,7 +737,7 @@ class ScyllaNode(Node):
             os.environ['GNUTLS_SYSTEM_PRIORITY_FILE'] = os.path.join(self.get_install_dir(), 'scylla-core-package/libreloc/gnutls.config')
         else:
             relative_repos_root = '..'
-            src = os.path.join(self.get_install_dir(), 'build', scylla_mode, 'scylla')
+            src = os.path.join(self.get_install_dir(), 'build', self.scylla_mode(), 'scylla')
             dst = os.path.join(self.get_bin_dir(), 'scylla')
             dbuild_so_dir = os.environ.get('SCYLLA_DBUILD_SO_DIR')
             if not dbuild_so_dir:

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -462,6 +462,8 @@ class ScyllaNode(Node):
             args[args.index('--memory') + 1] = '{}M'.format(self._mem_mb_per_cpu * self._smp)
         if '--default-log-level' not in args:
             args += ['--default-log-level', self.__global_log_level]
+        if self.scylla_mode() == 'debug' and '--blocked-reactor-notify-ms' not in args:
+            args += ['--blocked-reactor-notify-ms', '5000']
         # TODO add support for classes_log_level
         if '--collectd' not in args:
             args += ['--collectd', '0']


### PR DESCRIPTION
Timing in debug mode is much slower than release/dev modes and
the default reactor stall threshold of 200 ms produces
a lot of false positives. Therefore, increase it in this case using
the `--blocked-reactor-notify-ms` option to 5 seconds.
