### PR TITLE
ccmlib/common.py: make sure we look all directories

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -684,6 +684,7 @@ def get_version_from_build(install_dir=None, node_path=None):
 
 def _get_scylla_version(install_dir):
     scylla_version_files = [ os.path.join(install_dir, 'build', 'SCYLLA-VERSION-FILE'),
+                             os.path.join(install_dir, '..', '..', 'build', 'SCYLLA-VERSION-FILE'),
                                 os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-VERSION-FILE') ]
     for version_file in scylla_version_files:
         if os.path.exists(version_file):


### PR DESCRIPTION
In cases the `--cassandra-dir=<path-to-ent>/build/dev` was pointing
to specific build type inside the build tree, we were failing
to figure the version (since looking in the wrong directory)

most time it wasn't critical for running tests, but in case of
enterprise tests, dtest assumed it's OSS and filtered the tests
and making the test unrunable for a developer