### PR TITLE
scylla_reporsitry: add option to pass `scylla_product` to setup()

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -30,7 +30,8 @@ class ScyllaCluster(Cluster):
 
         cassandra_version = kwargs.get('cassandra_version', version)
         docker_image = kwargs.get('docker_image')
-
+        self.scylla_product = kwargs.get('scylla_product', 'scylla')
+        
         if cassandra_version:
             self.scylla_reloc = True
             self.scylla_mode = None
@@ -68,7 +69,7 @@ class ScyllaCluster(Cluster):
             self._scylla_manager = ScyllaManager(self)
 
     def load_from_repository(self, version, verbose):
-        install_dir, version = scylla_repository.setup(version, verbose)
+        install_dir, version = scylla_repository.setup(version, verbose, self.scylla_product)
         install_dir, self.scylla_mode = common.scylla_extract_install_dir_and_mode(install_dir)
         return install_dir, version
 

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1272,6 +1272,7 @@ class NodeUpgrader:
         self._scylla_version_for_upgrade = None
         self.orig_install_dir = node.node_install_dir
         self.install_dir_for_upgrade = None
+        self.scylla_product = None
 
     @property
     def scylla_version_for_upgrade(self):
@@ -1286,7 +1287,7 @@ class NodeUpgrader:
 
     def _setup_relocatable_packages(self):
         try:
-            cdir, _ = setup(self.scylla_version_for_upgrade)
+            cdir, _ = setup(self.scylla_version_for_upgrade, scylla_product=self.scylla_product)
         except Exception as exc:
             raise NodeUpgradeError("Failed to setup relocatable packages. %s" % exc)
         return cdir

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -146,7 +146,7 @@ def get_relocatable_s3_url(branch, s3_version, links):
     raise CCMError(f"s3 url was not found for {branch}:{s3_version}")
 
 
-def setup(version, verbose=True):
+def setup(version, verbose=True, scylla_product='scylla'):
     """
     :param version:
             Supported version values (examples):
@@ -163,7 +163,7 @@ def setup(version, verbose=True):
     """
     s3_url = ''
     type_n_version = version.split(':', 1)
-    scylla_product = os.environ.get('SCYLLA_PRODUCT', 'scylla')
+    scylla_product = os.environ.get('SCYLLA_PRODUCT', scylla_product)
     scylla_arch = os.environ.get('SCYLLA_ARCH', 'x86_64')
 
     packages = None


### PR DESCRIPTION
Since in some cases we need to be able to download enterprise versions, and not only OSS (or in some cases both versions)

insted of counting on enviremnt variable to be set, it's now can be called explicitly