### PR TITLE
fix(scylla_repository): Fix link relocatable_url_base

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -29,7 +29,8 @@ from ccmlib.utils.download import download_file, download_version_from_s3
 
 GIT_REPO = "http://github.com/scylladb/scylla.git"
 
-RELOCATABLE_URLS_BASE = 'https://s3.amazonaws.com/downloads.scylladb.com/relocatable/{0}/{1}'
+RELOCATABLE_URLS_BASE = ['https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/{0}/relocatable/{1}',
+                         'https://s3.amazonaws.com/downloads.scylladb.com/relocatable/unstable/{0}/{1}']
 RELEASE_RELOCATABLE_URLS_BASE = 'https://s3.amazonaws.com/downloads.scylladb.com/downloads/scylla/relocatable/scylladb-{0}'
 ENTERPRISE_RELEASE_RELOCATABLE_URLS_BASE = 'https://s3.amazonaws.com/downloads.scylladb.com/downloads/scylla-enterprise/relocatable/scylladb-{0}'
 ENTERPRISE_RELOCATABLE_URLS_BASE = 'https://s3.amazonaws.com/downloads.scylladb.com/enterprise/relocatable/{0}/{1}'
@@ -143,7 +144,12 @@ def setup(version, verbose=True):
             if 'enterprise' in scylla_product:
                 s3_url = ENTERPRISE_RELOCATABLE_URLS_BASE.format(type_n_version[0], s3_version)
             else:
-                s3_url = RELOCATABLE_URLS_BASE.format(type_n_version[0], s3_version)
+                _, branch = type_n_version[0].split("/")
+                for reloc_url in RELOCATABLE_URLS_BASE:
+                    s3_url = reloc_url.format(branch, s3_version)
+                    resp = aws_bucket_ls(s3_url)
+                    if resp:
+                        break
             packages = RelocatablePackages(scylla_jmx_package=os.path.join(s3_url,
                                                                            f'{scylla_product}-jmx-package.tar.gz'),
                                            scylla_tools_package=os.path.join(s3_url,

--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -6,14 +6,21 @@ from ccmlib.scylla_repository import setup
 
 
 @pytest.mark.repo_tests
+@pytest.mark.skip("slow integration test")
 class TestScyllaRepository:
-    @pytest.mark.skip("slow integration test")
     def test_setup_release_oss(self):
         cdir, version = setup(version="release:4.2.1", verbose=True)
         assert version == '4.2.1'
 
-    @pytest.mark.skip("slow integration test")
     @patch.dict('os.environ', {'SCYLLA_PRODUCT': 'scylla-enterprise'})
     def test_setup_release_enterprise(self):
         cdir, version = setup(version="release:2020.1.5", verbose=True)
         assert version == '2020.1.5'
+
+    def test_setup_unstable_master_new_url(self):
+        cdir, version = setup(version="unstable/master:2021-01-18T15:48:13Z", verbose=True)
+        assert version == '4.4.dev'
+
+    def test_setup_unstable_master_old_url(self):
+        cdir, version = setup(version="unstable/master:2020-08-29T22:24:05Z", verbose=True)
+        assert version == '3.0'


### PR DESCRIPTION
After move to new location usage:
`$ SCYLLA_VERSION=unstable/master:2021-01-18T15%3A48%3A13Z ./scripts/run_test.sh`
failed with error:
```
 File "/home/abykov/Projects/scylladb-project/scylla-ccm/ccmlib/scylla_repository.py", line 175, in setup
    tmp_download, 'scylla-core-package'))
  File "/home/abykov/Projects/scylladb-project/scylla-ccm/ccmlib/scylla_repository.py", line 289, in download_version
    download_file(url=url, target_path=target,verbose=verbose)
  File "/home/abykov/Projects/scylladb-project/scylla-ccm/ccmlib/utils/download.py", line 110, in download_file
    resp.raise_for_status()
  File "/usr/local/lib/python3.7/site-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://s3.amazonaws.com/downloads.scylladb.com/relocatable/unstable/master/2021-01-18T19%3A16%3A39Z/scylla-package.tar.gz
```
fixed url to support new location