### PR TITLE
Fix enterprise version extraction for path/url

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -443,6 +443,7 @@ def isOpscenter(install_dir):
     opscenter_script = os.path.join(bin_dir, 'opscenter')
     return os.path.exists(opscenter_script)
 
+
 def scylla_extract_mode(path):
     # path/url examples:
     #   build/dev
@@ -458,12 +459,13 @@ def scylla_extract_mode(path):
     # path/url examples:
     #   /jenkins/data/relocatable/unstable/master/202001192256/scylla-package.tar.gz
     #   url=https://downloads.scylla.com/relocatable/unstable/master/202001192256/scylla-debug-package.tar.gz
-    m = re.search(r'(^|/)scylla(-(\w+))?(-(\w+))?-package([-./][\w./]+|$)', path)
+    m = re.search(r'(^|/)(scylla|scylla-enterprise)(-(?P<mode>\w+))?(-(\w+))?-package([-./][\w./]+|$)', path)
     if m:
-        mode = m.groups()
-        return mode[2] if mode[4] or mode[2] in ('debug', 'dev') else 'release'
+        mode = m.groupdict().get('mode')
+        return mode if mode in ('debug', 'dev') else 'release'
 
     return None
+
 
 def scylla_extract_install_dir_and_mode(install_dir):
     scylla_mode = scylla_extract_mode(install_dir)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -17,3 +17,9 @@ def test_scylla_extract_mode():
     assert scylla_extract_mode("url=./scylla-debug-x86_64-package-4.5.2.0.20211114.26aca7b9f.tar.gz") == 'debug'
     assert scylla_extract_mode("url=./scylla-debug-package-4.5.2.0.20211114.26aca7b9f.tar.gz") == 'debug'
     assert scylla_extract_mode("url=./scylla-package-4.5.2.0.20211114.26aca7b9f.tar.gz") == 'release'
+
+    assert scylla_extract_mode('url=https://s3.amazonaws.com/downloads.scylladb.com/downloads/scylla-enterprise/'
+                               'relocatable/scylladb-2022.1/scylla-enterprise-x86_64-package-2022.1.rc6.0.20220523.'
+                               '30ce52b2e.tar.gz') == 'release'
+    assert scylla_extract_mode('url=https://s3.amazonaws.com/downloads.scylladb.com/downloads/scylla-enterprise/'
+                               'relocatable/scylladb-2022.1/scylla-enterprise-debug-aarch64-package-2022.1.rc0.0.20220331.f3ee71fba.tar.gz') == 'debug'


### PR DESCRIPTION
In enterprise release versions and release canidates
the the return value was `enterprise` and not one of
`release|debug|dev`