### PR TITLE
Increase the max-networking-io-control-blocks parameter

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -601,8 +601,8 @@ class ScyllaNode(Node):
         if parse_version(current_node_version) >= parse_version('4.5.dev'):
             args += ['--kernel-page-cache', '1']
 
-        if parse_version(current_node_version) >= parse_version('4.7.dev') and '--max-networking-io-control-blocks' not in args:
-            args += ['--max-networking-io-control-blocks', '100']
+        if parse_version(current_node_version) >= parse_version('4.6') and '--max-networking-io-control-blocks' not in args:
+            args += ['--max-networking-io-control-blocks', '1000']
 
         ext_env = {}
         scylla_ext_env = os.getenv('SCYLLA_EXT_ENV', "").strip()


### PR DESCRIPTION
It was reduced to 100 in b50e43f to deal with #334,
and then in 17567b52e it was restricted to version 4.7.dev and up.
But apparently the low value causes scylladb/seastar#976

This change increases it to a more reasonable value of 1000
and changes the version restriction to 4.6, since the bump
up to 50000 happened in scylladb/scylla@2cfc517874
which is in branch-4.6

Fixes #352

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>