### PR TITLE
ccmlib/utils/ssl_utils.py: change back to create default rsa key

### DIFF
--- a/ccmlib/utils/ssl_utils.py
+++ b/ccmlib/utils/ssl_utils.py
@@ -56,7 +56,11 @@ def generate_ssl_stores(base_dir, passphrase='cassandra', dns_names=None):
                            '-out', os.path.join(base_dir, 'ccm_node.tmp')] + legacy)
     subprocess.check_call(['openssl', 'pkcs8', '-in', os.path.join(base_dir, 'ccm_node.tmp'),
                            '-passin', 'pass:{0}'.format(passphrase),
+                           '-passout', 'pass:{0}'.format(passphrase),
                            '-topk8',
+                           '-out', os.path.join(base_dir, 'ccm_node.pkcs8')])
+    subprocess.check_call(['openssl', 'rsa', '-in', os.path.join(base_dir, 'ccm_node.tmp'),
+                           '-passin', 'pass:{0}'.format(passphrase),
                            '-out', os.path.join(base_dir, 'ccm_node.key')])
 
 


### PR DESCRIPTION
3b6323fa9dd6eb2b1586de0d601af2d090e66a3f changed the key format
seem like it's not working as expected, adding the option
to create both keys