### PR TITLE
Docker ccm

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -41,13 +41,18 @@ class Cluster(object):
 
         # This is incredibly important for
         # backwards compatibility.
-        if 'cassandra_version' in kwargs:
-            version = kwargs['cassandra_version']
-        if 'cassandra_dir' in kwargs:
-            install_dir = kwargs['cassandra_dir']
+        version = kwargs.get('cassandra_version', version)
+        install_dir = kwargs.get('cassandra_dir', install_dir)
+        docker_image = kwargs.get('docker_image')
         if create_directory:
             # we create the dir before potentially downloading to throw an error sooner if need be
             os.mkdir(self.get_path())
+
+        if docker_image:
+            self.__install_dir = None
+            self.__version = '3.0'
+            self._update_config()
+            return
 
         try:
             if version is None:

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -28,8 +28,13 @@ class ScyllaCluster(Cluster):
         install_func = common.scylla_extract_install_dir_and_mode
 
         cassandra_version = kwargs.get('cassandra_version', version)
+        docker_image = kwargs.get('docker_image')
+
         if cassandra_version:
             self.scylla_reloc = True
+            self.scylla_mode = None
+        elif docker_image:
+            self.scylla_reloc = False
             self.scylla_mode = None
         else:
             self.scylla_reloc = False
@@ -40,7 +45,8 @@ class ScyllaCluster(Cluster):
         super(ScyllaCluster, self).__init__(path, name, partitioner,
                                             install_dir, create_directory,
                                             version, verbose,
-                                            snitch=SNITCH, cassandra_version=cassandra_version)
+                                            snitch=SNITCH, cassandra_version=cassandra_version,
+                                            docker_image=docker_image)
 
         self._scylla_manager=None
         if not manager:
@@ -133,9 +139,9 @@ class ScyllaCluster(Cluster):
     def start(self, no_wait=True, verbose=False, wait_for_binary_proto=None,
               wait_other_notice=None, jvm_args=None, profile_options=None,
               quiet_start=False):
-        args = locals()
-        del args['self']
-        started = self.start_nodes(**args)
+        kwargs = dict(**locals())
+        del kwargs['self']
+        started = self.start_nodes(**kwargs)
         if self._scylla_manager:
             self._scylla_manager.start()
 
@@ -168,9 +174,9 @@ class ScyllaCluster(Cluster):
     def stop(self, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=127):
         if self._scylla_manager:
             self._scylla_manager.stop(gently)
-        args = locals()
-        del args['self']
-        return self.stop_nodes(**args)
+        kwargs = dict(**locals())
+        del kwargs['self']
+        return self.stop_nodes(**kwargs)
 
     def get_scylla_mode(self):
         return self.scylla_mode

--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -1,0 +1,53 @@
+import os
+from subprocess import run
+
+from ccmlib.scylla_cluster import ScyllaCluster
+from ccmlib.scylla_node import ScyllaNode
+
+
+class ScyllaDockerCluster(ScyllaCluster):
+    def __init__(self, *args, **kwargs):
+        super(ScyllaDockerCluster, self).__init__(*args, **kwargs)
+        self.docker_image = kwargs['docker_image']
+
+    def create_node(self, name, auto_bootstrap, thrift_interface,
+                    storage_interface, jmx_port, remote_debug_port,
+                    initial_token, save=True, binary_interface=None):
+
+        return ScyllaDockerNode(name, self, auto_bootstrap, thrift_interface,
+                                storage_interface, jmx_port, remote_debug_port,
+                                initial_token, save=save, binary_interface=binary_interface,
+                                scylla_manager=self._scylla_manager)
+
+
+class ScyllaDockerNode(ScyllaNode):
+    def __init__(self, *args, **kwargs):
+        kwargs['save'] = False
+        super(ScyllaDockerNode, self).__init__(*args, **kwargs)
+
+    def _get_directories(self):
+        dirs = {}
+        for i in ['data', 'commitlogs', 'conf', 'logs', 'hints', 'view_hints']:
+            dirs[i] = os.path.join(self.get_path(), i)
+        return dirs
+
+    def update_yaml(self):
+        pass # TODO: handle as mount point ?
+
+    def start(self, *args, **kwargs):
+        # TODO: find a better place to do this trick, at initializing maybe ? only if file doesn't exist in the test cluster dir yet ? as part as `update_yaml` ?
+        # get scylla.yaml out of the docker
+        local_yaml_path = os.path.join(self.get_path(), 'conf', 'scylla.yaml')
+        run(['bash', '-c',  f'docker run --rm --entrypoint cat {self.cluster.docker_image}  /etc/scylla/scylla.yaml > {local_yaml_path}'])
+        super(ScyllaDockerNode, self).start(*args, **kwargs)
+
+    def _start_scylla(self, args, marks, update_pid, wait_other_notice,
+                      wait_for_binary_proto, ext_env):
+        local_yaml_path = os.path.join(self.get_path(), 'conf', 'scylla.yaml')
+        # TODO: handle smp correctly via the correct param/api (or only via commandline params)
+        # TODO: mount of the data dir
+        # TODO: pass down the full command line params, since the docker ones doesn't support all of them ?
+        # TODO: pass down a unique tag, with the cluster name, or id, if we have such in ccm, like test_id in SCT ?
+        run(['bash', '-c', f"docker run -v {local_yaml_path}:/etc/scylla/scylla.yaml -d {self.cluster.docker_image} --smp 1"])
+
+        raise NotImplementedError()

--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -1,5 +1,6 @@
 import os
-from subprocess import run
+import random
+from subprocess import run, PIPE
 
 from ccmlib.scylla_cluster import ScyllaCluster
 from ccmlib.scylla_node import ScyllaNode
@@ -24,6 +25,9 @@ class ScyllaDockerNode(ScyllaNode):
     def __init__(self, *args, **kwargs):
         kwargs['save'] = False
         super(ScyllaDockerNode, self).__init__(*args, **kwargs)
+        self.docker_id = None
+        self.local_yaml_path = os.path.join(self.get_path(), 'conf')
+        self.docker_name = f'{self.cluster.name}-{self.name}'
 
     def _get_directories(self):
         dirs = {}
@@ -31,23 +35,68 @@ class ScyllaDockerNode(ScyllaNode):
             dirs[i] = os.path.join(self.get_path(), i)
         return dirs
 
+    @staticmethod
+    def get_docker_name():
+        return run(["docker", "ps", "-a"], stdout=PIPE).stdout.decode('utf-8').split()[-1]
+
     def update_yaml(self):
-        pass # TODO: handle as mount point ?
+        pass  # TODO: handle as mount point ?
+
+    def create_docker(self):
+        res = run(['bash', '-c', f"docker run -v {self.local_yaml_path}:/etc/scylla/ --name {self.docker_name} -d {self.cluster.docker_image} --smp 1"], stdout=PIPE, stderr=PIPE)
+        self.docker_id = res.stdout.decode('utf-8').strip() if res.stdout else None
+        return res.returncode == 0, res.stdout, res.stderr
+
+    def service_start(self, service_name):
+        res = run(['docker', 'exec', self.docker_name, 'supervisorctl', 'start', service_name],
+                  stdout=PIPE, stderr=PIPE)
+        if res.returncode != 0:
+            print(res.stdout)
+            print(f'service {service_name} failed to start with error\n{res.stderr}')
+
+    def service_stop(self, service_name):
+        res = run(['docker', 'exec', self.docker_name, 'supervisorctl', 'stop', service_name],
+                  stdout=PIPE, stderr=PIPE)
+        if res.returncode != 0:
+            print(res.stdout)
+            print(f'service {service_name} failed to stop with error\n{res.stderr}')
+
+    def service_status(self, service_name):
+        res = run(['docker', 'exec', self.docker_name, 'supervisorctl', 'status', service_name],
+                  stdout=PIPE, stderr=PIPE)
+        if res.returncode != 0:
+            print(res.stdout)
+            print(f'service {service_name} failed to stop with error\n{res.stderr}')
+        else:
+            return res.stdout.decode('utf-8').split()[1]
 
     def start(self, *args, **kwargs):
         # TODO: find a better place to do this trick, at initializing maybe ? only if file doesn't exist in the test cluster dir yet ? as part as `update_yaml` ?
         # get scylla.yaml out of the docker
-        local_yaml_path = os.path.join(self.get_path(), 'conf', 'scylla.yaml')
-        run(['bash', '-c',  f'docker run --rm --entrypoint cat {self.cluster.docker_image}  /etc/scylla/scylla.yaml > {local_yaml_path}'])
+        run(['bash', '-c', f'docker run --rm --entrypoint cat {self.cluster.docker_image}  /etc/scylla/scylla.yaml > {self.local_yaml_path}/scylla.yaml'])
+        # res = run([f'docker run --rm --entrypoint cat {self.cluster.docker_image}  '
+        #            f'/etc/scylla/scylla.yaml > {self.local_yaml_path}'],
+        #           stdout=PIPE, stderr=PIPE)
+        # if not res.returncode:
+        #     print(f'Failed to copy scylla.yaml to {self.local_yaml_path}\n{res.stderr}')
+        rc, out, err = self.create_docker()
+        if not rc:
+            raise BaseException(f'failed to create docker {self.docker_name}')
         super(ScyllaDockerNode, self).start(*args, **kwargs)
+        return random.randint(100, 10000)
 
     def _start_scylla(self, args, marks, update_pid, wait_other_notice,
                       wait_for_binary_proto, ext_env):
-        local_yaml_path = os.path.join(self.get_path(), 'conf', 'scylla.yaml')
         # TODO: handle smp correctly via the correct param/api (or only via commandline params)
         # TODO: mount of the data dir
         # TODO: pass down the full command line params, since the docker ones doesn't support all of them ?
         # TODO: pass down a unique tag, with the cluster name, or id, if we have such in ccm, like test_id in SCT ?
-        run(['bash', '-c', f"docker run -v {local_yaml_path}:/etc/scylla/scylla.yaml -d {self.cluster.docker_image} --smp 1"])
+        scylla_status = self.service_status('scylla')
+        if scylla_status and scylla_status.upper() != 'RUNNING':
+            self.service_start('scylla')
+        return random.randint(100, 10000)
 
-        raise NotImplementedError()
+    def _start_jmx(self, data):
+        jmx_status = self.service_status('scylla-jmx')
+        if not jmx_status and jmx_status.upper() == 'RUNNING':
+            self.service_start('scylla-jmx')

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -891,10 +891,10 @@ class ScyllaNode(Node):
 
     def _save(self):
         # TODO: - overwrite node
-        self.__update_yaml()
+        self.update_yaml()
         self._update_config()
 
-    def __update_yaml(self):
+    def update_yaml(self):
         # TODO: copied from node.py
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
         with open(conf_file, 'r') as f:

--- a/tests/test_scylla_docker_cluster.py
+++ b/tests/test_scylla_docker_cluster.py
@@ -1,0 +1,12 @@
+from subprocess import run
+from unittest import TestCase
+
+
+class TestScyllaDockerCluster(TestCase):
+    def test_01(self):
+        run(["bash", "-c", "rm -rf /home/fruch/.test/fruch01"])
+        from ccmlib.scylla_docker_cluster import ScyllaDockerCluster
+        cluster = ScyllaDockerCluster('/home/fruch/.test', name='fruch01', docker_image='scylladb/scylla-nightly:666.development-0.20201015.8068272b466')
+        cluster.populate(1)
+        cluster.start(no_wait=True)
+        node1 = cluster.nodes

--- a/tests/test_scylla_docker_cluster.py
+++ b/tests/test_scylla_docker_cluster.py
@@ -4,9 +4,10 @@ from unittest import TestCase
 
 class TestScyllaDockerCluster(TestCase):
     def test_01(self):
-        run(["bash", "-c", "rm -rf /home/fruch/.test/fruch01"])
+        run(["bash", "-c", "rm -rf /home/fabio/.test/fabio01"])
         from ccmlib.scylla_docker_cluster import ScyllaDockerCluster
-        cluster = ScyllaDockerCluster('/home/fruch/.test', name='fruch01', docker_image='scylladb/scylla-nightly:666.development-0.20201015.8068272b466')
+        cluster = ScyllaDockerCluster('/home/fabio/.test', name='fabio01',
+                                      docker_image='scylladb/scylla-nightly:666.development-0.20201015.8068272b466')
         cluster.populate(1)
         cluster.start(no_wait=True)
         node1 = cluster.nodes


### PR DESCRIPTION
started from @fruch PR on #262 and added the start function as it should be to the `scylla_docker_node` for both Scylla and jmx.

now, it is failing as the node didn't return a PID, so maybe we need to override that function that comes from `node`
