### PR TITLE
wait_until_stopped: increase wait time in debug mode

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -141,7 +141,7 @@ class ScyllaCluster(Cluster):
 
         return started
 
-    def stop_nodes(self, nodes=None, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=127):
+    def stop_nodes(self, nodes=None, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=None):
         if nodes is None:
             nodes = self.nodes.values()
         elif isinstance(nodes, ScyllaNode):
@@ -165,7 +165,7 @@ class ScyllaCluster(Cluster):
 
         return [node for node in nodes if not node.is_running()]
 
-    def stop(self, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=127):
+    def stop(self, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=None):
         if self._scylla_manager:
             self._scylla_manager.stop(gently)
         args = locals()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -714,7 +714,7 @@ class ScyllaNode(Node):
                 if dump_core and self.pid:
                     # Aborting is intended to generate a core dump
                     # so the reason the node didn't stop normally can be studied.
-                    print("{} is still running. Trying to generate coredump using kill({}, SIGQUIT)...".format(self.name, self.pid))
+                    self.warning("{} is still running. Trying to generate coredump using kill({}, SIGQUIT)...".format(self.name, self.pid))
                     try:
                         os.kill(self.pid, signal.SIGQUIT)
                     except OSError:


### PR DESCRIPTION
As seen in many debug tests, we're too quick to declare timeout on the stopping node and the core dump indicates the node is still busy flushing.

This will be more noticeable now that https://github.com/scylladb/scylla-dtest/pull/1763 is merged.
    
Increase the timeout to 10 minutes in debug mode to let the node have enough time to stop gracefully.

Test: cql_tracing_test.py:TestCqlTracing.tracing_startup_test (debug)

```
2020-11-19 11:34:08.814563 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - cluster ccm directory: /local/home/bhalevy/.dtest/dtest-3jw7vgbr
2020-11-19 11:34:08.814709 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Starting Scylla cluster from directory ../scylla/build/debug
2020-11-19 11:34:08.818760 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Allocated cluster ID 8: /local/home/bhalevy/.dtest/dtest-3jw7vgbr
2020-11-19 11:34:08.873001 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Scylla mode is 'debug'
2020-11-19 11:34:08.873086 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Cluster *_request_timeout_in_ms=30000, cql request_timeout=90
2020-11-19 11:36:14.746328 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Enable tracing for all CQL requests on node1...
2020-11-19 11:36:18.253300 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - CREATE COLUMNFAMILY cf (key varchar PRIMARY KEY, c1 text, c2 text) WITH comment='test cf' AND compression = {} AND read_repair_chance=0.000000
2020-11-19 11:36:20.463380 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Stopping node2...
2020-11-19 11:36:27.472447 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Checking log of node2 for assertions...
2020-11-19 11:36:27.474344 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Populating a table with 15000 keys...
2020-11-19 11:36:27.475625 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Wait for 0.5659240802493766 seconds
2020-11-19 11:36:28.042315 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Start node2...
2020-11-19 11:44:39.984019 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - insertion of 15000 keys is done
2020-11-19 11:44:39.986243 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Stopping cluster
2020-11-19 11:48:55.225546 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - stopping ccm cluster test at: /local/home/bhalevy/.dtest/dtest-3jw7vgbr
2020-11-19 11:48:55.273285 cql_tracing_test.py:TestCqlTracing.tracing_startup_test - Freeing cluster ID 8: link /local/home/bhalevy/.dtest/8
tracing_startup_test (cql_tracing_test.TestCqlTracing) ... ok
```

This shows it took the nodes ~4.5 minutes to stop gracefully on my machine in debug mode so setting the timeout to about twice that amount seems reasonable as the default, though we may need to adjust it for specific tests, or stop the cluster forcibly there.
