### PR TITLE
Force wait for cluster start

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -102,7 +102,7 @@ class ScyllaCluster(Cluster):
                     mark = node.mark_log()
 
                 p = node.start(update_pid=False, jvm_args=jvm_args,
-                               profile_options=profile_options)
+                               profile_options=profile_options, no_wait=True)
                 started.append((node, p, mark))
 
         self.__update_pids(started)

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -35,7 +35,7 @@ class ScyllaCluster(Cluster):
             install_dir, self.scylla_mode = install_func(install_dir)
 
         self.started = False
-        self.force_wait_for_cluster_start = force_wait_for_cluster_start
+        self.force_wait_for_cluster_start = (force_wait_for_cluster_start != False)
         super(ScyllaCluster, self).__init__(path, name, partitioner,
                                             install_dir, create_directory,
                                             version, verbose,
@@ -72,12 +72,13 @@ class ScyllaCluster(Cluster):
         for node, p, _ in started:
             node._update_pid(p)
 
-    def start_nodes(self, nodes=None, no_wait=False, verbose=False, wait_for_binary_proto=False,
-              wait_other_notice=False, jvm_args=None, profile_options=None,
+    def start_nodes(self, nodes=None, no_wait=False, verbose=False, wait_for_binary_proto=None,
+              wait_other_notice=None, jvm_args=None, profile_options=None,
               quiet_start=False):
-        if not self.started and self.force_wait_for_cluster_start:
-            wait_other_notice=True
-            wait_for_binary_proto=True
+        if wait_for_binary_proto is None:
+            wait_for_binary_proto = self.force_wait_for_cluster_start
+        if wait_other_notice is None:
+            wait_other_notice = self.force_wait_for_cluster_start
         self.started=True
 
         p = None
@@ -124,8 +125,8 @@ class ScyllaCluster(Cluster):
         return started
 
     # override cluster
-    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False,
-              wait_other_notice=False, jvm_args=None, profile_options=None,
+    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=None,
+              wait_other_notice=None, jvm_args=None, profile_options=None,
               quiet_start=False):
         args = locals()
         del args['self']

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -97,6 +97,10 @@ class ScyllaCluster(Cluster):
         started = []
         for node in nodes:
             if not node.is_running():
+                if started:
+                    last_node, _, last_mark = started[-1]
+                    last_node.watch_log_for("database - Schema version changed",
+                                            verbose=verbose, from_mark=last_mark)
                 mark = 0
                 if os.path.exists(node.logfilename()):
                     mark = node.mark_log()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -369,9 +369,9 @@ class ScyllaNode(Node):
         pairs of "var=value" separated by either space or semicolon (';')
         """
         if wait_for_binary_proto is None:
-            wait_for_binary_proto = self.cluster.force_wait_for_cluster_start
+            wait_for_binary_proto = self.cluster.force_wait_for_cluster_start and not no_wait
         if wait_other_notice is None:
-            wait_other_notice = self.cluster.force_wait_for_cluster_start
+            wait_other_notice = self.cluster.force_wait_for_cluster_start and not no_wait
         if jvm_args is None:
             jvm_args = []
 

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -343,8 +343,8 @@ class ScyllaNode(Node):
 
     # Scylla Overload start
     def start(self, join_ring=True, no_wait=False, verbose=False,
-              update_pid=True, wait_other_notice=False, replace_token=None,
-              replace_address=None, jvm_args=None, wait_for_binary_proto=False,
+              update_pid=True, wait_other_notice=None, replace_token=None,
+              replace_address=None, jvm_args=None, wait_for_binary_proto=None,
               profile_options=None, use_jna=False, quiet_start=False):
         """
         Start the node. Options includes:
@@ -368,6 +368,10 @@ class ScyllaNode(Node):
         Those are represented in a single string comprised of one or more
         pairs of "var=value" separated by either space or semicolon (';')
         """
+        if wait_for_binary_proto is None:
+            wait_for_binary_proto = self.cluster.force_wait_for_cluster_start
+        if wait_other_notice is None:
+            wait_other_notice = self.cluster.force_wait_for_cluster_start
         if jvm_args is None:
             jvm_args = []
 


### PR DESCRIPTION
Infrastructure for changing the dtest default to `wait_for_binary_proto=True` and wait_other_notice=True` when starting cluster and single nodes.