### PR TITLE
scylla_cluster: add each nodes to marks after calling node.start()

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -123,6 +123,7 @@ class ScyllaCluster(Cluster):
                                wait_for_binary_proto=wait_for_binary_proto,
                                wait_other_notice=wait_other_notice)
                 started.append((node, p, mark))
+                marks.append((node, mark))
 
         self.__update_pids(started)
 


### PR DESCRIPTION
while working on scylladb/scylla-dtest#2455, setting `skip_wait_for_gossip_to_settle`
to 0, we've found out that we are not waiting for others on the first time
we boot a cluster, since no node is available before we start.
but while we start we need to add the started node so the next node
can actually use `wait_for_others` correctly.