### PR TITLE
WIP - making CCM cmd line work with docker_image

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -49,6 +49,7 @@ class Cluster(object):
             os.mkdir(self.get_path())
 
         if docker_image:
+            self.docker_image = docker_image
             self.__install_dir = None
             self.__version = '3.0'
             self._update_config()
@@ -538,8 +539,8 @@ class Cluster(object):
                 'dse_config_options': self._dse_config_options,
                 'log_level': self.__log_level,
                 'use_vnodes': self.use_vnodes,
-                'id' : self.id,
-                'ipprefix' : self.ipprefix
+                'id': self.id,
+                'ipprefix': self.ipprefix
             }, f)
 
     def __update_pids(self, started):

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -6,6 +6,7 @@ from ccmlib import common, repository
 from ccmlib.cluster import Cluster
 from ccmlib.dse_cluster import DseCluster
 from ccmlib.scylla_cluster import ScyllaCluster
+from ccmlib.scylla_docker_cluster import ScyllaDockerCluster
 from ccmlib import repository
 from ccmlib.node import Node
 
@@ -20,14 +21,16 @@ class ClusterFactory():
             data = yaml.safe_load(f)
         try:
             install_dir = None
-            if 'install_dir' in data:
+            if 'install_dir' in data and 'docker_image' not in data:
                 install_dir = data['install_dir']
                 repository.validate(install_dir)
             if install_dir is None and 'cassandra_dir' in data:
                 install_dir = data['cassandra_dir']
                 repository.validate(install_dir)
-
-            if common.isScylla(install_dir):
+            if 'docker_image' in data and data['docker_image']:
+                cluster = ScyllaDockerCluster(path, data['name'], docker_image=data['docker_image'],
+                                              install_dir=install_dir, create_directory=False)
+            elif common.isScylla(install_dir):
                 cluster = ScyllaCluster(path, data['name'], install_dir=install_dir, create_directory=False)
             elif common.isDse(install_dir):
                 cluster = DseCluster(path, data['name'], install_dir=install_dir, create_directory=False)

--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -73,6 +73,8 @@ class Cmd(object):
             self.name = args[0]
 
         if load_cluster:
+            # FIXME: here must take info from cluster.cfg
+            # TODO: from scylla_docker_cluster.py we need to save all data into cluster.cfg (and also node.cfg)
             self.cluster = self._load_current_cluster()
             if node_name and load_node:
                 try:

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -383,7 +383,6 @@ def isDse(install_dir):
 def isScylla(install_dir):
     if install_dir is None:
         scylla_version = os.environ.get('SCYLLA_VERSION', None)
-
         if scylla_version:
             from ccmlib.scylla_repository import setup
             cdir, _ = setup(scylla_version)


### PR DESCRIPTION
currently failing with an error:

```
Traceback (most recent call last):
  File "/home/fabio/git/scylla-ccm/.venv38/bin/ccm", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/fabio/git/scylla-ccm/ccm", line 75, in <module>
    cmd.run()
  File "/home/fabio/git/scylla-ccm/ccmlib/cmds/cluster_cmds.py", line 257, in run
    cluster.populate(self.nodes, self.options.debug, use_vnodes=self.options.vnodes, ipprefix=self.options.ipprefix, ipformat=self.options.ipformat)
  File "/home/fabio/git/scylla-ccm/ccmlib/scylla_docker_cluster.py", line 72, in populate
    self.new_node(i, debug=debug, initial_token=tk, data_center=dc)
  File "/home/fabio/git/scylla-ccm/ccmlib/scylla_docker_cluster.py", line 85, in new_node
    self.add(node, is_seed=is_seed, data_center=data_center)
  File "/home/fabio/git/scylla-ccm/ccmlib/scylla_docker_cluster.py", line 100, in add
    node.create_docker()
  File "/home/fabio/git/scylla-ccm/ccmlib/scylla_docker_cluster.py", line 217, in create_docker
    self.network_interfaces = {k: (address, v[1]) for k, v in self.network_interfaces.items()}
  File "/home/fabio/git/scylla-ccm/ccmlib/scylla_docker_cluster.py", line 217, in <dictcomp>
    self.network_interfaces = {k: (address, v[1]) for k, v in self.network_interfaces.items()}
TypeError: 'NoneType' object is not subscriptable
```