### PR TITLE
ssl_utils.py: return list and not str, on older openssh

### DIFF
--- a/ccmlib/utils/ssl_utils.py
+++ b/ccmlib/utils/ssl_utils.py
@@ -22,7 +22,7 @@ def generate_ssl_stores(base_dir, passphrase='cassandra', dns_names=None):
         return
 
     legacy = ['-legacy'] if '-legacy' in subprocess.run(['openssl', 'pkcs12', '--help'],
-                                                      universal_newlines=True, stderr=subprocess.PIPE).stderr else ''
+                                                        universal_newlines=True, stderr=subprocess.PIPE).stderr else []
     dns_names = dns_names or ['any.cluster-id.scylla.com']
     ext = ",".join(["dns:{}".format(name) for name in dns_names])
     print("generating keystore.jks in [{0}]".format(base_dir))


### PR DESCRIPTION
when running with older versions of openssh, we were failing
like the following:

```
E       TypeError: can only concatenate list (not "str") to list
```

we should return a list, and not empty string