### PR TITLE
Docker ccm fix docker name

### DIFF
--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -36,7 +36,7 @@ class ScyllaDockerNode(ScyllaNode):
         self.docker_id = None
         self.local_data_path = os.path.join(self.get_path(), 'data')
         self.local_yaml_path = os.path.join(self.get_path(), 'conf')
-        self.docker_name = f'{self.cluster.name}-{self.name}'
+        self.docker_name = f'{self.cluster.get_path().split("/")[-2]}-{self.cluster.name}-{self.name}'
         self.jmx_port = 7199
         self.log_thread = None
 


### PR DESCRIPTION
from `get_path` i got the last part and added to the `docker_name` to make dockers unique..
the path when running from dtest will be generated by the framework and the path is the only difference between the "clusters"