### PR TITLE
introduce 'common.get_scylla_full_version'

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,6 +40,7 @@ jobs:
         if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
 
     - name: Cache binary versions
+      id: cache-versions
       uses: actions/cache@v2
       with:
         path: |
@@ -48,6 +49,7 @@ jobs:
         key: ${{ runner.os }}-repos-${{ hashFiles('**/test_config.py') }}
 
     - name: Download versions
+      if: steps.cache-versions.outputs.cache-hit != 'true'
       run: |
         if [ ! -f ~/.ccm/scylla-repository/unstable/master/2020-08-29T22_24_05Z ]; then
           RELOC_VERSION="2020-08-29T22:24:05Z"

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -637,6 +637,20 @@ def _get_scylla_version(install_dir):
     return '3.0'
 
 
+def _get_scylla_release(install_dir):
+    scylla_release_files = [os.path.join(install_dir, 'build', 'SCYLLA-RELEASE-FILE'),
+                                os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-RELEASE-FILE')]
+    for release_file in scylla_release_files:
+        if os.path.exists(release_file):
+            with open(release_file) as file:
+                return file.read().strip()
+    raise ValueError("SCYLLA-RELEASE-FILE wasn't found")
+
+
+def get_scylla_full_version(install_dir):
+    return f'{_get_scylla_version(install_dir)}-{_get_scylla_release(install_dir)}'
+
+
 def get_scylla_version(install_dir):
     if isScylla(install_dir):
         return _get_scylla_version(install_dir)

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -632,9 +632,10 @@ def _get_scylla_version(install_dir):
             # return only version strings (loosly) conforming to PEP-440
             # See https://www.python.org/dev/peps/pep-0440/
             # 'i.j(.|-)dev[N]' < 'i.j.rc[N]' < 'i.j.k' < i.j(.|-)post[N]
-            if re.fullmatch('(\d+!)?\d+([.-]\d+)*([a-z]+\d?)?([.-]post\d?)?([.-]dev\d?)?', v):
+            if re.fullmatch('(\d+!)?\d+([.-]\d+)*([a-z]+\d*)?([.-](post|dev|rc)\d*)*', v):
                 return v
     return '3.0'
+
 
 def get_scylla_version(install_dir):
     if isScylla(install_dir):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from tests.test_config import RESULTS_DIR, TEST_ID, SCYLLA_DOCKER_IMAGE, SCYLLA_RELOCATABLE_VERSION
 
+from ccmlib.scylla_cluster import ScyllaCluster
 from ccmlib.scylla_docker_cluster import ScyllaDockerCluster
 from .ccmcluster import CCMCluster
 
@@ -58,6 +59,26 @@ def docker_cluster(test_dir, test_id):
         'request_timeout_in_ms': timeout
     })
     cluster.populate(3)
+    cluster.start(wait_for_binary_proto=True)
+    try:
+        yield cluster
+    finally:
+        cluster.clear()
+
+
+@pytest.fixture(scope="session")
+def relocatable_cluster(test_dir, test_id):
+    cluster_name = f"relocatable_cluster_{test_id}"
+    cluster = ScyllaCluster(str(test_dir), name=cluster_name, version=SCYLLA_RELOCATABLE_VERSION)
+    timeout = 10000
+    cluster.set_configuration_options(values={
+        'read_request_timeout_in_ms': timeout,
+        'range_request_timeout_in_ms': timeout,
+        'write_request_timeout_in_ms': timeout,
+        'truncate_request_timeout_in_ms': timeout,
+        'request_timeout_in_ms': timeout
+    })
+    cluster.populate(1)
     cluster.start(wait_for_binary_proto=True)
     try:
         yield cluster

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,3 +8,5 @@ SCYLLA_DOCKER_IMAGE = os.environ.get(
     "SCYLLA_DOCKER_IMAGE", "scylladb/scylla-nightly:666.development-0.20201015.8068272b466")
 SCYLLA_RELOCATABLE_VERSION = os.environ.get(
     "SCYLLA_VERSION", "unstable/master:2020-08-29T22:24:05Z")
+
+# Jan/6 comment to refresh the action cache

--- a/tests/test_scylla_relocatable_cluster.py
+++ b/tests/test_scylla_relocatable_cluster.py
@@ -1,0 +1,15 @@
+import pytest
+
+from ccmlib.common import get_scylla_full_version, get_scylla_version
+
+
+@pytest.mark.reloc
+class TestScyllaRelocatableCluster:
+    def test_get_scylla_full_version(self, relocatable_cluster):
+        install_dir = relocatable_cluster.get_install_dir()
+        assert get_scylla_full_version(install_dir) == '3.0-0.20200829.f1255cb2d02'
+
+    def test_get_scylla_version(self, relocatable_cluster):
+        install_dir = relocatable_cluster.get_install_dir()
+        assert get_scylla_version(install_dir) == '3.0'
+

--- a/tests/test_version_parsing.py
+++ b/tests/test_version_parsing.py
@@ -1,0 +1,34 @@
+import pytest
+from pathlib import Path
+
+from ccmlib.common import get_scylla_version
+
+
+@pytest.mark.parametrize("version_to_test", ['4.2', '4.2.rc1', '4.2.rc111', '4.2.dev'])
+def test_valid_versions(tmpdir, version_to_test):
+
+    # mock it's a scylla dir
+    (Path(tmpdir) / 'scylla').touch()
+
+    # mock the version file
+    (Path(tmpdir) / 'build').mkdir()
+    with (Path(tmpdir) / 'build' / 'SCYLLA-VERSION-FILE').open(mode='w') as f:
+        f.write(version_to_test)
+
+    version = get_scylla_version(install_dir=tmpdir)
+    assert version == version_to_test
+
+
+@pytest.mark.parametrize("version_to_test", ['666.development', 'strings_only'])
+def test_invalid_versions(tmpdir, version_to_test):
+
+    # mock it's a scylla dir
+    (Path(tmpdir) / 'scylla').touch()
+
+    # mock the version file
+    (Path(tmpdir) / 'build').mkdir()
+    with (Path(tmpdir) / 'build' / 'SCYLLA-VERSION-FILE').open(mode='w') as f:
+        f.write(version_to_test)
+
+    version = get_scylla_version(install_dir=tmpdir)
+    assert version == '3.0'


### PR DESCRIPTION
new function that can show the full version of relocatable/source runs (including the date and git sha)

we want this to be part of the data collect per dtest run.

Closes: #252 