### PR TITLE
fix(#303): collect more info when nodetool raises `TimeoutExpired`

### DIFF
--- a/tests/test_scylla_relocatable_cluster.py
+++ b/tests/test_scylla_relocatable_cluster.py
@@ -1,6 +1,10 @@
+import time
+import subprocess
+
 import pytest
 
 from ccmlib.common import get_scylla_full_version, get_scylla_version
+from ccmlib.node import Node
 
 
 @pytest.mark.reloc
@@ -13,3 +17,11 @@ class TestScyllaRelocatableCluster:
         install_dir = relocatable_cluster.get_install_dir()
         assert get_scylla_version(install_dir) == '3.0'
 
+    def test_nodetool_timeout(self, relocatable_cluster):
+        node1: Node = relocatable_cluster.nodelist()[0]
+        node1._update_jmx_pid(wait=True)
+        with pytest.raises(subprocess.TimeoutExpired):
+            node1.nodetool("cfstats", timeout=0.0001)
+        with pytest.raises(subprocess.TimeoutExpired):
+            node1.nodetool("cfstats", capture_output=True, timeout=0.0001)
+        time.sleep(5)


### PR DESCRIPTION
When nodetool command get timeout, we try to send `SIGQUIT` to get
a threaddump inforamtion into scylla-jmx stdout.

Close: #303
Ref: https://github.com/scylladb/scylla/issues/7991#issuecomment-771468592