### PR TITLE
fix(cluster.py): fix nodelist ordering

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -25,7 +25,7 @@ class Cluster(object):
         self.id = 0
         self.ipprefix = None
         self.ipformat = None
-        self.nodes = {}
+        self.nodes = OrderedDict()
         self.seeds = []
         self.partitioner = partitioner
         self.snitch = snitch
@@ -216,7 +216,7 @@ class Cluster(object):
         return False
 
     def nodelist(self):
-        return [self.nodes[name] for name in sorted(self.nodes.keys())]
+        return [self.nodes[name] for name in self.nodes.keys()]
 
     def version(self):
         return self.__version


### PR DESCRIPTION
When there's more than 9 nodes in cluster,
nodes with number >9 are improperly sorted by nodelist() method
this causes errors in some tests when test relies on last node
in nodelist is the one with highest number

This fix converts node's dictionary to OrderedDict