### PR TITLE
_grep_log_for_errors: avoid explicit `flags` argument in `re.compile`

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1994,8 +1994,8 @@ def _get_row_cache_entries_from_info_output(info):
 
 def _grep_log_for_errors(log, distinct_errors=False, search_str=None, case_sensitive=True):
     def make_pat_for_log_level(level):
-        flags = 0 if case_sensitive else re.IGNORECASE
-        return re.compile(rf'\b{level}\b', flags=flags)
+        kwargs = {} if case_sensitive else {'flags': re.IGNORECASE}
+        return re.compile(rf'\b{level}\b', **kwargs)
 
     error_pat = make_pat_for_log_level("ERROR")
     info_pat = make_pat_for_log_level("INFO")


### PR DESCRIPTION
This is a followup to #389. Now, when grepping the logs in
a case-sensitive manner, instead of passing `flags=0` to `re.compile`,
the argument is omitted entirely which makes sure that the function
receives the default value for the `flags` argument. This future proofs
the logic a bit so that, in case the default value for `flags` changes
in the future, it will still work correctly.