### PR TITLE
nodetool timeout: timeout missing on `communicate()` call

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -733,7 +733,7 @@ class Node(object):
         args += cmd.split()
         if capture_output:
             p = subprocess.Popen(args, universal_newlines=True, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = p.communicate()
+            stdout, stderr = p.communicate(timeout=timeout)
         else:
             p = subprocess.Popen(args, env=env, universal_newlines=True)
             stdout, stderr = None, None


### PR DESCRIPTION
a change in 373a62bd54d2377708f7f527937714730ed3a842 was missing
some small but importent part.