### PR TITLE
node: flush: add ks and table optional args

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1317,8 +1317,13 @@ class Node(object):
         info = self.nodetool('info', capture_output=True)[0]
         return _get_row_cache_entries_from_info_output(info)
 
-    def flush(self):
-        self.nodetool("flush")
+    def flush(self, ks=None, table=None):
+        cmd = "flush"
+        if ks:
+            cmd += f" {ks}"
+        if table:
+            cmd += f" {table}"
+        self.nodetool(cmd)
 
     def compact(self):
         self.nodetool("compact")

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1251,8 +1251,8 @@ class ScyllaNode(Node):
             raise NodeError("Node %s still has pending flushes after "
                             "%s seconds" % (self.name, wait_timeout))
 
-    def flush(self):
-        self.nodetool("flush")
+    def flush(self, ks=None, table=None):
+        super(ScyllaNode, self).flush(ks, table)
         self._wait_no_pending_flushes()
 
     def get_node_scylla_version(self, scylla_exec_path=None):


### PR DESCRIPTION
Allow flushing a specified keyspace / table.

DTest: (modified) test_disable_autocompaction_schema

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>