### PR TITLE
fix(ccmlib/node.py): Waiting for "initialization completed" log

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -536,6 +536,12 @@ class Node(object):
             warnings.warn("Binary interface %s:%s is not listening after 10 seconds, node may have failed to start."
                           % (binary_itf[0], binary_itf[1]))
 
+    def watch_log_for_initialization_completed(self, from_mark=None, timeout=60):
+        """
+        Watch the log of this node until it detects that the provided that initialization completed.
+        """
+        self.watch_log_for("[Ss]cylla version.*initialization completed", from_mark=from_mark, timeout=timeout)
+
     def start(self,
               join_ring=True,
               no_wait=False,

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -596,6 +596,7 @@ class ScyllaNode(Node):
         self.is_running()
         if self.scylla_manager and self.scylla_manager.is_agent_available:
             self.start_scylla_manager_agent()
+        self.watch_log_for_initialization_completed(from_mark=self.mark)
         return scylla_process
 
     def start_dse(self,


### PR DESCRIPTION
There are additional operations that occur after a node become UP.
Therefore, waiting for this message ensures that the node is ready
 for testing.