### PR TITLE
scripts/*: switch to let ccm download files

### DIFF
--- a/scripts/download_enterprise.sh
+++ b/scripts/download_enterprise.sh
@@ -8,20 +8,9 @@ LATEST_ENTERPRISE_JOB_ID=`aws --no-sign-request s3 ls downloads.scylladb.com/uns
 AWS_BASE=s3://downloads.scylladb.com/enterprise/relocatable/unstable/enterprise/${LATEST_ENTERPRISE_JOB_ID}
 AWS_BASE=s3://downloads.scylladb.com/unstable/scylla-enterprise/${BRANCH}/relocatable/${LATEST_ENTERPRISE_JOB_ID}
 
-rm scylla-*.tar.gz
-
-aws s3 --no-sign-request cp ${AWS_BASE}/scylla-enterprise-package.tar.gz .
-aws s3 --no-sign-request cp ${AWS_BASE}/scylla-enterprise-tools-package.tar.gz .
-aws s3 --no-sign-request cp ${AWS_BASE}/scylla-enterprise-jmx-package.tar.gz .
-
-NAME=master_$LATEST_ENTERPRISE_JOB_ID
-NAME=$(echo enterprise_$LATEST_ENTERPRISE_JOB_ID | sed 's/:/_/g')
-
-ccm create scylla-driver-temp -n 1 --scylla --version $NAME \
-  --scylla-core-package-uri=./scylla-enterprise-package.tar.gz \
-  --scylla-tools-java-package-uri=./scylla-enterprise-tools-package.tar.gz \
-  --scylla-jmx-package-uri=./scylla-enterprise-jmx-package.tar.gz
-
+NAME="unstable/${BRANCH}:${LATEST_ENTERPRISE_JOB_ID}"
+export SCYLLA_PRODUCT=scylla-enterprise
+ccm create scylla-temp -n 1 --scylla --version $NAME
 ccm remove
 
 echo "now it can be used in dtest as:"

--- a/scripts/download_master.sh
+++ b/scripts/download_master.sh
@@ -8,20 +8,9 @@ export BRANCH=master
 export LATEST_MASTER_JOB_ID=`aws --no-sign-request s3 ls downloads.scylladb.com/unstable/scylla/${BRANCH}/relocatable/ | grep '-' | tr -s ' ' | cut -d ' ' -f 3 | tr -d '\/'  | sort -g | tail -n 1`
 AWS_BASE=s3://downloads.scylladb.com/unstable/scylla/${BRANCH}/relocatable/${LATEST_MASTER_JOB_ID}
 
-rm scylla-*.tar.gz
+NAME="unstable/master:$LATEST_MASTER_JOB_ID"
 
-aws s3 --no-sign-request cp ${AWS_BASE}/scylla-x86_64-package.tar.gz .
-aws s3 --no-sign-request cp ${AWS_BASE}/scylla-tools-package.tar.gz .
-aws s3 --no-sign-request cp ${AWS_BASE}/scylla-jmx-package.tar.gz .
-
-NAME=master_$LATEST_MASTER_JOB_ID
-NAME=$(echo master_$LATEST_MASTER_JOB_ID | sed 's/:/_/g')
-
-ccm create scylla-driver-temp -n 1 --scylla --version $NAME \
-  --scylla-core-package-uri=./scylla-x86_64-package.tar.gz \
-  --scylla-tools-java-package-uri=./scylla-tools-package.tar.gz \
-  --scylla-jmx-package-uri=./scylla-jmx-package.tar.gz
-
+ccm create scylla-driver-temp -n 1 --scylla --version $NAME
 ccm remove
 
 echo "now it can be used in dtest as:"

--- a/scripts/download_release.sh
+++ b/scripts/download_release.sh
@@ -1,13 +1,12 @@
 # download release candidates version from release direcorty
 #
 # Usage:
-#   ./scripts/download_rc_version.sh 4.3.rc1
-#   ./scripts/download_rc_version.sh 4.2 rc1
+#   ./scripts/download_rc_version.sh 4.3
+#   ./scripts/download_rc_version.sh 4.2
 
 BRANCH=$1
-VERSION=$2
 
-NAME="$BRANCH.$VERSION"
+NAME="$BRANCH"
 ccm create temp_${NAME} -n 1 --scylla --version release:${NAME}
 ccm remove
 


### PR DESCRIPTION
since the move to have the arch in the package name, the ccm code
is going to do a better job of selecting the correct packages to download