### PR TITLE
Fix direcorty name for new date format in S3

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -191,7 +191,7 @@ def download_version(version, url=None, verbose=False, target_dir=None):
 
 
 def directory_name(version):
-    return os.path.join(__get_dir(), version)
+    return os.path.join(__get_dir(), version).replace(':', '_')
 
 
 def version_directory(version):


### PR DESCRIPTION
new foramt like `unstable/master:2020-02-15T03:02:19Z` is breaking
the install.sh causing patchelf to coredump