### PR TITLE
fix(get_seeds): return correct seed nodes after set_configuration_options changed.

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -397,8 +397,15 @@ class Cluster(object):
     def get_path(self):
         return os.path.join(self.path, self.name)
 
-    def get_seeds(self):
-        return [s.network_interfaces['storage'][0] for s in self.seeds]
+    def get_seeds(self, node=None):
+        # if first node, or there is now seeds at all
+        # or node added is not a seed, return 
+        # all cluster seed nodes
+        if not node or not self.seeds or node not in self.seeds:
+            return [s.network_interfaces['storage'][0] for s in self.seeds]
+
+        seed_index = self.seeds.index(node)
+        return [s.network_interfaces['storage'][0] for s in self.seeds[:seed_index + 1]]
 
     def show(self, verbose):
         msg = "Cluster: '%s'" % self.name

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1000,7 +1000,7 @@ class ScyllaNode(Node):
         else:
             # cassandra 0.8
             data['seed_provider'][0]['parameters'][0]['seeds'] = (
-                ','.join(self.cluster.get_seeds()))
+                ','.join(self.cluster.get_seeds(node=self)))
         data['listen_address'], data['storage_port'] = (
             self.network_interfaces['storage'])
         data['rpc_address'], data['rpc_port'] = (


### PR DESCRIPTION
ccmlib **cluster.populate** method create nodes with
seeds, where each node have seeds all previous seeds
and itself
ex:
node1: node1
node2: node1, node2
node3: node1, node2, node3

the **cluster.set_configuration_options()** method rewrite the
scylla.yaml per node.

If it is called after **cluster.populate** method, but before
**cluster.start** method, **cluster.set_configuration_options()**
rewrite the node's scylla.yaml with seeds configuration all seeds:
node1: node1, node2, node3
node2: node1, node2, node3
node3: node1, node2, node3

for some feature, such seed configuration could affect cluster start
and cluster will not be started.

New method parameter is presented, which allow to return
all seeds node before provided node.