### PR TITLE
Use parse_version to compare versions conforming to PEP-440

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -5,6 +5,7 @@ import random
 import shutil
 import subprocess
 import time
+from pkg_resources import parse_version
 
 import yaml
 from six import iteritems, print_
@@ -196,7 +197,7 @@ class Cluster(object):
     def new_node(self, i, auto_bootstrap=False, debug=False, initial_token=None, add_node=True, is_seed=True, data_center=None):
         ipformat = self.get_ipformat()
         binary = None
-        if self.cassandra_version() >= '1.2':
+        if parse_version(self.version()) >= parse_version('1.2'):
             binary = self.get_binary_interface(i)
         node = self.create_node(name='node{}'.format(i),
                                 auto_bootstrap=auto_bootstrap,
@@ -238,7 +239,7 @@ class Cluster(object):
         return 2000 + nodeid * 100
 
     def balanced_tokens(self, node_count):
-        if self.cassandra_version() >= '1.2' and not self.partitioner:
+        if parse_version(self.version()) >= parse_version('1.2') and not self.partitioner:
             ptokens = [(i * (2 ** 64 // node_count)) for i in xrange(0, node_count)]
             return [int(t - 2 ** 63) for t in ptokens]
         return [int(i * (2 ** 127 // node_count)) for i in range(0, node_count)]
@@ -341,7 +342,7 @@ class Cluster(object):
         else:
             for node, p, mark in started:
                 try:
-                    start_message = "Listening for thrift clients..." if self.cassandra_version() < "2.2" else "Starting listening for CQL clients"
+                    start_message = "Listening for thrift clients..." if parse_version(self.version()) < parse_version("2.2") else "Starting listening for CQL clients"
                     node.watch_log_for(start_message, timeout=60, process=p, verbose=verbose, from_mark=mark)
                 except RuntimeError:
                     return None
@@ -352,7 +353,7 @@ class Cluster(object):
             if not node.is_running():
                 raise NodeError("Error starting {0}.".format(node.name), p)
 
-        if not no_wait and self.cassandra_version() >= "0.8":
+        if not no_wait and parse_version(self.version()) >= parse_version("0.8"):
             # 0.7 gossip messages seems less predictible that from 0.8 onwards and
             # I don't care enough
             for node, _, mark in started:
@@ -424,7 +425,7 @@ class Cluster(object):
         if len(livenodes) == 0:
             print_("No live node")
             return
-        if self.cassandra_version() <= '2.1':
+        if parse_version(self.version()) <= parse_version('2.1'):
             args = [stress, '-d', ",".join(livenodes)] + stress_options
         else:
             args = [stress] + stress_options + ['-node', ','.join(livenodes)]

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -618,7 +618,12 @@ def _get_scylla_version(install_dir):
                                 os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-VERSION-FILE') ]
     for version_file in scylla_version_files:
         if os.path.exists(version_file):
-            return open(version_file).read().strip()
+            v = open(version_file).read().strip()
+            # return only version strings (loosly) conforming to PEP-440
+            # See https://www.python.org/dev/peps/pep-0440/
+            # 'i.j(.|-)dev[N]' < 'i.j.rc[N]' < 'i.j.k' < i.j(.|-)post[N]
+            if re.fullmatch('(\d+!)?\d+([.-]\d+)*([a-z]+\d?)?([.-]post\d?)?([.-]dev\d?)?', v):
+                return v
     return '3.0'
 
 def get_scylla_version(install_dir):

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -593,7 +593,7 @@ def get_version_from_build(install_dir=None, node_path=None):
         install_dir = get_install_dir_from_cluster_conf(node_path)
     if install_dir is not None:
         if isScylla(install_dir):
-            return '3.0'    # return cassandra-compatible version
+            return _get_scylla_version(install_dir)
         # Binary cassandra installs will have a 0.version.txt file
         version_file = os.path.join(install_dir, '0.version.txt')
         if os.path.exists(version_file):
@@ -613,14 +613,17 @@ def get_version_from_build(install_dir=None, node_path=None):
     raise CCMError("Cannot find version")
 
 
+def _get_scylla_version(install_dir):
+    scylla_version_files = [ os.path.join(install_dir, 'build', 'SCYLLA-VERSION-FILE'),
+                                os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-VERSION-FILE') ]
+    for version_file in scylla_version_files:
+        if os.path.exists(version_file):
+            return open(version_file).read().strip()
+    return '3.0'
+
 def get_scylla_version(install_dir):
     if isScylla(install_dir):
-        scylla_version_files = [ os.path.join(install_dir, 'build', 'SCYLLA-VERSION-FILE'),
-                                 os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-VERSION-FILE') ]
-        for version_file in scylla_version_files:
-            if os.path.exists(version_file):
-                return open(version_file).read().strip()
-        return '3.0'
+        return _get_scylla_version(install_dir)
     else:
         return None
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1442,7 +1442,7 @@ class Node(object):
         data['data_file_directories'] = [os.path.join(self.get_path(), 'data')]
         data['commitlog_directory'] = os.path.join(self.get_path(), 'commitlogs')
         data['saved_caches_directory'] = os.path.join(self.get_path(), 'saved_caches')
-        if self.get_cassandra_version() > '3.0' and 'hints_directory' in yaml_text:
+        if parse_version(self.get_cassandra_version()) > parse_version('3.0') and 'hints_directory' in yaml_text:
             data['hints_directory'] = os.path.join(self.get_path(), 'data', 'hints')
 
         if self.cluster.partitioner:
@@ -1502,7 +1502,7 @@ class Node(object):
 
     def __update_logback_loglevel(self, conf_file):
         # Setting the right log level - 2.2.2 introduced new debug log
-        if self.get_cassandra_version() >= '2.2.2' and self.__global_log_level:
+        if parse_version(self.get_cassandra_version()) >= parse_version('2.2.2') and self.__global_log_level:
             if self.__global_log_level in ['DEBUG', 'TRACE']:
                 root_log_level = self.__global_log_level
                 cassandra_log_level = self.__global_log_level
@@ -1553,7 +1553,7 @@ class Node(object):
             remote_debug_port_pattern = '((-Xrunjdwp:)|(-agentlib:jdwp=))transport=dt_socket,server=y,suspend=n,address='
             common.replace_in_file(conf_file, remote_debug_port_pattern, remote_debug_options)
 
-        if self.get_cassandra_version() < '2.0.1':
+        if parse_version(self.get_cassandra_version()) < parse_version('2.0.1'):
             common.replace_in_file(conf_file, "-Xss", '    JVM_OPTS="$JVM_OPTS -Xss228k"')
 
         for itf in list(self.network_interfaces.values()):

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -15,6 +15,7 @@ import time
 import warnings
 from datetime import datetime
 import locale
+from pkg_resources import parse_version
 
 import yaml
 from six import iteritems, print_, string_types
@@ -490,7 +491,7 @@ class Node(object):
 
         Emits a warning if not listening after 10 seconds.
         """
-        if self.cluster.version() >= '1.2':
+        if parse_version(self.cluster.version()) >= parse_version('1.2'):
             self.watch_log_for("Starting listening for CQL clients", **kwargs)
 
         binary_itf = self.network_interfaces['binary']

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -130,7 +130,7 @@ class ScyllaNode(Node):
 
     def get_cassandra_version(self):
         # TODO: Handle versioning
-        return '2.2'
+        return '3.0'
 
     def set_log_level(self, new_level, class_name=None):
         known_level = {'TRACE' : 'trace', 'DEBUG' : 'debug', 'INFO' : 'info', 'WARN' : 'warn', 'ERROR' : 'error', 'OFF' : 'info'}


### PR DESCRIPTION
from `pkg_resources` import `parse_version` and use to to compare structured versions conforming to https://www.python.org/dev/peps/pep-0440/.

This will provided the following ordering:
`'i.j(.|-)dev[N]' < 'i.j.rc[N]' < 'i.j.k' < i.j(.|-)post[N]`

So we can use 'i.j.dev' for the master branch, before it's forked to `branch-i.j` that will initially versioned as `i.j.rc0` and so on until it becomes `i.j.0`.

Cc @avikivity @penberg @fruch 

See also usage in https://github.com/bhalevy/scylla-dtest/commits/parse_version