### PR TITLE
Refactor cluster start and stop

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -102,9 +102,6 @@ class ScyllaCluster(Cluster):
 
                 p = node.start(update_pid=False, jvm_args=jvm_args,
                                profile_options=profile_options)
-                # Let's ensure the nodes start at different times to avoid
-                # race conditions while creating system tables
-                time.sleep(1)
                 started.append((node, p, mark))
 
         self.__update_pids(started)

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -86,7 +86,7 @@ class ScyllaCluster(Cluster):
 
         marks = []
         if wait_other_notice:
-            marks = [(node, node.mark_log()) for node in self.nodes.values()]
+            marks = [(node, node.mark_log()) for node in self.nodes.values() if node.is_running()]
 
         if nodes is None:
             nodes = self.nodes.values()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -549,12 +549,14 @@ class ScyllaNode(Node):
 
         start = time.time()
         while not (os.path.isfile(pidfile) and os.stat(pidfile).st_size > 0):
-            if time.time() - start > 30.0 or not wait:
-                print_("Timed out waiting for pidfile {} to be filled (after {} seconds): File {} size={}".format(
-                        pidfile,
-                        0 if not wait else time.time() - start,
-                        'exists' if os.path.isfile(pidfile) else 'does not exist' if not os.path.exists(pidfile) else 'is not a file',
-                        os.stat(pidfile).st_size if os.path.exists(pidfile) else -1))
+            elapsed = time.time() - start
+            if elapsed > 30.0 or not wait:
+                if wait:
+                    print_("Timed out waiting for pidfile {} to be filled (after {} seconds): File {} size={}".format(
+                            pidfile,
+                            elapsed,
+                            'exists' if os.path.isfile(pidfile) else 'does not exist' if not os.path.exists(pidfile) else 'is not a file',
+                            os.stat(pidfile).st_size if os.path.exists(pidfile) else -1))
                 break
             else:
                 time.sleep(0.1)

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -251,8 +251,6 @@ class ScyllaNode(Node):
 
         if wait_for_binary_proto:
             self.wait_for_binary_interface(from_mark=self.mark, process=self._process_scylla)
-        else:
-            time.sleep(2)
 
         return self._process_scylla
 


### PR DESCRIPTION
Provide additional start_nodes and stop_nodes methods that can be used to start/stop multiple nodes in parallel.

Fix #212 
