### PR TITLE
ccmlib/scylla_node: extend wait_for_bootstrap_repair to cover streaming

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -226,7 +226,9 @@ class ScyllaNode(Node):
                 self.print_process_output(self.name, process, verbose)
                 if process.returncode != 0:
                     raise RuntimeError("The process is dead, returncode={}".format(process.returncode))
-            if self.grep_log('repair - Repair \d+ out of \d+ ranges', from_mark=prev_mark):
+            repair_pattern = r'repair - Repair \d+ out of \d+ ranges'
+            streaming_pattern = r'range_streamer - Bootstrap .* streaming .* ranges'
+            if self.grep_log("{}|{}".format(repair_pattern, streaming_pattern), from_mark=prev_mark):
                 prev_mark = self.mark_log()
                 prev_mark_time = time.time()
             elif time.time() - prev_mark_time >= timeout:


### PR DESCRIPTION
Now that repair-based node operations are disabled by default
since scylladb/scylla@b8ac10c4514d2ff099a288dfa3cb6f938b42d582,

We see failures like https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-debug-random/147/testReport/materialized_views_test/TestMaterializedViews/mv_populating_from_existing_data_during_extend_test/
```
Traceback (most recent call last):
  File "/usr/lib64/python3.7/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/usr/lib64/python3.7/unittest/case.py", line 645, in run
    testMethod()
  File "/jenkins/workspace/scylla-master/dtest-debug-random/scylla-dtest/materialized_views_test.py", line 598, in mv_populating_from_existing_data_during_extend_test
    self._mv_populating_from_existing_data_during_changes_test('add node', nodes=4, rf=3, mvs=10, prefill=40000)
  File "/jenkins/workspace/scylla-master/dtest-debug-random/scylla-dtest/materialized_views_test.py", line 659, in _mv_populating_from_existing_data_during_changes_test
    run_in_parallel(proc_functions)
  File "/jenkins/workspace/scylla-master/dtest-debug-random/scylla-dtest/scylla_tools.py", line 872, in run_in_parallel
    results = [task.result() for task in tasks]
  File "/jenkins/workspace/scylla-master/dtest-debug-random/scylla-dtest/scylla_tools.py", line 872, in <listcomp>
    results = [task.result() for task in tasks]
  File "/usr/lib64/python3.7/concurrent/futures/_base.py", line 435, in result
    return self.__get_result()
  File "/usr/lib64/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/usr/lib64/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/jenkins/workspace/scylla-master/dtest-debug-random/scylla-dtest/materialized_views_test.py", line 1290, in _add_new_node
    node.start(wait_for_binary_proto=wait_for_binary_proto, wait_other_notice=wait_other_notice, jvm_args=jvm_args)
  File "/jenkins/workspace/scylla-master/dtest-debug-random/scylla-ccm/ccmlib/scylla_node.py", line 541, in start
    ext_env)
  File "/jenkins/workspace/scylla-master/dtest-debug-random/scylla-ccm/ccmlib/scylla_node.py", line 283, in _start_scylla
    if not self.wait_for_bootstrap_repair(from_mark=self.mark):
  File "/jenkins/workspace/scylla-master/dtest-debug-random/scylla-ccm/ccmlib/scylla_node.py", line 233, in wait_for_bootstrap_repair
    raise TimeoutError("{}: Timed out waiting for '{}'".format(self.name, starting_message))
ccmlib.node.TimeoutError: node5: Timed out waiting for 'Starting listening for CQL clients'
```

This change extends `wait_for_bootstrap_repair` to cover both repair-based and streaming-based bootstrap
in order to track thew progress of the bootstrapped node and give it more time to start listening for CQL.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>

Test: materialized_views_test.py:TestMaterializedViews.mv_populating_from_existing_data_during_extend_test