### PR TITLE
Run boto3 client in parallel

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -16,7 +16,7 @@ import tempfile
 import logging
 
 import yaml
-from boto3 import client
+from boto3.session import Session
 from botocore import UNSIGNED
 from botocore.client import Config
 from six import print_
@@ -705,7 +705,7 @@ def assert_jdk_valid_for_cassandra_version(cassandra_version):
 def aws_bucket_ls(s3_url):
     bucket_object = s3_url.replace('https://s3.amazonaws.com/', '').split('/')
     prefix = '/'.join(bucket_object[1:])
-    s3_conn = client('s3', config=Config(signature_version=UNSIGNED))
+    s3_conn = Session().client(service_name='s3', config=Config(signature_version=UNSIGNED))
     paginator = s3_conn.get_paginator('list_objects_v2')
     pages = paginator.paginate(Bucket=bucket_object[0], Prefix=prefix)
 

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -201,7 +201,7 @@ class ScyllaCluster(Cluster):
         self._config_options['server_encryption_options'] = node_ssl_options
         self._update_config()
 
-    def _update_config(self):
+    def _update_config(self, install_dir=None):
         """
         add scylla specific item to the cluster.conf
         :return: None

--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -44,7 +44,7 @@ class ScyllaDockerCluster(ScyllaCluster):
                                 initial_token, save=save, binary_interface=binary_interface,
                                 scylla_manager=self._scylla_manager)
 
-    def _update_config(self):
+    def _update_config(self, install_dir=None):
         node_list = [node.name for node in list(self.nodes.values())]
         seed_list = [node.name for node in self.seeds]
         filename = os.path.join(self.get_path(), 'cluster.conf')


### PR DESCRIPTION
Using boto3.client is not thread safe. These special classes contain additional
meta data that cannot be shared between threads. 
When run relocatable packages download in parallel in threads, it may fail (not every run) with error:

```
15:02:23  Traceback (most recent call last):
15:02:23    File "/jenkins/workspace/scylla-master/byo/dtest-byo/scylla-dtest/dtest.py", line 640, in setUp
15:02:23      self.cluster = self.get_cluster(version=self.cassandra_version)
15:02:23    File "/jenkins/workspace/scylla-master/byo/dtest-byo/scylla-dtest/upgrade_test.py", line 42, in get_cluster
15:02:23      self.download_all_relocatables()
15:02:23    File "/jenkins/workspace/scylla-master/byo/dtest-byo/scylla-dtest/upgrade_test.py", line 73, in download_all_relocatables
15:02:23      thread.result(timeout=1800)
15:02:23    File "/usr/lib64/python3.7/concurrent/futures/_base.py", line 428, in result
15:02:23      return self.__get_result()
15:02:23    File "/usr/lib64/python3.7/concurrent/futures/_base.py", line 384, in __get_result
15:02:23      raise self._exception
15:02:23    File "/usr/lib64/python3.7/concurrent/futures/thread.py", line 57, in run
15:02:23      result = self.fn(*self.args, **self.kwargs)
15:02:23    File "/jenkins/workspace/scylla-master/byo/dtest-byo/scylla-ccm/ccmlib/scylla_repository.py", line 141, in setup
15:02:23      packages, type_n_version[1] = release_packages(s3_url=s3_url, version=s3_version)
15:02:23    File "/jenkins/workspace/scylla-master/byo/dtest-byo/scylla-ccm/ccmlib/scylla_repository.py", line 66, in release_packages
15:02:23      files_in_bucket = aws_bucket_ls(s3_url)
15:02:23    File "/jenkins/workspace/scylla-master/byo/dtest-byo/scylla-ccm/ccmlib/common.py", line 704, in aws_bucket_ls
15:02:23      s3_conn = client('s3', config=Config(signature_version=UNSIGNED))
15:02:23    File "/usr/local/lib/python3.7/site-packages/boto3/__init__.py", line 91, in client
15:02:23      return _get_default_session().client(*args, **kwargs)
15:02:23    File "/usr/local/lib/python3.7/site-packages/boto3/session.py", line 263, in client
15:02:23      aws_session_token=aws_session_token, config=config)
15:02:23    File "/usr/local/lib/python3.7/site-packages/botocore/session.py", line 824, in create_client
15:02:23      endpoint_resolver = self._get_internal_component('endpoint_resolver')
15:02:23    File "/usr/local/lib/python3.7/site-packages/botocore/session.py", line 697, in _get_internal_component
15:02:23      return self._internal_components.get_component(name)
15:02:23    File "/usr/local/lib/python3.7/site-packages/botocore/session.py", line 923, in get_component
15:02:23      del self._deferred[name]
15:02:23  KeyError: 'endpoint_resolver'
```

Low-level clients are thread safe.
Change to use boto3.session.Session().client.

[Multithreading and multiprocessing](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html#multithreading-multiprocessing)