### PR TITLE
fix(scylla_repository): wrong logic when scylla-manager isn't

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -191,7 +191,7 @@ def setup(version, verbose=True):
     scylla_ext_opts = os.environ.get('SCYLLA_EXT_OPTS', '')
     scylla_manager_package = os.environ.get('SCYLLA_MANAGER_PACKAGE')
 
-    if not scylla_ext_opts:
+    if not scylla_ext_opts and scylla_manager_package:
         manager_install_dir = setup_scylla_manager(scylla_manager_package)
         scylla_ext_opts += ' --scylla-manager={}'.format(manager_install_dir)
         os.environ['SCYLLA_EXT_OPTS'] = scylla_ext_opts


### PR DESCRIPTION
Wronly send parameter when scylla-manager isn't defined

```
--scylla-manager=None
```