### PR TITLE
Fix get_version_from_build

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -581,9 +581,8 @@ def get_version_from_build(install_dir=None, node_path=None):
     if install_dir is None and node_path is not None:
         install_dir = get_install_dir_from_cluster_conf(node_path)
     if install_dir is not None:
-        scylla_version = get_scylla_version(install_dir)
-        if (scylla_version is not None):
-            return scylla_version
+        if isScylla(install_dir):
+            return '3.0'    # return cassandra-compatible version
         # Binary cassandra installs will have a 0.version.txt file
         version_file = os.path.join(install_dir, '0.version.txt')
         if os.path.exists(version_file):

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -605,7 +605,7 @@ def get_version_from_build(install_dir=None, node_path=None):
 
 def get_scylla_version(install_dir):
     if isScylla(install_dir):
-        scylla_version_files = [ os.path.join(install_dir, 'SCYLLA-VERSION-FILE'),
+        scylla_version_files = [ os.path.join(install_dir, 'build', 'SCYLLA-VERSION-FILE'),
                                  os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-VERSION-FILE') ]
         for version_file in scylla_version_files:
             if os.path.exists(version_file):


### PR DESCRIPTION
The dtest code that uses get_version_from_build via cluster.version()
expects the version string to be numeric based - 2.2, 3.0, etc.
And it is no use returning something like '666.development' or
'9999.enterprise_dev'.  So for scylla, just return '3.0' as returned
by get_scylla_version when no specific version is found.
    
In particular, '20XX.1.*' release versions mess up tests that
compare them as greater than '2.2', as seen in e.g.:
https://jenkins.scylladb.com/view/enterprise-2020.1/job/enterprise-2020.1/job/dtest-release/2/testReport/thrift_tests/TestMutations/test_describe_keyspace/
```
Traceback (most recent call last):
  File "/usr/lib64/python3.7/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/usr/lib64/python3.7/unittest/case.py", line 645, in run
    testMethod()
  File "/jenkins/workspace/enterprise-2020.1/dtest-release/scylla-dtest/thrift_tests.py", line 1599, in test_describe_keyspace
    assert len(kspaces) == 5, [x.name for x in kspaces]  # ['Keyspace2', 'Keyspace1', 'system', 'system_traces']
AssertionError: ['Keyspace2', 'Keyspace1', 'system', 'system_schema', 'system_auth', 'system_distributed', 'system_traces']
```
    
Signed-off-by: Benny Halevy <bhalevy@scylladb.com>

Test: thrift_tests:TestMutations.test_describe_keyspace