### PR TITLE
fix cassandra bin path in node.run_sstablesplit

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -990,7 +990,7 @@ class Node(object):
             if debug:
                 cmd.append('--debug')
             cmd.append(f)
-            p = subprocess.Popen(cmd, cwd=os.path.join(self.get_install_dir(), 'resources', 'cassandra', 'bin'),
+            p = subprocess.Popen(cmd, cwd=os.path.join(self.get_path(), 'resources', 'cassandra', 'tools', 'bin'),
                                  env=env, stderr=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
             (out, err) = p.communicate()
             rc = p.returncode


### PR DESCRIPTION
The issue here is wrong path to cassandra/bin folder
It affects on the sstablesplit_test only. I didn't find other test that use it.
It's not connected to pytest.
Actually this test is not running, not part of the scylla_tests file