### PR TITLE
fix(ccmlib/cluster.py): Removing mutable defaults argument

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -521,7 +521,8 @@ class Cluster(object):
         self.nodelist()[0].stress(stress_options=stress_options + ['-node', ','.join(livenodes)] )
         return self
 
-    def run_cli(self, cmds=None, show_output=False, cli_options=[]):
+    def run_cli(self, cmds=None, show_output=False, cli_options=None):
+        cli_options = cli_options or []
         livenodes = [node for node in list(self.nodes.values()) if node.is_live()]
         if len(livenodes) == 0:
             raise common.ArgumentError("No live node")

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -855,7 +855,8 @@ class Node(object):
                         print_(log, end='')
                     i = i + 1
 
-    def run_cqlsh(self, cmds=None, show_output=False, cqlsh_options=[], return_output=False):
+    def run_cqlsh(self, cmds=None, show_output=False, cqlsh_options=None, return_output=False):
+        cqlsh_options = cqlsh_options or []
         cqlsh = self.get_tool('cqlsh')
         if not isinstance(cqlsh, list):
             cqlsh = [cqlsh]

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -774,14 +774,14 @@ class ScyllaNode(Node):
             elif wait_time_sec <= 16:
                 wait_time_sec *= 2
 
-    def wait_until_stopped(self, wait_seconds=None, marks=[], dump_core=True):
+    def wait_until_stopped(self, wait_seconds=None, marks=None, dump_core=True):
         """
         Wait until node is stopped after do_stop was called.
           - wait_other_notice: return only when the other live nodes of the
             cluster have marked this node has dead.
           - marks: optional list of (node, mark) to call watch_log_for_death on.
         """
-
+        marks = marks or []
         if wait_seconds is None:
             wait_seconds = 127 if self.scylla_mode() != 'debug' else 600
 
@@ -827,7 +827,7 @@ class ScyllaNode(Node):
             if node != self:
                 node.watch_log_for_death(self, from_mark=mark)
 
-    def stop(self, wait=True, wait_other_notice=False, other_nodes=None, gently=True, wait_seconds=None, marks=[]):
+    def stop(self, wait=True, wait_other_notice=False, other_nodes=None, gently=True, wait_seconds=None, marks=None):
         """
         Stop the node.
           - wait: if True (the default), wait for the Scylla process to be
@@ -844,6 +844,7 @@ class ScyllaNode(Node):
           - gently: Let Scylla and Scylla JMX clean up and shut down properly.
             Otherwise do a 'kill -9' which shuts down faster.
         """
+        marks = marks or []
         was_running = self.is_running()
         if was_running:
             if wait_other_notice:


### PR DESCRIPTION
In Python, when passing a mutable value as a default argument in a function,
the default argument is mutated anytime that value is mutated.
Here, "mutable value" refers to anything such as a list, a dictionnary
or even a class instance.

Example:
```
def append(element, seq=[]):
    seq.append(element)
    return seq

>>> append(1)  # seq is assigned to []
[1]  # This returns a reference the *same* list as the default for `seq`
>>> append(2)  # => `seq` is now given [1] as a default!
[1, 2]  # WTFs and headaches start here…
```