### PR TITLE
scylla_cluster: start_nodes: start nodes in parallel more conservatively

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -100,7 +100,7 @@ class ScyllaCluster(Cluster):
             if not node.is_running():
                 if started:
                     last_node, _, last_mark = started[-1]
-                    last_node.watch_log_for("Schema version changed",
+                    last_node.watch_log_for("node is now in normal status|Starting listening for CQL clients",
                                             verbose=verbose, from_mark=last_mark)
                 mark = 0
                 if os.path.exists(node.logfilename()):


### PR DESCRIPTION
Note: This is "replay" of https://github.com/scylladb/scylla-ccm/pull/247
that was dequeued due to https://github.com/scylladb/scylla/issues/7396, that is now fixed.

Wait for previous nodes' `"node is now in normal status"` message
to let is finish bootstrapping if it needs to.

Otherwise, the 60 seconds timeout on the booting node may not be sufficient
as seen in dtest-debug:

https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-debug/609/artifact/logs-debug.2/1601767547770_internode_ssl_test.TestInternodeSSL.putget_with_reloaded_certificates_test/node3.log
```
INFO  2020-10-03 23:14:45,477 [shard 0] storage_service - Checking bootstrapping/leaving nodes: tokens 256, leaving 0, sleep 1 second and check again (59 seconds elapsed)
...
ERROR 2020-10-03 23:14:48,151 [shard 0] init - Startup failed: std::runtime_error (Other bootstrapping/leaving nodes detected, cannot bootstrap while consistent_rangemovement is true)
```

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>