### PR TITLE
scylla_cluster: stop_nodes: ignore node.is_running

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -163,14 +163,13 @@ class ScyllaCluster(Cluster):
             marks = [(node, node.mark_log()) for node in other_nodes if node.is_live()]
 
         # stop all nodes in parallel
-        stopped = [node for node in nodes if node.is_running()]
-        for node in stopped:
+        for node in nodes:
             node.do_stop(gently=gently)
 
         # wait for stopped nodes is needed
         if wait or wait_other_notice:
-            for node in stopped:
-                node.wait_until_stopped(wait_seconds, marks)
+            for node in nodes:
+                node.wait_until_stopped(wait_seconds, marks, dump_core=gently)
 
         return [node for node in nodes if not node.is_running()]
 


### PR DESCRIPTION
In addition to 23880da688cc8f3bc2b0ba5d17363c4edd42a138
cluster.stop_nodes also needs to ignore node.is_running
to kill scylla-jmx, e.g. when the cluster is stopped
in the end of a dtest.

This change calls node.do_stop on all nodes to be stopped,
regardless if they are running or not (as it is possible
that the scylla process would have already exited, or
failed to start), and then call node.wait_until_stopped
if wait=True on all the above nodes.  wait_until_stopped
makes sure to kill all processes, and to get a core dump
from scylla if dump_core=True (derived from gently).

Dtest: secondary_indexes_test.py:TestSecondaryIndexes.test_insert_data_after_recreating_ks
Signed-off-by: Benny Halevy <bhalevy@scylladb.com>