### PR TITLE
Prevent parallel relocatable packages download to the same folder

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -44,6 +44,8 @@ CASSANDRA_SH = "cassandra.in.sh"
 CONFIG_FILE = "config"
 CCM_CONFIG_DIR = "CCM_CONFIG_DIR"
 
+INSTALL_DIR_PLACEHOLDER_FILE = "placeholder"
+
 logger = logging.getLogger('ccm')
 
 class CCMError(Exception):
@@ -458,9 +460,42 @@ def scylla_extract_install_dir_and_mode(install_dir):
     return install_dir, scylla_mode
 
 
+def check_file_exists(path_to_file):
+    if os.path.exists(path_to_file):
+        return True
+    return False
+
+
+def _wait_until_false(wait_seconds, func, kwargs):
+    start_time = time.time()
+    wait_time_sec = 5
+    while True:
+        if not func(**kwargs):
+            return True
+        elapsed = time.time() - start_time
+        if elapsed >= wait_seconds:
+            return False
+        time.sleep(wait_time_sec)
+        if elapsed + wait_time_sec > wait_seconds:
+            wait_time_sec = wait_seconds - elapsed
+        elif wait_time_sec <= 16:
+            wait_time_sec *= 2
+
+
+def wait_for_parallel_download_finish(placeholder_file):
+    if check_file_exists(placeholder_file):
+        if not _wait_until_false(3600, check_file_exists, kwargs={'path_to_file': placeholder_file}):
+            raise TimeoutError(f"Relocatables download still runs in parallel from another test after 60 min. "
+                               f"Placeholder file exists: {placeholder_file}")
+
+
 def validate_install_dir(install_dir):
     if install_dir is None:
         raise ArgumentError('Undefined installation directory')
+
+    # If relocatables download is running in parallel from another test, the install_dir exists with placehoslder file
+    # in the folder. Once it will be downloaded and installed, this file will be removed.
+    wait_for_parallel_download_finish(os.path.join(install_dir, INSTALL_DIR_PLACEHOLDER_FILE))
 
     # Windows requires absolute pathing on installation dir - abort if specified cygwin style
     if is_win():

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -44,7 +44,7 @@ CASSANDRA_SH = "cassandra.in.sh"
 CONFIG_FILE = "config"
 CCM_CONFIG_DIR = "CCM_CONFIG_DIR"
 
-INSTALL_DIR_PLACEHOLDER_FILE = "placeholder"
+DOWNLOAD_IN_PROGRESS_FILE = "download_in_progress"
 
 logger = logging.getLogger('ccm')
 
@@ -484,7 +484,7 @@ def _wait_until_false(wait_seconds, func, kwargs):
 
 def wait_for_parallel_download_finish(placeholder_file):
     if check_file_exists(placeholder_file):
-        if not _wait_until_false(3600, check_file_exists, kwargs={'path_to_file': placeholder_file}):
+        if not _wait_until_false(wait_seconds=3600, func=check_file_exists, kwargs={'path_to_file': placeholder_file}):
             raise TimeoutError(f"Relocatables download still runs in parallel from another test after 60 min. "
                                f"Placeholder file exists: {placeholder_file}")
 
@@ -495,7 +495,7 @@ def validate_install_dir(install_dir):
 
     # If relocatables download is running in parallel from another test, the install_dir exists with placehoslder file
     # in the folder. Once it will be downloaded and installed, this file will be removed.
-    wait_for_parallel_download_finish(os.path.join(install_dir, INSTALL_DIR_PLACEHOLDER_FILE))
+    wait_for_parallel_download_finish(placeholder_file=os.path.join(install_dir, DOWNLOAD_IN_PROGRESS_FILE))
 
     # Windows requires absolute pathing on installation dir - abort if specified cygwin style
     if is_win():


### PR DESCRIPTION
If few tests start in parallel, run same cluster version and download same
relocatable packages, add mechanism to prevent failure when copy the
packages to the version folder. Create placeholder file when start
downloading and remove it once the process has been completed