### PR TITLE
ccmlib/node.py: refactor stress() and stress_object()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,9 @@ def relocatable_cluster(test_dir, test_id):
         'range_request_timeout_in_ms': timeout,
         'write_request_timeout_in_ms': timeout,
         'truncate_request_timeout_in_ms': timeout,
-        'request_timeout_in_ms': timeout
+        'request_timeout_in_ms': timeout,
+        'skip_wait_for_gossip_to_settle': 0,
+        'ring_delay_ms': 0,
     })
     cluster.populate(1)
     cluster.start(wait_for_binary_proto=True)

--- a/tests/test_scylla_docker_cluster.py
+++ b/tests/test_scylla_docker_cluster.py
@@ -72,6 +72,6 @@ class TestScyllaDockerCluster:
 
     def test_node_stress(self, docker_cluster):
         node1, *_ = docker_cluster.nodelist()
-        stdout, _ = node1.stress(['write', 'n=1000'], capture_output=True)
-        assert '1,000 [WRITE: 1,000]' in stdout
-        assert 'END' in stdout
+        ret = node1.stress(['write', 'n=1000'])
+        assert '1,000 [WRITE: 1,000]' in ret.stdout
+        assert 'END' in ret.stdout

--- a/tests/test_scylla_relocatable_cluster.py
+++ b/tests/test_scylla_relocatable_cluster.py
@@ -4,7 +4,7 @@ import subprocess
 import pytest
 
 from ccmlib.common import get_scylla_full_version, get_scylla_version
-from ccmlib.node import Node
+from ccmlib.node import Node, ToolError
 
 
 @pytest.mark.reloc
@@ -25,3 +25,28 @@ class TestScyllaRelocatableCluster:
         with pytest.raises(subprocess.TimeoutExpired):
             node1.nodetool("cfstats", capture_output=True, timeout=0.0001)
         time.sleep(5)
+
+    def test_node_stress(self, relocatable_cluster):
+        node1, *_ = relocatable_cluster.nodelist()
+        node1: Node
+        ret = node1.stress(['write', 'n=10'])
+        assert '10 [WRITE: 10]' in ret.stdout
+        assert 'END' in ret.stdout
+
+        ret = node1.stress_object(['write', 'n=10'])
+        assert list(ret.keys()) == ['op rate:write',
+                                    'partition rate:write',
+                                    'row rate:write',
+                                    'latency mean:write',
+                                    'latency median:write',
+                                    'latency 95th percentile:write',
+                                    'latency 99th percentile:write',
+                                    'latency 99.9th percentile:write',
+                                    'latency max:write', 'total partitions',
+                                    'total partitions:write', 'total errors',
+                                    'total errors:write', 'total gc count',
+                                    'total gc memory', 'total gc time',
+                                    'avg gc time', 'stddev gc time', 'total operation time']
+
+        with pytest.raises(ToolError):
+            node1.stress_object(['abc', 'n=10'])


### PR DESCRIPTION
since `stress()` was returning only stderr and stdout
`stress_object()` treated anything printed in the stderr as errors
but cassandra stress also print warning into the stderr
and `stress_object()` started accumlating all kind of strings
it should ignore.

this change align those two function to be working similar
to the code in the ccm upstream, and now `stress()` returns
a nametuple that has rc,stderr,stdout. so the user can read
the outout and parse it as it wants, if the `rc!==0` an exception
is being raised (caller should catch it, if it's expected to fail
non of the dtest use it like that)

Test: added an integration test to cover those two function

Close: #402
Ref: scylladb/scylladb#11445