### PR TITLE
fix SCYLLA_VERSION parsing of new format in S3 folders

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -33,7 +33,7 @@ def run(cmd, cwd=None):
 
 def setup(version, verbose=True):
     s3_url = ''
-    type_n_version = version.split(':')
+    type_n_version = version.split(':', 1)
     if len(type_n_version) == 2:
         s3_version = type_n_version[1]
         s3_url = RELOCATABLE_URLS_BASE.format(type_n_version[0], s3_version)


### PR DESCRIPTION
new names in S3 folder `unstable/master:2020-02-15T03:02:19Z`
since it has `:` in it, we need to split only on the first one