### PR TITLE
common: fix `scylla_extract_mode` to handle new package name

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -429,16 +429,17 @@ def scylla_extract_mode(path):
     #   build/dev/
     #   ../build/release/scylla
     #   url=../scylla/build/debug/scylla-package.tar.gz
-    m = re.search('(^|/)build/(\w+)(/|$)', path)
+    m = re.search(r'(^|/)build/(\w+)(/|$)', path)
     if m:
         return m.group(2)
 
     # path/url examples:
     #   /jenkins/data/relocatable/unstable/master/202001192256/scylla-package.tar.gz
     #   url=https://downloads.scylla.com/relocatable/unstable/master/202001192256/scylla-debug-package.tar.gz
-    m = re.search('(^|/)scylla(-(\w+))?-package([./][\w./]+|$)', path)
+    m = re.search(r'(^|/)scylla(-(\w+))?(-(\w+))?-package([-./][\w./]+|$)', path)
     if m:
-        return m.group(3) if m.group(3) else 'release' 
+        mode = m.groups()
+        return mode[2] if mode[4] or mode[2] in ('debug', 'dev') else 'release'
 
     return None
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,19 @@
+from ccmlib.common import scylla_extract_mode
+
+
+def test_scylla_extract_mode():
+    assert scylla_extract_mode("build/dev") == 'dev'
+    assert scylla_extract_mode("../build/release") == 'release'
+    assert scylla_extract_mode("../build/release/scylla") == 'release'
+    assert scylla_extract_mode("/home/foo/scylla/build/debug") == 'debug'
+    assert scylla_extract_mode("url=../scylla/build/debug/scylla-package.tar.gz") == 'debug'
+
+    assert scylla_extract_mode("url=./scylla-debug-x86_64-package.tar.gz") == 'debug'
+    assert scylla_extract_mode("url=./scylla-x86_64-package.tar.gz") == 'release'
+    assert scylla_extract_mode("url=./scylla-debug-aarch64-package.tar.gz") == 'debug'
+    assert scylla_extract_mode("url=./scylla-package.tar.gz") == 'release'
+    assert scylla_extract_mode("url=./scylla-debug-package.tar.gz") == 'debug'
+
+    assert scylla_extract_mode("url=./scylla-debug-x86_64-package-4.5.2.0.20211114.26aca7b9f.tar.gz") == 'debug'
+    assert scylla_extract_mode("url=./scylla-debug-package-4.5.2.0.20211114.26aca7b9f.tar.gz") == 'debug'
+    assert scylla_extract_mode("url=./scylla-package-4.5.2.0.20211114.26aca7b9f.tar.gz") == 'release'


### PR DESCRIPTION
since now package filename has arch where the mode was, this
function was return wrong the arch in some cases