### PR TITLE
repository: fix directory creation failure

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -453,7 +453,7 @@ def __download(url, target, username=None, password=None, show_progress=False):
 def __get_dir():
     repo = os.path.join(get_default_path(), 'repository')
     if not os.path.exists(repo):
-        os.mkdir(repo)
+        os.makedirs(repo, exist_ok=True)
     return repo
 
 

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -408,7 +408,7 @@ def version_directory(version):
 def __get_dir():
     repo = os.path.join(get_default_path(), 'scylla-repository')
     if not os.path.exists(repo):
-        os.mkdir(repo)
+        os.makedirs(repo, exist_ok=True)
     return repo
 
 


### PR DESCRIPTION
In some race condition when multiple test are running at the same time,
we might fail to create directories