### PR TITLE
test(support_relloctable): Run tests for ccm via cli

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,6 @@ log_cli=true
 log_level=INFO
 log_format = %(asctime)s %(levelname)-8s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
+markers = 
+  docker: Run tests with docker image
+  reloc: Run tests with relocatable packages

--- a/tests/ccmcluster.py
+++ b/tests/ccmcluster.py
@@ -1,0 +1,97 @@
+import logging
+import os
+import subprocess
+
+from ccmlib import common
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CCMCluster:
+
+    def __init__(self, test_id, use_scylla=True, relocatable_version=None, docker_image=None):
+        self.name = f"{self.__class__.__name__}-{test_id}"
+        self.ccm_bin = os.path.join(os.curdir, "ccm")
+        self.cluster_dir = os.path.join(common.get_default_path(), self.name)
+        self.use_scylla = use_scylla
+        self.relocatable_version = relocatable_version
+        self.docker_image = docker_image
+        self._process = None
+
+    def get_create_cmd(self, args=None):
+        cmd_args = [self.ccm_bin, 'create', self.name]
+        if self.use_scylla and self.relocatable_version:
+            cmd_args += ["--scylla", "-v", self.relocatable_version]
+        elif self.use_scylla and self.docker_image:
+            cmd_args += ["--scylla", "--docker", self.docker_image]
+        elif not self.use_scylla and self.docker_image:
+            cmd_args = ["--docker", self.docker_image]
+        else:
+            cmd_args += ["-v", "2.0.10"]
+
+        if args:
+            cmd_args += args
+
+        return cmd_args
+
+    def get_remove_cmd(self):
+        return [self.ccm_bin, "remove", self.name]
+
+    def get_list_cmd(self):
+        return [self.ccm_bin, "list"]
+
+    def get_status_cmd(self):
+        return [self.ccm_bin, "status"]
+
+    def get_start_cmd(self):
+        return [self.ccm_bin, "start"]
+
+    def run_command(self, cmd):
+        LOGGER.info(cmd)
+        self.process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return self.process
+
+    def validate_command_result(self):
+        stdout, stderr = self.process.communicate()
+        try:
+            stdout = stdout.decode().strip()
+            stderr = stderr.decode().strip()
+
+            if not stderr.count("\n") and stderr.startswith("pydev debugger"):
+                return (stdout, stderr)
+            LOGGER.debug("[OUT] %s" % stdout)
+            assert len(stderr) == 0
+            return (stdout, stderr)
+        except AssertionError:
+            LOGGER.error("[ERROR] %s" % stderr.strip())
+            raise
+
+    def parse_cluster_status(self, stdout):
+        """
+            Output:
+
+            Cluster: 'CCMCluster-reloc'
+            ---------------------------
+            node1: UP
+
+            return:
+            [(node1, UP)]
+        """
+        nodes_status = []
+        for line in stdout.split("\n")[2:]:
+            node, status = line.split(":")
+            nodes_status.append((node.strip(), status.strip()))
+
+        return nodes_status
+
+    def get_nodetool_cmd(self, node, subcmd, args=None):
+        cmd = [self.ccm_bin, node, 'nodetool', subcmd]
+        if args:
+            cmd += args
+        return cmd
+
+    def nodelist(self):
+        self.run_command(self.get_status_cmd())
+        stdout, _ = self.validate_command_result()
+        return [node for node, _ in self.parse_cluster_status(stdout)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,11 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-from tests.test_config import RESULTS_DIR, TEST_ID, SCYLLA_DOCKER_IMAGE
+from tests.test_config import RESULTS_DIR, TEST_ID, SCYLLA_DOCKER_IMAGE, SCYLLA_RELOCATABLE_VERSION
 
 from ccmlib.scylla_docker_cluster import ScyllaDockerCluster
+from .ccmcluster import CCMCluster
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,3 +55,20 @@ def docker_cluster(test_dir, test_id):
         yield cluster
     finally:
         cluster.clear()
+
+
+@pytest.fixture(scope="session")
+def ccm_docker_cluster():
+    cluster = CCMCluster(test_id="docker", docker_image=SCYLLA_DOCKER_IMAGE)
+    return cluster
+
+
+@pytest.fixture(scope="session")
+def ccm_reloc_cluster():
+    cluster = CCMCluster(test_id="reloc", relocatable_version=SCYLLA_RELOCATABLE_VERSION)
+    return cluster
+
+
+@pytest.fixture(scope="session")
+def cluster_under_test(request):
+    return request.getfixturevalue(request.param)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,3 +6,5 @@ RESULTS_DIR = "test_results"
 TEST_ID = os.environ.get("CCM_TEST_ID", None)
 SCYLLA_DOCKER_IMAGE = os.environ.get(
     "SCYLLA_DOCKER_IMAGE", "scylladb/scylla-nightly:666.development-0.20201015.8068272b466")
+SCYLLA_RELOCATABLE_VERSION = os.environ.get(
+    "SCYLLA_VERSION", "unstable/master:2020-10-25T21%3A55%3A10Z")

--- a/tests/test_scylla_cmds.py
+++ b/tests/test_scylla_cmds.py
@@ -1,0 +1,151 @@
+import os
+import logging
+import time
+
+import pytest
+
+from ccmlib import common
+# from .test_config import SCYLLA_DOCKER_IMAGE, SCYLLA_RELOCATABLE_VERSION
+from .test_scylla_docker_cluster import TestScyllaDockerCluster
+
+LOGGER = logging.getLogger(__file__)
+
+cluster_params = pytest.mark.parametrize(
+    'cluster_under_test',
+    (pytest.param('ccm_docker_cluster', marks=pytest.mark.docker),
+     pytest.param('ccm_reloc_cluster', marks=pytest.mark.reloc)),
+    indirect=True
+)
+
+
+@cluster_params
+class TestCCMCreateCluster:
+    cluster = None
+
+    @classmethod
+    @pytest.fixture(autouse=True)
+    def base_setup(cls, cluster_under_test):
+        setattr(TestCCMClusterStatus, "cluster", cluster_under_test)
+        try:
+            yield
+        finally:
+            cls.cluster.run_command(cls.cluster.get_remove_cmd())
+            cls.cluster.process.wait()
+            if os.path.exists(cls.cluster.cluster_dir):
+                common.rmdirs(cls.cluster.cluster_dir)
+
+    def validate_cluster_dir(self):
+        assert os.path.exists(self.cluster.cluster_dir)
+
+    def test_create_cluster(self):
+        create_cmd = self.cluster.get_create_cmd()
+        self.cluster.run_command(create_cmd)
+        self.cluster.validate_command_result()
+        self.validate_cluster_dir()
+
+    def test_create_cluster_with_nodes(self):
+        create_cmd = self.cluster.get_create_cmd(args=['-n', '1'])
+        self.cluster.run_command(create_cmd)
+        self.cluster.validate_command_result()
+        self.validate_cluster_dir()
+
+
+@cluster_params
+class TestCCMClusterStatus:
+
+    @classmethod
+    @pytest.fixture(scope="class", autouse=True)
+    def base_setup(cls, cluster_under_test):
+        setattr(TestCCMClusterStatus, "cluster", cluster_under_test)
+        try:
+            cls.cluster.run_command(cls.cluster.get_create_cmd(args=['-n', '1']))
+            cls.cluster.validate_command_result()
+            yield
+        finally:
+            cls.cluster.run_command(cls.cluster.get_remove_cmd())
+            cls.cluster.process.wait()
+            if os.path.exists(cls.cluster.cluster_dir):
+                common.rmdirs(cls.cluster.cluster_dir)
+
+    def test_list_of_cluster(self):
+        self.cluster.run_command(self.cluster.get_list_cmd())
+        stdout, stderr = self.cluster.validate_command_result()
+        assert self.cluster.name in stdout.decode().strip()
+
+    def test_status_cluster(self):
+        self.cluster.run_command(self.cluster.get_status_cmd())
+        stdout, stderr = self.cluster.validate_command_result()
+        LOGGER.info(stdout.split())
+
+
+@cluster_params
+class TestCCMClusterStart:
+
+    @classmethod
+    @pytest.fixture(autouse=True)
+    def base_setup(cls, cluster_under_test):
+        setattr(TestCCMClusterStart, "cluster", cluster_under_test)
+        try:
+            yield
+        finally:
+            cls.cluster.run_command(cls.cluster.get_remove_cmd())
+            cls.cluster.process.wait()
+            if os.path.exists(cls.cluster.cluster_dir):
+                common.rmdirs(cls.cluster.cluster_dir)
+
+    def test_create_and_start_cluster_without_nodes(self):
+        self.cluster.run_command(self.cluster.get_create_cmd())
+        self.cluster.validate_command_result()
+        self.cluster.run_command(self.cluster.get_start_cmd())
+        stdout, stderr = self.cluster.validate_command_result()
+        assert "No node in this cluster yet. Use the populate command before starting" in stdout
+
+    def test_create_and_start_cluster_with_nodes(self):
+        self.cluster.run_command(self.cluster.get_create_cmd(args=['-n', '1']))
+        self.cluster.validate_command_result()
+        self.cluster.run_command(self.cluster.get_start_cmd())
+        self.cluster.validate_command_result()
+        self.cluster.run_command(self.cluster.get_status_cmd())
+        stdout, stderr = self.cluster.validate_command_result()
+        for node, status in self.cluster.parse_cluster_status(stdout):
+            LOGGER.info("%s: %s", node, status)
+            assert "UP" in status, f"{node} was not started and have status {status}"
+
+
+@cluster_params
+class TestCCMClusterNodetool:
+
+    @classmethod
+    @pytest.fixture(scope="class", autouse=True)
+    def base_setup_with_2_nodes(cls, cluster_under_test):
+        setattr(TestCCMClusterNodetool, "cluster", cluster_under_test)
+        try:
+            cls.cluster.run_command(cls.cluster.get_create_cmd(args=['-n', '2']))
+            cls.cluster.validate_command_result()
+            cls.cluster.run_command(cls.cluster.get_start_cmd())
+            cls.cluster.validate_command_result()
+            time.sleep(30)
+            yield
+        finally:
+            cls.cluster.run_command(cls.cluster.get_remove_cmd())
+            cls.cluster.process.wait()
+            if os.path.exists(cls.cluster.cluster_dir):
+                common.rmdirs(cls.cluster.cluster_dir)
+
+    def test_ccm_status(self):
+        self.cluster.run_command(self.cluster.get_status_cmd())
+        stdout, stderr = self.cluster.validate_command_result()
+        for node, status in self.cluster.parse_cluster_status(stdout):
+            LOGGER.info("%s: %s", node, status)
+            assert "UP" in status, f"{node} was not started and have status {status}"
+
+    def test_nodetool_status(self):
+        for node in self.cluster.nodelist():
+            nodetool_cmd = self.cluster.get_nodetool_cmd(node, "status")
+            self.cluster.run_command(nodetool_cmd)
+            stdout, _ = self.cluster.validate_command_result()
+            node_statuses = TestScyllaDockerCluster.parse_nodetool_status(stdout.split("\n"))
+            assert node_statuses
+            LOGGER.info(node_statuses)
+            for node in node_statuses:
+                assert node['status'] == 'UN'


### PR DESCRIPTION
Added new tests which check that cluster could be configured
via ./ccm cli command.

to run process next command could be used:
 USE_SCYLLA=true SCYLLA_VERSION="relocatable pkg" python -m unittest tests/test_scylla_cmds.py
or
export USE_SCYLLA=true
export SCYLLA_VERSION="relocatable pkg"
pytest -sv tests/test_scylla_cmds.py

Test validate:
 - create cluster
 - create cluter with nodes
 - start cluster
 - check cluster status
 - remove cluster