### PR TITLE
Generate key in PKCS#8 format instead of PKCS#1

### DIFF
--- a/ccmlib/utils/ssl_utils.py
+++ b/ccmlib/utils/ssl_utils.py
@@ -54,8 +54,9 @@ def generate_ssl_stores(base_dir, passphrase='cassandra', dns_names=None):
                            '-passin', 'pass:{0}'.format(passphrase),
                            '-passout', 'pass:{0}'.format(passphrase), '-nocerts',
                            '-out', os.path.join(base_dir, 'ccm_node.tmp')] + legacy)
-    subprocess.check_call(['openssl', 'rsa', '-in', os.path.join(base_dir, 'ccm_node.tmp'),
+    subprocess.check_call(['openssl', 'pkcs8', '-in', os.path.join(base_dir, 'ccm_node.tmp'),
                            '-passin', 'pass:{0}'.format(passphrase),
+                           '-topk8',
                            '-out', os.path.join(base_dir, 'ccm_node.key')])
 
 


### PR DESCRIPTION
Due to language constraints java driver desperately needs the key to be in `PKCS#8` format.
I'm not fully aware if this change would break any other tool.
