### PR TITLE
feature(unified-package): support scylla unified packages

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -140,6 +140,9 @@ class ClusterCreateCmd(Cmd):
         parser.add_option('--scylla-jmx-package-uri', type="string", dest="scylla_jmx_package_uri",
                           help="The path scylla jmx relocatable package", default=None)
 
+        parser.add_option('--scylla-unified-package-uri', type="string", dest="scylla_unified_package_uri",
+                          help="The path scylla relocatable unified package", default=None)
+
         parser.epilog = """
         
         Examples of using relocatable packages:
@@ -196,6 +199,8 @@ class ClusterCreateCmd(Cmd):
 
         if options.scylla_core_package_uri:
             os.environ['SCYLLA_CORE_PACKAGE'] = options.scylla_core_package_uri
+        if options.scylla_unified_package_uri:
+            os.environ['SCYLLA_UNIFIED_PACKAGE'] = options.scylla_unified_package_uri
         if options.scylla_tools_java_package_uri:
             os.environ['SCYLLA_TOOLS_JAVA_PACKAGE'] = options.scylla_tools_java_package_uri
             # TODO: remove this export eventually, it's for backward

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -332,9 +332,13 @@ def parse_bin(executable):
     tokens = re.split(os.sep, executable)
     return tokens[-1]
 
+
 def get_tools_java_dir(install_dir, relative_repos_root='..'):
     if 'scylla-repository' in install_dir:
-        return os.path.join(install_dir, 'scylla-tools-java')
+        candidates = [
+            os.path.join(install_dir, 'scylla-tools-java'),
+            os.path.join(install_dir, 'scylla-core-package', 'scylla-tools'),
+        ]
     else:
         dir = os.environ.get('TOOLS_JAVA_DIR')
         if dir:
@@ -344,9 +348,10 @@ def get_tools_java_dir(install_dir, relative_repos_root='..'):
             os.path.join(install_dir, 'tools', 'java'),
             os.path.join(install_dir, relative_repos_root, 'scylla-tools-java')
         ]
-        for dir in candidates:
-            if os.path.isdir(dir):
-                return dir
+    for candidate in candidates:
+        if os.path.isdir(candidate):
+            return candidate
+
 
 def get_jmx_dir(install_dir, relative_repos_root='..'):
     dir = os.environ.get('SCYLLA_JMX_DIR')
@@ -354,11 +359,15 @@ def get_jmx_dir(install_dir, relative_repos_root='..'):
         return dir
     candidates = [
         os.path.join(install_dir, 'tools', 'jmx'),
-        os.path.join(install_dir, relative_repos_root, 'scylla-jmx')
+        os.path.join(install_dir, relative_repos_root, 'scylla-jmx'),
+        os.path.join(install_dir, relative_repos_root, 'scylla-core-package', 'scylla-jmx'),
+        os.path.join(install_dir, 'scylla-core-package', 'scylla-jmx'),
+        os.path.join(install_dir, 'scylla-jmx'),
     ]
-    for dir in candidates:
-        if os.path.isdir(dir):
-            return dir
+    for candidate in candidates:
+        if os.path.isdir(candidate):
+            return candidate
+
 
 def get_stress_bin(install_dir):
     candidates = [
@@ -683,9 +692,12 @@ def get_version_from_build(install_dir=None, node_path=None):
 
 
 def _get_scylla_version(install_dir):
-    scylla_version_files = [ os.path.join(install_dir, 'build', 'SCYLLA-VERSION-FILE'),
-                             os.path.join(install_dir, '..', '..', 'build', 'SCYLLA-VERSION-FILE'),
-                                os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-VERSION-FILE') ]
+    scylla_version_files = [
+        os.path.join(install_dir, 'build', 'SCYLLA-VERSION-FILE'),
+        os.path.join(install_dir, '..', '..', 'build', 'SCYLLA-VERSION-FILE'),
+        os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-VERSION-FILE'),
+        os.path.join(install_dir, 'scylla-core-package', 'scylla', 'SCYLLA-VERSION-FILE'),
+    ]
     for version_file in scylla_version_files:
         if os.path.exists(version_file):
             with open(version_file) as file:
@@ -699,8 +711,11 @@ def _get_scylla_version(install_dir):
 
 
 def _get_scylla_release(install_dir):
-    scylla_release_files = [os.path.join(install_dir, 'build', 'SCYLLA-RELEASE-FILE'),
-                                os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-RELEASE-FILE')]
+    scylla_release_files = [
+        os.path.join(install_dir, 'build', 'SCYLLA-RELEASE-FILE'),
+        os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-RELEASE-FILE'),
+        os.path.join(install_dir, 'scylla-core-package', 'scylla', 'SCYLLA-RELEASE-FILE'),
+    ]
     for release_file in scylla_release_files:
         if os.path.exists(release_file):
             with open(release_file) as file:

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -423,9 +423,9 @@ def download_version(version, url=None, verbose=False, target_dir=None, unified=
         tar.close()
 
         # if relocatable package format >= 2, need to extract files under subdir
-        package_version_file = "{}/.relocatable_package_version".format(target_dir)
-        if os.path.exists(package_version_file):
-            with open(package_version_file) as f:
+        package_version_files = glob.glob("{}/**/.relocatable_package_version".format(Path(target_dir).parent))
+        if package_version_files and os.path.exists(package_version_files[0]):
+            with open(package_version_files[0]) as f:
                 package_version = packaging.version.parse(f.read().strip())
             if package_version > packaging.version.parse('3'):
                 print(f'Unknown relocatable package format version: {package_version}')
@@ -508,6 +508,9 @@ def run_scylla_unified_install_script(install_dir, target_dir, package_version):
     install_opt = ''
     if package_version >= packaging.version.parse('2.2'):
         install_opt = ' --without-systemd'
+
+    if package_version >= packaging.version.parse('3'):
+        run('''cd scylla-*; mv * ../''', cwd=install_dir)
 
     run('''{0}/install.sh --prefix {1} --nonroot{2}'''.format(
         install_dir, target_dir, install_opt), cwd=install_dir)

--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -2,25 +2,25 @@ from unittest.mock import patch
 
 import pytest
 
-from ccmlib.scylla_repository import setup
+from ccmlib.scylla_repository import setup as scylla_setup
 
 
 @pytest.mark.repo_tests
 @pytest.mark.skip("slow integration test")
 class TestScyllaRepository:
     def test_setup_release_oss(self):
-        cdir, version = setup(version="release:4.2.1", verbose=True)
+        cdir, version = scylla_setup(version="release:4.2.1", verbose=True)
         assert version == '4.2.1'
 
     @patch.dict('os.environ', {'SCYLLA_PRODUCT': 'scylla-enterprise'})
     def test_setup_release_enterprise(self):
-        cdir, version = setup(version="release:2020.1.5", verbose=True)
+        cdir, version = scylla_setup(version="release:2020.1.5", verbose=True)
         assert version == '2020.1.5'
 
     def test_setup_unstable_master_new_url(self):
-        cdir, version = setup(version="unstable/master:2021-01-18T15:48:13Z", verbose=True)
+        cdir, version = scylla_setup(version="unstable/master:2021-01-18T15:48:13Z", verbose=True)
         assert version == '4.4.dev'
 
     def test_setup_unstable_master_old_url(self):
-        cdir, version = setup(version="unstable/master:2020-08-29T22:24:05Z", verbose=True)
+        cdir, version = scylla_setup(version="unstable/master:2020-08-29T22:24:05Z", verbose=True)
         assert version == '3.0'


### PR DESCRIPTION
For a while now scylla supplies a unified package that consist of scylla, jmx, and tools. historicly ccm handle each one on it's own, and never consumed the unified package.

we now default to taking the unified package, and fallback to regular flow if we fail to retrive it's path from the metadata file `00_Build.txt`

Closes: #243


TODO:

- [x] change release download to use unified, and test older versions. both enterprise and OSS