### PR TITLE
scylla_cluster: start with no_wait=False by default

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -83,13 +83,14 @@ class ScyllaCluster(Cluster):
         for node, p, _ in started:
             node._update_pid(p)
 
-    def start_nodes(self, nodes=None, no_wait=True, verbose=False, wait_for_binary_proto=None,
+    def start_nodes(self, nodes=None, no_wait=False, verbose=False, wait_for_binary_proto=None,
               wait_other_notice=None, jvm_args=None, profile_options=None,
               quiet_start=False):
         if wait_for_binary_proto is None:
             wait_for_binary_proto = self.force_wait_for_cluster_start
         if wait_other_notice is None:
             wait_other_notice = self.force_wait_for_cluster_start
+        self.debug(f"start_nodes: no_wait={no_wait} wait_for_binary_proto={wait_for_binary_proto} wait_other_notice={wait_other_notice} force_wait_for_cluster_start={self.force_wait_for_cluster_start}")
         self.started=True
 
         p = None
@@ -143,7 +144,7 @@ class ScyllaCluster(Cluster):
         return started
 
     # override cluster
-    def start(self, no_wait=True, verbose=False, wait_for_binary_proto=None,
+    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=None,
               wait_other_notice=None, jvm_args=None, profile_options=None,
               quiet_start=False):
         kwargs = dict(**locals())

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -118,7 +118,9 @@ class ScyllaCluster(Cluster):
                     mark = node.mark_log()
 
                 p = node.start(update_pid=False, jvm_args=jvm_args,
-                               profile_options=profile_options, no_wait=no_wait)
+                               profile_options=profile_options, no_wait=no_wait,
+                               wait_for_binary_proto=wait_for_binary_proto,
+                               wait_other_notice=wait_other_notice)
                 started.append((node, p, mark))
 
         self.__update_pids(started)


### PR DESCRIPTION
This effectively reverts scylla_cluster: handle no_wait flag
since we need the default start to be safe and set `no_wait=True`
explicitly from tests that are proved to tolerate it.
    
Scylla start became faster since
scylladb/scylla@78d0cc4ab5ebd47f101ce78b79a30a48ee9f4b9b
and without this change, multi-node dtests tend to fail.
    
DTest: consistent_bootstrap_test.py::TestBootstrapConsistency::test_consistent_reads_after_bootstrap
(with --cassandra-dir)
    
Validating the debug log:
```
21:13:06,524 3398130 ccm                            DEBUG    cluster.py          :694  | test_consistent_reads_after_bootstrap: start_nodes: no_wait=False wait_for_binary_proto=True wait_other_notice=True force_wait_for_cluster_start=True
21:13:06,528 3398130 ccm                            DEBUG    cluster.py          :694  | test_consistent_reads_after_bootstrap: node1: Starting scylla: args=['/home/bhalevy/.dtest/dtest-_3m0rc17/test/node1/bin/scylla', '--options-file', '/home/bhalevy/.dtest/dtest-_3m0rc17/test/node1/conf/scylla.yaml', '--log-to-stdout', '1', '--api-address', '127.0.72.1', '--collectd-hostname', 'localhost.localdomain.node1', '--developer-mode', 'true', '--smp', '1', '--memory', '512M', '--default-log-level', 'info', '--collectd', '0', '--overprovisioned', '--prometheus-address', '127.0.72.1', '--unsafe-bypass-fsync', '1', '--kernel-page-cache', '1', '--max-networking-io-control-blocks', '1000'] wait_other_notice=True wait_for_binary_proto=True
```
    
Signed-off-by: Benny Halevy <bhalevy@scylladb.com>

Refs and complements https://github.com/scylladb/scylla-dtest/pull/2490