### PR TITLE
node.py: Fix node:watch_log_for to handle multiple expressions matchi…

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -426,19 +426,16 @@ class Node(object):
                 line = f.readline()
                 if line:
                     reads = reads + line
-                    for e in tofind:
+                    search = tofind
+                    for e in search:
                         m = e.search(line)
                         if m:
                             matchings.append((line, m))
-
-                            # This is bogus! - One should not modify the list from inside the loop which iterates on
-                            # that list.
-                            # However since we are going to break from the loop a few lines below that should be ok.
                             tofind.remove(e)
 
-                            if len(tofind) == 0:
-                                return matchings[0] if isinstance(exprs, string_types) else matchings
-                            break
+                    if len(tofind) == 0:
+                        return matchings[0] if isinstance(exprs, string_types) else matchings
+                    break
                 else:
                     # yep, it's ugly
                     time.sleep(0.01)


### PR DESCRIPTION
…ng same line

Original impl did not handle doing something like:

watch_log_for([".*Prepare.*kossa.*", ".*Prepare.*mu.*"])

and the log producing either

[...] Prepare kossa, elk, ninja
[...] Prepare mu, tuta

or

[...] Prepare kossa, elk, mu

i.e. expressions that match same or different lines, depending on
timing.

This will run each match on every line instead, which seems more
correct.

See /scylladb/scylla#6067