### PR TITLE
ccmlib - node.py - ignore additional messages from stress output

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1281,7 +1281,10 @@ class Node(object):
 
     def stress_object(self, stress_options=[], ignore_errors = False, **kwargs):
         out, err = self.stress(stress_options, True, **kwargs)
-        if not ignore_errors and err != "" and not err.startswith("Failed to connect over JMX; not collecting these stats") and not err.startswith("Picked up JAVA_TOOL_OPTIONS"):
+        if not ignore_errors and err != "" \
+           and not err.startswith("Failed to connect over JMX; not collecting these stats") \
+           and not err.startswith("Picked up JAVA_TOOL_OPTIONS") \
+           and "too many windows" not in err:
             return err
         p = re.compile(r'^\s*([^:]+)\s*:\s*(\S.*)\s*$')
         res = {}


### PR DESCRIPTION
This commit ignore a new string ("too many windows") part of cassandra-stress output prior to simply returning an error back to the caller. The decision to ignore that specific string is because it is tied to a specific pull request, rather than simply ignoring a more generic message such as "Warning" which may mistakenly ignore messages which shouldn't.

The first time we saw several tests relying on C-S outputs failing was in https://github.com/scylladb/scylladb/commit/4d7f55a29f20d2ca413aa04eb79666738d8e2467.
However - in https://github.com/scylladb/scylla-dtest/pull/2331 the "fix" for it was simply deprecate and override all mentions of DateTieredCompactionStrategy to TimeWindowCompactionStrategy.

As of https://github.com/scylladb/scylladb/pull/11445 we are now introducing a TimeWindowCompactionStrategy guard rails and - since cassandra-stress doesn't
provide a simple way to create a table with a specific default_time_to_live value (other than manually going through an user provided profile or hacking it around by creating the table early in the process) - this broke some tests which didn't expect the new introduced warning.

An example of such a failure may be found under https://jenkins.scylladb.com/job/releng/job/Scylla-CI/2066/testReport/junit/resharding_test/TestReshardingSingleNodeGating/Sanity_Tests___test_resharding_by_murmur3_gating_1_TimeWindowCompactionStrategy_15_/ .