### PR TITLE
Adjust scylla start timeout

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -109,7 +109,8 @@ class ScyllaCluster(Cluster):
                 if started:
                     last_node, _, last_mark = started[-1]
                     last_node.watch_log_for("node is now in normal status|Starting listening for CQL clients",
-                                            verbose=verbose, from_mark=last_mark)
+                                            verbose=verbose, from_mark=last_mark,
+                                            process=last_node._process_scylla)
                 mark = 0
                 if os.path.exists(node.logfilename()):
                     mark = node.mark_log()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -267,7 +267,7 @@ class ScyllaNode(Node):
         return bool(self.grep_log("{}|{}".format(bootstrap_message, resharding_message), from_mark=from_mark))
 
     def _start_scylla(self, args, marks, update_pid, wait_other_notice,
-                      wait_for_binary_proto, ext_env):
+                      wait_for_binary_proto, ext_env, timeout=None):
         log_file = os.path.join(self.get_path(), 'logs', 'system.log')
         # In case we are restarting a node
         # we risk reading the old cassandra.pid file
@@ -305,11 +305,13 @@ class ScyllaNode(Node):
 
         if wait_other_notice:
             for node, mark in marks:
-                node.watch_log_for_alive(self, from_mark=mark)
+                t = timeout if timeout is not None else 120 if self.cluster.scylla_mode != 'debug' else 360
+                node.watch_log_for_alive(self, from_mark=mark, timeout=t)
 
         if wait_for_binary_proto:
             try:
-                self.wait_for_binary_interface(from_mark=self.mark, process=self._process_scylla, timeout=420)
+                t = timeout * 4 if timeout is not None else 420 if self.cluster.scylla_mode != 'debug' else 900
+                self.wait_for_binary_interface(from_mark=self.mark, process=self._process_scylla, timeout=t)
             except TimeoutError as e:
                 if not self.wait_for_starting(from_mark=self.mark):
                     raise e


### PR DESCRIPTION
Currently we need to wait the full `node.watch_log_for` timeout
(600 seconds) to detect that a node failed during startup.
Pass the last_node process to `watch_log_for` so it
can fail as as it detects that the node terminated.

And in scylla_start: increase timeout in debug mode
to prevent test failures due to slow start when scylla is resharding sstables when started.

Test: materialized_views_test:TestMaterializedViews.{interrupt_build_process_with_resharding_low_to_half_test,interrupt_build_process_and_resharding_low_to_half_test}