### PR TITLE
fix(scylla_extract_install_dir_and_mode): never to return a None scylla_mode

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -451,7 +451,7 @@ def scylla_extract_install_dir_and_mode(install_dir):
                 f = open(os.path.join(install_dir, 'scylla-core-package', 'source.txt'), 'r')
                 for l in f.readlines():
                     if l.startswith('url='):
-                        scylla_mode = scylla_extract_mode(l)
+                        scylla_mode = scylla_extract_mode(l) or scylla_mode
                 f.close()
             except:
                 pass


### PR DESCRIPTION
in some cases when used a specific local files, it would return None, and not
default `release`