### PR TITLE
Fix Node.run_sstableverify to handle correctly get_tool response

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1081,7 +1081,7 @@ class Node(object):
         if dry_run:
             cmd = sstableofflinerelevel + ["--dry-run", keyspace, cf]
         else:
-            cmd = sstableofflinerelevel +[keyspace, cf]
+            cmd = sstableofflinerelevel + [keyspace, cf]
 
         if output:
             p = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, env=env, universal_newlines=True)
@@ -1095,7 +1095,8 @@ class Node(object):
         sstableverify = self.get_tool('sstableverify')
         env = self.get_env()
         sstablefiles = self.__cleanup_sstables(keyspace, cf)
-
+        if not isinstance(sstableverify, list):
+            sstableverify = [sstableverify]
         cmd = sstableverify + [keyspace, cf]
         if options is not None:
             cmd[1:1] = options


### PR DESCRIPTION
this was breaking `offline_tools_test.TestOfflineTools.test_sstableverify`

introduce by 54cf7b8e17508acbfb946f260f866fda8b0e4628