### PR TITLE
node: check_node_sstables_format wasn't skipping snapshots

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -335,7 +335,7 @@ class Node(object):
 
     def check_node_sstables_format(self, timeout=10):
         node_system_folder = os.path.join(self.get_path(), 'data', 'system')
-        find_cmd = f"find {node_system_folder} -type f ! -path '*snapshots*' -printf %f\\n".split()
+        find_cmd = f"find {node_system_folder} -type f ! -path *snapshots* -printf %f\\n".split()
         try:
             result = subprocess.run(find_cmd, capture_output=True, timeout=timeout, text=True)
             assert not result.stderr, result.stderr


### PR DESCRIPTION
Since recently for upgrade/rollback we started doing snapshots
rolling upgrade test started failing like this:

```
>                   assert len(sstable_versions) == 1, "expected all table format to be the same found {}".format(
                        sstable_versions)
E                       AssertionError: expected all table format to be the same found {'md', 'me', 'mc'}
E                       assert 3 == 1
E                         +3
E                         -1
```

turns out the `check_node_sstables_format` method was reading
also from the snapshots direcotry, hence the failure.
it was cause of wrong escaping of the filter find command.