### PR TITLE
scylla_node: start: set --max-networking-io-control-blocks=100 by default

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -595,6 +595,8 @@ class ScyllaNode(Node):
         if replace_address:
             args += ['--replace-address', replace_address]
         args += ['--unsafe-bypass-fsync', '1']
+        if '--max-networking-io-control-blocks' not in args:
+            args += ['--max-networking-io-control-blocks', '100']
 
         # The '--kernel-page-cache' was introduced by
         # https://github.com/scylladb/scylla/commit/8785dd62cb740522d80eb12f8272081f85be9b7e from 4.5 version


### PR DESCRIPTION
scylladb/scylla@2cfc517 sets max_networking_aio_io_control_blocks to
50000 by default, causing us to run out of aio iocb slots and fail
starting in setup_aio_context.

Reduce it by default to 100 that is sufficient for testing
if not given a different value via jvm_args.

Fixes #334

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>