### PR TITLE
nodetool: add timeout

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -709,11 +709,13 @@ class Node(object):
                 break
             time.sleep(10)
 
-    def nodetool(self, cmd, capture_output=True, wait=True):
+    def nodetool(self, cmd, capture_output=True, wait=True, timeout=None):
         """
         Setting wait=False makes it impossible to detect errors,
         if capture_output is also False. wait=False allows us to return
         while nodetool is still running.
+        When wait=True, timeout may be set to a number, in seconds,
+        to limit how long the function will wait for nodetool to complete.
         """
         if capture_output and not wait:
             raise common.ArgumentError("Cannot set capture_output while wait is False.")
@@ -733,7 +735,7 @@ class Node(object):
             stdout, stderr = None, None
 
         if wait:
-            exit_status = p.wait()
+            exit_status = p.wait(timeout=timeout)
             if exit_status != 0:
                 raise NodetoolError(" ".join(args), exit_status, stdout, stderr)
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1267,8 +1267,8 @@ class Node(object):
         self.status = Status.DECOMMISSIONED
         self._update_config()
 
-    def hostid(self):
-        info = self.nodetool('info', capture_output=True)[0]
+    def hostid(self, timeout=60):
+        info = self.nodetool('info', capture_output=True, timeout=timeout)[0]
         id_lines = [s for s in info.split('\n')
                     if s.startswith('ID')]
         if not len(id_lines) == 1:

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1109,7 +1109,7 @@ class ScyllaNode(Node):
 
     def _wait_no_pending_flushes(self, wait_timeout=60):
         def no_pending_flushes():
-            stdout, _ = self.nodetool('cfstats')
+            stdout, _ = self.nodetool('cfstats', timeout=wait_timeout)
             pending_flushes = False
             for line in stdout.splitlines():
                 line = line.strip()


### PR DESCRIPTION
Add a timeout parameter to nodetool since we saw to hanging in
https://github.com/scylladb/scylla/issues/7244

Currently, the default timeout is `None`, so the behavior remains backward compatible
and nodetool will be waited for forever.
Only the explicit paths seen in https://github.com/scylladb/scylla/issues/7244 pass a timeout in this series.
We may want to consider as a follow up setting the default timeout to a long, but not infinite, timeout, like 10 minutes or more, so that if it hangs, the test will fail and if scylla hangs we can kill it and get a core dump.