### PR TITLE
fix(ccm add): support `ccm add` for relocatable package

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -690,7 +690,6 @@ class Cluster(object):
         self._config_options['server_encryption_options'] = node_ssl_options
         self._update_config()
 
-
     def debug(self, message):
         logger.debug(message)
 
@@ -702,3 +701,7 @@ class Cluster(object):
 
     def error(self, message):
         logger.error(message)
+
+    @staticmethod
+    def is_docker():
+        return False

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -33,7 +33,7 @@ class ClusterFactory():
                                               install_dir=install_dir, create_directory=False)
             elif common.isScylla(install_dir):
                 cluster = ScyllaCluster(path, data['name'], install_dir=install_dir, create_directory=False,
-                                        manager=scylla_manager_install_path)
+                                        manager=scylla_manager_install_path, cassandra_version=data.get('scylla_version', None))
             elif common.isDse(install_dir):
                 cluster = DseCluster(path, data['name'], install_dir=install_dir, create_directory=False)
             else:

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -358,7 +358,11 @@ class ClusterAddCmd(Cmd):
     def run(self):
         try:
             if self.options.scylla_node:
-                node = ScyllaNode(self.name, self.cluster, self.options.bootstrap, self.thrift, self.storage, self.jmx_port, self.remote_debug_port, self.initial_token, binary_interface=self.binary)
+                if self.cluster.is_docker():
+                    node_class = ScyllaDockerNode
+                else:
+                    node_class = ScyllaNode
+                node = node_class(self.name, self.cluster, self.options.bootstrap, self.thrift, self.storage, self.jmx_port, self.remote_debug_port, self.initial_token, binary_interface=self.binary)
             elif self.options.dse_node:
                 node = DseNode(self.name, self.cluster, self.options.bootstrap, self.thrift, self.storage, self.jmx_port, self.remote_debug_port, self.initial_token, binary_interface=self.binary)
             else:

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -854,7 +854,7 @@ class Node(object):
             if common.is_win():
                 subprocess.Popen(cqlsh + args, env=env, creationflags=subprocess.CREATE_NEW_CONSOLE, universal_newlines=True)
             else:
-                os.execve(cqlsh, [common.platform_binary('cqlsh')] + args, env)
+                os.execve(cqlsh[0], cqlsh + args, env)
         else:
             p = subprocess.Popen(cqlsh + args, env=env, stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
             for cmd in cmds.split(';'):
@@ -1605,13 +1605,13 @@ class Node(object):
         if common.is_win() and self.get_base_cassandra_version() >= 2.1:
             conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_WIN_ENV)
             jmx_port_pattern = '^\s+\$JMX_PORT='
-            jmx_port_setting = '    $JMX_PORT="' + self.jmx_port + '"'
-            remote_debug_options = '    $env:JVM_OPTS="$env:JVM_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=' + str(self.remote_debug_port) + '"'
+            jmx_port_setting = f'    $JMX_PORT="{self.jmx_port}"'
+            remote_debug_options = f'    $env:JVM_OPTS="$env:JVM_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={self.jmx_port}"'
         else:
             conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_ENV)
             jmx_port_pattern = 'JMX_PORT='
-            jmx_port_setting = 'JMX_PORT="' + self.jmx_port + '"'
-            remote_debug_options = 'JVM_OPTS="$JVM_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=' + str(self.remote_debug_port) + '"'
+            jmx_port_setting = f'JMX_PORT="{self.jmx_port}"'
+            remote_debug_options = f'JVM_OPTS="$JVM_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={self.jmx_port}"'
 
         common.replace_in_file(conf_file, jmx_port_pattern, jmx_port_setting)
 

--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -65,6 +65,10 @@ class ScyllaDockerCluster(ScyllaCluster):
         run(['bash', '-c', f'docker run --rm -v {path}:/node busybox chmod -R 777 /node'], stdout=PIPE, stderr=PIPE)
         super(ScyllaDockerCluster, self).remove_dir_with_retry(path)
 
+    @staticmethod
+    def is_docker():
+        return True
+
 
 class ScyllaDockerNode(ScyllaNode):
     def __init__(self, *args, **kwargs):

--- a/tests/ccmcluster.py
+++ b/tests/ccmcluster.py
@@ -56,6 +56,15 @@ class CCMCluster:
     def get_start_cmd(self):
         return [self.ccm_bin, "start", "--wait-for-binary-proto"]
 
+    def get_add_cmd(self, node_name):
+        cmd_args = []
+        if self.use_scylla:
+            cmd_args += ["--scylla"]
+        return [self.ccm_bin, "add", "-b", *cmd_args, node_name]
+
+    def get_node_start_cmd(self, node_name):
+        return [self.ccm_bin, node_name, "start"]
+
     def get_updateconf_cmd(self):
         return [self.ccm_bin, "updateconf",
                 'read_request_timeout_in_ms:10000',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,7 @@ def ccm_reloc_with_manager_cluster():
 
 @pytest.fixture(scope="session")
 def ccm_cassandra_cluster():
-    cluster = CCMCluster(test_id="cassandra")
+    cluster = CCMCluster(use_scylla=False, test_id="cassandra")
     return cluster
 
 

--- a/tests/test_scylla_cmds.py
+++ b/tests/test_scylla_cmds.py
@@ -170,6 +170,14 @@ class TestCCMClusterNodetool:
             for node in node_statuses:
                 assert node['status'] == 'UN'
 
+    def test_add_node(self, cluster_under_test):
+        node_name = "node3"
+        cluster_under_test.run_command(cluster_under_test.get_add_cmd(node_name))
+        cluster_under_test.validate_command_result()
+
+        cluster_under_test.run_command(cluster_under_test.get_node_start_cmd(node_name))
+        cluster_under_test.validate_command_result()
+
 
 @pytest.mark.parametrize(
     'cluster_under_test',


### PR DESCRIPTION
Seems that since relocatable was introduced, not many people were using
the ccm commandline for it, and this was broken for relocatable packages
now the `scylla_version` is persisted and any other following ccm commands
now would know it's relocatable version, and could work correctly.