### PR TITLE
improvement: Improving ccm performance

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -383,7 +383,7 @@ class Cluster(object):
                     removed = True
                 except:
                     tries = tries + 1
-                    time.sleep(.1)
+                    time.sleep(0.1)
                     if tries == 5:
                         raise
 


### PR DESCRIPTION
* Remove sleep and use `wait_for` method
* Reduce most sleep to 50 ms
* Bug ticket https://github.com/scylladb/scylla-dtest/issues/2429