### PR TITLE
Added two functions to the node class

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1259,6 +1259,17 @@ class Node(object):
         id_line = id_lines[0].replace(":", "").split()
         return id_line[1]
 
+    def get_datacenter_name(self):
+        info = self.nodetool('info', capture_output=True)[0]
+        id_lines = [s for s in info.split('\n')
+                    if s.startswith('Data Center')]
+        if not len(id_lines) == 1:
+            msg = ('Expected output from `nodetool info` to contain exactly 1 '
+                   'line starting with "ID". Found:\n') + info
+            raise RuntimeError(msg)
+        dc_name = id_lines[0].split(":")[1].strip()
+        return dc_name
+
     def removeToken(self, token):
         self.nodetool("removeToken " + str(token))
 

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -295,6 +295,20 @@ class ScyllaNode(Node):
             raise Exception(
                 "scylla manager agent interface %s:%s is not listening after 180 seconds, scylla manager agent may have failed to start."
                 % (api_interface[0], api_interface[1]))
+    
+    def restart_scylla_manager_agent(self, gently):
+        if gently:
+            try:
+                self._process_agent.terminate()
+            except OSError:
+                pass
+        else:
+            try:
+                self._process_agent.kill()
+            except OSError:
+                pass
+        
+        self._start_scylla_manager_agent()
 
     def _wait_java_up(self, data):
         java_up = False


### PR DESCRIPTION
one that restarts the node's manager agent
and one that returns the node's true datacenter name using nodetool info (unlike the false one that ccm bequeaths it)