### PR TITLE
fix(scylla_repository): logic for setup of manager wasn't correct

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -205,7 +205,7 @@ def setup(version, verbose=True):
     scylla_ext_opts = os.environ.get('SCYLLA_EXT_OPTS', '')
     scylla_manager_package = os.environ.get('SCYLLA_MANAGER_PACKAGE')
 
-    if not scylla_ext_opts and scylla_manager_package:
+    if scylla_manager_package:
         manager_install_dir = setup_scylla_manager(scylla_manager_package)
         scylla_ext_opts += ' --scylla-manager={}'.format(manager_install_dir)
         os.environ['SCYLLA_EXT_OPTS'] = scylla_ext_opts


### PR DESCRIPTION
seems like the fix in 4571bc7c3835e8a1632d571f7beff707c96b4563 wasn't enough
and not accurate, and was breaking the manager dtest jobs
since `SCYLLA_EXT_OPTS` was defined, while the logic assume it would be defined
only when manger is used locally