### PR TITLE
fix(#304): wait a bit more when killing scylla-jmx on timeout

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -655,6 +655,7 @@ class ScyllaNode(Node):
         except subprocess.TimeoutExpired:
             self.error("nodetool timeout, going to kill scylla-jmx with SIGQUIT")
             self.kill_jmx(signal.SIGQUIT)
+            time.sleep(5)  # give the java process time to print the threaddump into the log
             raise
 
     def kill_jmx(self, __signal):


### PR DESCRIPTION
The `SIGQUIT` is follow too soon by a forcefull kill, i.e. we don't let
the process enough time to print the output to stdout

Close: #303
Ref: https://github.com/scylladb/scylla/issues/7991#issuecomment-771468592