### PR TITLE
ccmlib/scylla_node: wait_for_bootstrap_repair: TimeoutError requires argument

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -230,7 +230,7 @@ class ScyllaNode(Node):
                 prev_mark = self.mark_log()
                 prev_mark_time = time.time()
             elif time.time() - prev_mark_time >= timeout:
-                raise TimeoutError
+                raise TimeoutError("{}: Timed out waiting for '{}'".format(self.name, starting_message))
             time.sleep(sleep_time)
         return bool(self.grep_log(bootstrap_message, from_mark=from_mark))
 


### PR DESCRIPTION
When raising TimeoutError exception, the caller must provide the `data` argument.

Hit in https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-release/471/testReport/replace_address_test/TestReplaceAddress/replace_first_boot_test/
```
Traceback (most recent call last):
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-ccm/ccmlib/scylla_node.py", line 281, in _start_scylla
    self.wait_for_binary_interface(from_mark=self.mark, process=self._process_scylla, timeout=420)
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-ccm/ccmlib/node.py", line 494, in wait_for_binary_interface
    self.watch_log_for("Starting listening for CQL clients", **kwargs)
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-ccm/ccmlib/node.py", line 448, in watch_log_for
    [e.pattern for e in tofind]) + ":\n" + reads[:50] + ".....\nSee {} for remainder".format(filename))
ccmlib.node.TimeoutError: 03 May 2020 02:48:20 [node4] Missing: ['Starting listening for CQL clients']:
Scylla version 666.development-0.20200501.e44b2826.....
See system.log for remainder

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.7/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/usr/lib64/python3.7/unittest/case.py", line 645, in run
    testMethod()
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-dtest/replace_address_test.py", line 216, in replace_first_boot_test
    node4.start(jvm_args=["-Dcassandra.replace_address_first_boot="+self.cluster.get_node_ip(3)], wait_for_binary_proto=True)
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-ccm/ccmlib/scylla_node.py", line 541, in start
    ext_env)
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-ccm/ccmlib/scylla_node.py", line 283, in _start_scylla
    if not self.wait_for_bootstrap_repair(from_mark=self.mark):
  File "/jenkins/workspace/scylla-master/dtest-release/scylla-ccm/ccmlib/scylla_node.py", line 233, in wait_for_bootstrap_repair
    raise TimeoutError
TypeError: __init__() missing 1 required positional argument: 'data'
```

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>