### PR TITLE
ccmlib/scylla_repository: use --packaging option, drop sed to prevent running systemctl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/pcmanus/ccm',
     packages=['ccmlib', 'ccmlib.cmds'],
     scripts=[ccmscript],
-    install_requires=['pyYaml', 'psutil', 'six >=1.4.1', 'requests'],
+    install_requires=['pyYaml', 'psutil', 'six >=1.4.1', 'requests', 'packaging'],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",


### PR DESCRIPTION
To skip running systemctl in scylla-ccm, rewriting install.sh by sed can break
the script, we can use --packaging option instead.

Fixes #249