### PR TITLE
fix(ccmlib/repository.py): Fixing SyntaxWarning warning log

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -303,7 +303,7 @@ def compile_version(version, target_dir, verbose=False):
             # Similar patch seen with buildbot
             attempt = 0
             ret_val = 1
-            while attempt < 3 and ret_val is not 0:
+            while attempt < 3 and ret_val != 0:
                 if attempt > 0:
                     lf.write("\n\n`ant jar` failed. Retry #%s...\n\n" % attempt)
                 ret_val = subprocess.call([platform_binary('ant'), 'jar'], cwd=target_dir, stdout=lf, stderr=lf)


### PR DESCRIPTION
The following code incorrect:
```python
while attempt < 3 and ret_val != 0:
...
```
From Python version 3.8+, the following warning message is shown:
```
ccmlib/repository.py:311: SyntaxWarning: "is not" with a literal. Did you mean "!="?
```