### PR TITLE
add padding zero to node names

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -293,7 +293,7 @@ class Cluster(object):
         binary = None
         if parse_version(self.version()) >= parse_version('1.2'):
             binary = self.get_binary_interface(i)
-        node = self.create_node(name='node{}'.format(i),
+        node = self.create_node(name='node{0:02d}'.format(i),
                                 auto_bootstrap=auto_bootstrap,
                                 thrift_interface=self.get_thrift_interface(i),
                                 storage_interface=self.get_storage_interface(i),


### PR DESCRIPTION
when there's more than 9 nodes in cluster,
nodes with number >9 are improperly sorted by nodelist() method
this causes errors in some tests when test relies on last node
in nodelist is the one with highest number

This commit adds padding zero to node number. E.g:
node01, node09, node10, node11