### PR TITLE
fix(manager): config migrate_dir option only on supporting versions

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -286,7 +286,8 @@ class ScyllaManager:
             data['database'] = {}
         data['database']['hosts'] = [self.scylla_cluster.get_node_ip(1)]
         data['database']['replication_factor'] = 3
-        if install_dir:
+        if install_dir and (self.version < LooseVersion("2.5") or
+                            self.version < LooseVersion('666.dev-0.20210430.2217cc84')):
             data['database']['migrate_dir'] = os.path.join(install_dir, 'schema', 'cql')
         if 'https' in data:
             del data['https']


### PR DESCRIPTION
Due to recent changes in scylla manager, the migrate_dir config option
should not be used if using manager version that is older than 2.5
or if using a master build before 20210430.2217cc84.
I made sure ccm will not config this option unless using supporting versions