### PR TITLE
    feature(.node.py): Fixing stress command for docker cluster

### DIFF
--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -37,7 +37,7 @@ class ScyllaDockerNode(ScyllaNode):
         self.local_data_path = os.path.join(self.get_path(), 'data')
         self.local_yaml_path = os.path.join(self.get_path(), 'conf')
         self.docker_name = f'{self.cluster.get_path().split("/")[-2]}-{self.cluster.name}-{self.name}'
-        self.jmx_port = 7199
+        self.jmx_port = "7199"  # The old CCM code expected to get a string and not int
         self.log_thread = None
 
     def _get_directories(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def test_id():
 
 @pytest.fixture(scope="session")
 def test_dir(test_id, results_dir):
-    max_test_dirs, dir_count = 1, 100
+    max_test_dirs, dir_count = 100, 1
     test_dir = results_dir / Path("ccm-" + test_id)
     while test_dir.exists() and dir_count <= max_test_dirs:
         test_dir = results_dir / Path("ccm-{}-{}".format(test_id, dir_count))

--- a/tests/test_scylla_docker_cluster.py
+++ b/tests/test_scylla_docker_cluster.py
@@ -69,3 +69,7 @@ class TestScyllaDockerCluster:
 
         node3.stop(gently=False)
         node3.start()
+
+    def test_node_stress(self, docker_cluster):
+        node1, *_ = docker_cluster.nodelist()
+        node1.stress(['write', 'n=1000000'])


### PR DESCRIPTION
* Create `docker_image` variable under `Node` class
* Change the `jmx_port` field under ScyllaDockerNode from
    int to string (because the old CCN code expected to get
    string)
* stress method - Convert the `stress` variable to list and 
    set None value for `cwd` variable in case the cluster is 
    docker
