### PR TITLE
node: pass down kwargs to node.flush() call

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1319,13 +1319,13 @@ class Node(object):
         info = self.nodetool('info', capture_output=True)[0]
         return _get_row_cache_entries_from_info_output(info)
 
-    def flush(self, ks=None, table=None):
+    def flush(self, ks=None, table=None, **kwargs):
         cmd = "flush"
         if ks:
             cmd += f" {ks}"
         if table:
             cmd += f" {table}"
-        self.nodetool(cmd)
+        self.nodetool(cmd, **kwargs)
 
     def compact(self):
         self.nodetool("compact")

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1230,8 +1230,8 @@ class ScyllaNode(Node):
             raise NodeError("Node %s still has pending flushes after "
                             "%s seconds" % (self.name, wait_timeout))
 
-    def flush(self, ks=None, table=None):
-        super(ScyllaNode, self).flush(ks, table)
+    def flush(self, ks=None, table=None, **kwargs):
+        super(ScyllaNode, self).flush(ks, table, **kwargs)
         self._wait_no_pending_flushes()
 
     def _run_scylla_executable_with_option(self, option, scylla_exec_path=None):


### PR DESCRIPTION
so we can pass down parameters to the `nodetool()`
mostly timeout