### PR TITLE
_grep_log_for_errors: match only if ERROR, INFO, DEBUG is a whole word

### DIFF
--- a/old_tests/test_lib.py
+++ b/old_tests/test_lib.py
@@ -270,3 +270,7 @@ class TestErrorLogGrepping(ccmtest.Tester):
         err = ('ERROR: You have made a terrible mistake\n'
                '  2015-05-12 14:12:12,720 INFO: why would you ever do that\n')
         self.assertGreppedLog(err, [['ERROR: You have made a terrible mistake']])
+
+    def test_ignore_error_as_a_part_of_word(self):
+        err = ('INFO: Feature MORE_VERBOSE_ERRORS is enabled')
+        self.assertGreppedLog(err, [])


### PR DESCRIPTION
Modifies the _grep_for_log_errors function so that it matches on ERROR,
INFO and DEBUG strings only if they are a whole word, e.g. a line which
contains "ERRORS" won't be considered by the function.

My motivation behind this change is that I would like to introduce a
feature called "TYPED_ERRORS_IN_READ_RPC" in Scylla. Feature names are
printed to logs with INFO level on startup, and the current logic in
dtests (which uses the grep_log_for_errors function) considers this to
be a failure. This commit tightens the check so that the feature can be
added without problems, and lines printed with error log level (I
suppose they are of most interest here) are still matched by the logic.