### PR TITLE
docker-ccm: `tar --keep-old-files` to prevent overwriting `cassandra-…

### DIFF
--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -103,7 +103,7 @@ class ScyllaDockerNode(ScyllaNode):
             # copy all the content of /etc/scylla out of the image without actually running it
             run(['bash', '-c', f"""
                     ID=$(docker run --rm -d {self.cluster.docker_image} tail -f /dev/null) ; 
-                    docker container cp -a "${{ID}}:/etc/scylla/" - | tar -x --strip-components=1 -C {self.local_yaml_path} ;
+                    docker container cp -a "${{ID}}:/etc/scylla/" - | tar --keep-old-files -x --strip-components=1 -C {self.local_yaml_path} ;
                     docker stop ${{ID}}
                 """], stdout=PIPE, stderr=PIPE, universal_newlines=True)
         super(ScyllaDockerNode, self).update_yaml()


### PR DESCRIPTION
…rackdc.properties`

`cassandra-rackdc.properties` is written before we spin up the node.
and our logic that copy the content of /etc/scylla/ out of the image
was overwriting those files