### PR TITLE
Add ccm cluster logging facility

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -13,6 +13,7 @@ from six.moves import xrange
 
 from ccmlib import common, repository
 from ccmlib.node import Node, NodeError
+from ccmlib.common import logger
 
 
 class Cluster(object):
@@ -607,3 +608,16 @@ class Cluster(object):
 
         self._config_options['server_encryption_options'] = node_ssl_options
         self._update_config()
+
+
+    def debug(self, message):
+        logger.debug(message)
+
+    def info(self, message):
+        logger.info(message)
+
+    def warning(self, message):
+        logger.warning(message)
+
+    def error(self, message):
+        logger.error(message)

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -72,6 +72,7 @@ class Cluster(object):
             if create_directory:
                 common.rmdirs(self.get_path())
             raise
+        self.debug("Started cluster '{}' version {} installed in {}".format(self.name, self.__version, self.__install_dir))
 
     def load_from_repository(self, version, verbose):
         return repository.setup(version, verbose)

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import time
 import tempfile
+import logging
 
 import yaml
 from six import print_
@@ -39,6 +40,7 @@ CASSANDRA_SH = "cassandra.in.sh"
 CONFIG_FILE = "config"
 CCM_CONFIG_DIR = "CCM_CONFIG_DIR"
 
+logger = logging.getLogger('ccm')
 
 class CCMError(Exception):
     pass

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1828,6 +1828,22 @@ class Node(object):
         return subprocess.Popen(jstack_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
 
 
+    def _log_message(self, message):
+        return "{}: {}".format(self.name, message)
+
+    def debug(self, message):
+        self.cluster.debug(self._log_message(message))
+
+    def info(self, message):
+        self.cluster.info(self._log_message(message))
+
+    def warning(self, message):
+        self.cluster.warning(self._log_message(message))
+
+    def error(self, message):
+        self.cluster.error(self._log_message(message))
+
+
 def _get_load_from_info_output(info):
     load_lines = [s for s in info.split('\n')
                   if s.startswith('Load')]

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -717,6 +717,10 @@ class Node(object):
         When wait=True, timeout may be set to a number, in seconds,
         to limit how long the function will wait for nodetool to complete.
         """
+        log_params = "" if capture_output else " capture_output=False"
+        log_params += "" if wait else " wait=False"
+        log_params += "" if timeout is None else f" timeout={timeout}"
+        self.debug(f"Running nodetool {cmd}{log_params}")
         if capture_output and not wait:
             raise common.ArgumentError("Cannot set capture_output while wait is False.")
         env = self.get_env()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -540,6 +540,9 @@ class ScyllaNode(Node):
                 else:
                     ext_env[k] = v
 
+        message = "Starting scylla: args={} wait_other_notice={} wait_for_binary_proto={}".format(args, wait_other_notice, wait_for_binary_proto)
+        self.debug(message)
+
         scylla_process = self._start_scylla(args, marks, update_pid,
                                             wait_other_notice,
                                             wait_for_binary_proto,


### PR DESCRIPTION
Add a logging facility to Cluster class.
Provide optional `ccm_logger` and `ccm_log_level` parameters provided for integration with dtest logging.
See https://github.com/bhalevy/scylla-dtest/commit/9dac036a8e8ff5766559f3d158b872972cee4bec for planned usage.

Fixes #214

Note: this series depends on https://github.com/scylladb/scylla-ccm/pull/253
that was recently merged, hence it's based off of `scylla-ccm/next`.

Output example:
```
(env) $ PRINT_DEBUG=true CASSANDRA_DIR=../scylla/build/debug NOSE_PROCESSES=2 SCYLLA_EXT_OPTS="--smp 2" nosetests -s -v --process-timeout=7200 cfid_test:TestCFID.cfid_test
2020-10-18 10:55:35.257537 going to run tests in parallel
2020-10-18 10:55:35.257622 using the RandomClusterIdAllocator
2020-10-18 10:55:35.284624 cfid_test.py:TestCFID.cfid_test - cluster ccm directory: /local/home/bhalevy/.dtest/dtest-i5u1fsh5
2020-10-18 10:55:35.284784 cfid_test.py:TestCFID.cfid_test - Starting Scylla cluster from directory ../scylla/build/debug
2020-10-18 10:55:35.288229 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: Started cluster version 3.0 installed in /local/home/bhalevy/dev/scylla
2020-10-18 10:55:35.289910 cfid_test.py:TestCFID.cfid_test - Allocated cluster ID 48: /local/home/bhalevy/.dtest/dtest-i5u1fsh5
2020-10-18 10:55:35.344042 cfid_test.py:TestCFID.cfid_test - Scylla mode is 'debug'
2020-10-18 10:55:35.344126 cfid_test.py:TestCFID.cfid_test - Cluster *_request_timeout_in_ms=30000, cql request_timeout=90
2020-10-18 10:55:35.345772 cfid_test.py:TestCFID.cfid_test - configuring skip_wait_for_gossip_to_settle=0 for single_node test
2020-10-18 10:55:35.421944 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: node1: Starting scylla: args=['/local/home/bhalevy/.dtest/dtest-i5u1fsh5/test/node1/bin/scylla', '--options-file', '/local/home/bhalevy/.dtest/dtest-i5u1fsh5/test/node1/conf/scylla.yaml', '--log-to-stdout', '1', '--api-address', '127.0.48.1', '--collectd-hostname', 'localhost.localdomain.node1', '--smp', '2', '--developer-mode', 'true', '--memory', '1024M', '--default-log-level', 'info', '--blocked-reactor-notify-ms', '5000', '--collectd', '0', '--overprovisioned', '--prometheus-address', '127.0.48.1', '--unsafe-bypass-fsync', '1'] wait_other_notice=False wait_for_binary_proto=False
2020-10-18 10:55:56.256866 cfid_test.py:TestCFID.cfid_test - CREATE COLUMNFAMILY cf (key int PRIMARY KEY, c1 int) WITH comment='test cf' AND compression = {} AND gc_grace_seconds=0
2020-10-18 10:55:57.270330 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: node1: Running nodetool flush
2020-10-18 10:55:59.953793 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: node1: Running nodetool cfstats timeout=60
2020-10-18 10:56:10.265263 cfid_test.py:TestCFID.cfid_test - CREATE COLUMNFAMILY cf (key int PRIMARY KEY, c1 int) WITH comment='test cf' AND compression = {} AND gc_grace_seconds=0
2020-10-18 10:56:11.494248 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: node1: Running nodetool flush
2020-10-18 10:56:12.914373 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: node1: Running nodetool cfstats timeout=60
2020-10-18 10:56:21.581253 cfid_test.py:TestCFID.cfid_test - CREATE COLUMNFAMILY cf (key int PRIMARY KEY, c1 int) WITH comment='test cf' AND compression = {} AND gc_grace_seconds=0
2020-10-18 10:56:22.628048 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: node1: Running nodetool flush
2020-10-18 10:56:23.994833 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: node1: Running nodetool cfstats timeout=60
2020-10-18 10:56:32.298134 cfid_test.py:TestCFID.cfid_test - CREATE COLUMNFAMILY cf (key int PRIMARY KEY, c1 int) WITH comment='test cf' AND compression = {} AND gc_grace_seconds=0
2020-10-18 10:56:33.325099 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: node1: Running nodetool flush
2020-10-18 10:56:35.007422 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: node1: Running nodetool cfstats timeout=60
2020-10-18 10:56:43.001427 cfid_test.py:TestCFID.cfid_test - CREATE COLUMNFAMILY cf (key int PRIMARY KEY, c1 int) WITH comment='test cf' AND compression = {} AND gc_grace_seconds=0
2020-10-18 10:56:43.991935 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: node1: Running nodetool flush
2020-10-18 10:56:45.308304 cfid_test.py:TestCFID.cfid_test - ccm: cluster test: node1: Running nodetool cfstats timeout=60
2020-10-18 10:56:53.356763 cfid_test.py:TestCFID.cfid_test - stopping ccm cluster test at: /local/home/bhalevy/.dtest/dtest-i5u1fsh5
2020-10-18 10:56:54.408121 cfid_test.py:TestCFID.cfid_test - Freeing cluster ID 48: link /local/home/bhalevy/.dtest/48
cfid_test (cfid_test.TestCFID) ... ok

----------------------------------------------------------------------
Ran 1 test in 79.146s

OK
```
