### PR TITLE
scylla_node: start: correctly process --opt=value in SCYLLA_EXT_OPTS

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -514,15 +514,17 @@ class ScyllaNode(Node):
             if scylla_ext_opts[opts_i].startswith("--scylla-manager="):
                opts_i += 1
             elif scylla_ext_opts[opts_i].startswith('-'):
-                add = False
-                if scylla_ext_opts[opts_i] not in orig_args:
-                    add = True
-                    args.append(scylla_ext_opts[opts_i])
+                o = scylla_ext_opts[opts_i]
                 opts_i += 1
-                while opts_i < len(scylla_ext_opts) and not scylla_ext_opts[opts_i].startswith('-'):
-                    if add:
-                        args.append(scylla_ext_opts[opts_i])
-                    opts_i += 1
+                if '=' in o:
+                    opt = o.replace('=', ' ', 1).split()
+                else:
+                    opt = [ o ]
+                    while opts_i < len(scylla_ext_opts) and not scylla_ext_opts[opts_i].startswith('-'):
+                        opt.append(scylla_ext_opts[opts_i])
+                        opts_i += 1
+                if opt[0] not in orig_args:
+                    args.extend(opt)
 
         if '--developer-mode' not in args:
             args += ['--developer-mode', 'true']


### PR DESCRIPTION
Currently, the functions applies options given in SCYLLA_EXT_OPTS
only if they aren't already present in jvm_args.

However, the environment may provide the option and its arg
as --opt=arg, and then it is not found in jvm_args, that is given
as a list with the option string and its argument as two separate
entries.

scylladb/scylla-dtest@092465a7b8221ba4bfd69b8f7a47606b6ac5147d
added ['--abort-on-lsa-bad-alloc', '0'] to jvm_args,
but the jenkins environement sets `--abort-on-lsa-bad-alloc=1`
in SCYLLA_EXT_OPTS, causing a conflict, and the node doesn't start.

See https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-release/762/artifact/logs-release.2/1615353430139_toppartitions_test.TestTopPartitions.test_read_by_gause_key_distribution_for_compound_primary_key_and_large_rows_number/node1.log
```
FATAL: Exception during startup, aborting: boost::wrapexcept<boost::program_options::multiple_occurrences> (option '--abort-on-lsa-bad-alloc' cannot be specified more than once)
```

https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-release/762/artifact/logs-release.2/dtest.log
```
2021-03-10 05:17:07,125 1939366 ccm                            DEBUG    | node1: Starting scylla: args=['/jenkins/workspace/scylla-master/dtest-release/scylla/.dtest/dtest-uimv3xm3/test/node1/bin/scylla', '--options-file', '/jenkins/workspace/scylla-master/dtest-release/scylla/.dtest/dtest-uimv3xm3/test/node1/conf/scylla.yaml', '--log-to-stdout', '1', '--abort-on-lsa-bad-alloc', '0', '--api-address', '127.0.23.1', '--collectd-hostname', 'aa8d295aabc2.node1', '--smp', '2', '--memory', '1024M', '--abort-on-seastar-bad-alloc', '--abort-on-lsa-bad-alloc=1', '--abort-on-internal-error', '1', '--developer-mode', 'true', '--default-log-level', 'info', '--collectd', '0', '--overprovisioned', '--prometheus-address', '127.0.23.1', '--unsafe-bypass-fsync', '1'] wait_other_notice=False wait_for_binary_proto=False
```

This change looks for a '=' seperator in the parsed opt
and if present, it splits the option into the option string
and its argument value.  Otherwise, it just collects the option string
and optional following arg(s) into a list.
Then it decides whether to apply the option, if the option
string (and only) it aren't present in jvm_args.

Dtest:
```
CASSANDRA_DIR=../scylla/build/release SCYLLA_EXT_OPTS="--abort-on-seastar-bad-alloc --abort-on-lsa-bad-alloc=1 --smp 2" ./scripts/run_test.sh toppartitions_test:TestTopPartitions.test_read_by_gause_key_distribution_for_compound_primary_key_and_large_rows_number
```
Signed-off-by: Benny Halevy <bhalevy@scylladb.com>