### PR TITLE
ccmlib/scylla_repository.py: automaticlly detect releases product

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -30,8 +30,7 @@ class ScyllaCluster(Cluster):
 
         cassandra_version = kwargs.get('cassandra_version', version)
         docker_image = kwargs.get('docker_image')
-        self.scylla_product = kwargs.get('scylla_product', 'scylla')
-        
+
         if cassandra_version:
             self.scylla_reloc = True
             self.scylla_mode = None
@@ -69,7 +68,7 @@ class ScyllaCluster(Cluster):
             self._scylla_manager = ScyllaManager(self)
 
     def load_from_repository(self, version, verbose):
-        install_dir, version = scylla_repository.setup(version, verbose, self.scylla_product)
+        install_dir, version = scylla_repository.setup(version, verbose)
         install_dir, self.scylla_mode = common.scylla_extract_install_dir_and_mode(install_dir)
         return install_dir, version
 

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1272,7 +1272,6 @@ class NodeUpgrader:
         self._scylla_version_for_upgrade = None
         self.orig_install_dir = node.node_install_dir
         self.install_dir_for_upgrade = None
-        self.scylla_product = None
 
     @property
     def scylla_version_for_upgrade(self):
@@ -1287,7 +1286,7 @@ class NodeUpgrader:
 
     def _setup_relocatable_packages(self):
         try:
-            cdir, _ = setup(self.scylla_version_for_upgrade, scylla_product=self.scylla_product)
+            cdir, _ = setup(self.scylla_version_for_upgrade)
         except Exception as exc:
             raise NodeUpgradeError("Failed to setup relocatable packages. %s" % exc)
         return cdir

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -13,6 +13,7 @@ import subprocess
 import re
 import sys
 import glob
+from pkg_resources import parse_version
 
 import hashlib
 import requests
@@ -176,6 +177,8 @@ def setup(version, verbose=True):
         s3_version = type_n_version[1]
 
         if type_n_version[0] == 'release':
+            scylla_product = 'scylla-enterprise' if parse_version(s3_version) > parse_version("2018.1") else  'scylla'
+            scylla_product = os.environ.get('SCYLLA_PRODUCT', scylla_product)
             if 'enterprise' in scylla_product:
                 s3_url = ENTERPRISE_RELEASE_RELOCATABLE_URLS_BASE
             else:

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -146,7 +146,7 @@ def get_relocatable_s3_url(branch, s3_version, links):
     raise CCMError(f"s3 url was not found for {branch}:{s3_version}")
 
 
-def setup(version, verbose=True, scylla_product='scylla'):
+def setup(version, verbose=True):
     """
     :param version:
             Supported version values (examples):
@@ -163,7 +163,7 @@ def setup(version, verbose=True, scylla_product='scylla'):
     """
     s3_url = ''
     type_n_version = version.split(':', 1)
-    scylla_product = os.environ.get('SCYLLA_PRODUCT', scylla_product)
+    scylla_product = os.environ.get('SCYLLA_PRODUCT', 'scylla')
     scylla_arch = os.environ.get('SCYLLA_ARCH', 'x86_64')
 
     packages = None


### PR DESCRIPTION
since we have a very clear versioning scheme for release
we can detect from a release version if it's enterprise or not.
we don't need any changes to dtest for that, since setting
the product by the under test product, means that we'll lock
the enterprise test from upgrading from OSS, which we do
want to keep testing.

Fixes: https://github.com/scylladb/scylla-dtest/issues/2852