### PR TITLE
Scylla manager: set an address for the debug server

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -252,6 +252,9 @@ class ScyllaManager:
         data['prometheus'] = "{}:56091".format(self.scylla_cluster.get_node_ip(1))
         # Changing port to 56091 since the manager and the first node share the same ip and 56090 is already in use
         # by the first node's manager agent
+        data["debug"] = "{}:5611".format(self.scylla_cluster.get_node_ip(1))
+        # Since both the manager server and the first node use the same address, the manager can't use port
+        # 56112, as node 1's agent already seized it
         if 'ssh' in data:
             del data['ssh']
         with open(conf_file, 'w') as f:

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -265,6 +265,7 @@ class ScyllaNode(Node):
         data['tls_cert_file'] = os.path.join(ssl_dir, 'scylla-manager-agent.crt')
         data['tls_key_file'] = os.path.join(ssl_dir, 'scylla-manager-agent.key')
         data['logger'] = dict(level='debug')
+        data['debug'] = "{}:56112".format(self.address())
         data['scylla'] = {'api_address': "{}".format(self.address()),
                           'api_port': 10000}
         data['prometheus'] = "{}:56090".format(self.address())


### PR DESCRIPTION
both in the agent and the manager's yaml