### PR TITLE
node: use the kernel page cache for ccm scylla nodes

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -560,6 +560,7 @@ class ScyllaNode(Node):
         if replace_address:
             args += ['--replace-address', replace_address]
         args += ['--unsafe-bypass-fsync', '1']
+        args += ['--kernel-page-cache', '1']
 
         ext_env = {}
         scylla_ext_env = os.getenv('SCYLLA_EXT_ENV', "").strip()


### PR DESCRIPTION
Scylla nodes started by ccm run in an overprovisioned environment
with limited performance disks. To reduce load on the disks, use
the new --kernel-page-cache option. This will reduce the likelihood
of timeouts on more intensive tests.