### PR TITLE
ccm: explicitly use Python3 interpreter

### DIFF
--- a/ccm
+++ b/ccm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 


### PR DESCRIPTION
On some (all?) modern Linux distros /usr/bin/python
still points to python2.

At the same time our code uses some Python3-specific features
like f-strings.

Hence we (still) need to be explicit about Python3.

Fixes #336

Signed-off-by: Vlad Zolotarov <vladz@scylladb.com>