### PR TITLE
scylla_repository: fix retriving older versions

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -191,6 +191,7 @@ def setup(version, verbose=True):
             else:
                 s3_url = get_relocatable_s3_url(branch, s3_version, RELOCATABLE_URLS_BASE)
 
+            scylla_package_path = f'{scylla_product}-package.tar.gz'
             scylla_arch_package_path = f'{scylla_product}-{scylla_arch}-package.tar.gz'
             scylla_noarch_package_path = f'{scylla_product}-package.tar.gz'
             scylla_java_reloc = f'{scylla_product}-tools-package.tar.gz'
@@ -198,7 +199,7 @@ def setup(version, verbose=True):
 
             aws_files = aws_bucket_ls(s3_url)
 
-            if scylla_arch_package_path not in aws_files:
+            if scylla_arch_package_path not in aws_files and scylla_package_path not in aws_files:
                 scylla_java_reloc = list(filter(re.compile(f'{scylla_product}-tools-[0-9].*.noarch.tar.gz').match, aws_files))[0]
                 scylla_jmx_reloc = list(filter(re.compile(f'{scylla_product}-jmx-[0-9].*.noarch.tar.gz').match, aws_files))[0]
                 scylla_arch_package_path = list(filter(re.compile(f'{scylla_product}-[0-9].*.{scylla_arch}.tar.gz').match, aws_files))[0]
@@ -207,6 +208,8 @@ def setup(version, verbose=True):
                 scylla_package_path = scylla_arch_package_path
             elif scylla_noarch_package_path in aws_files:
                 scylla_package_path = scylla_noarch_package_path
+            elif scylla_package_path in aws_files:
+                scylla_package_path = scylla_package_path
             else:
                 raise RuntimeError("Can't find %s or %s in the %s",
                                    scylla_arch_package_path, scylla_noarch_package_path, s3_url)


### PR DESCRIPTION
When we are trying to download older versions (5.0 and below), the download is failing like this:

```
Traceback (most recent call last):
  File "/home/fruch/.pyenv/versions/3.10.5/envs/scylla-ccm-3.10.5/bin/ccm", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/fruch/projects/scylla-ccm/ccm", line 75, in <module>
    cmd.run()
  File "/home/fruch/projects/scylla-ccm/ccmlib/cmds/cluster_cmds.py", line 218, in run
    cluster = ScyllaCluster(self.path, self.name, install_dir=self.options.install_dir,
  File "/home/fruch/projects/scylla-ccm/ccmlib/scylla_cluster.py", line 50, in __init__
    super(ScyllaCluster, self).__init__(path, name, partitioner,
  File "/home/fruch/projects/scylla-ccm/ccmlib/cluster.py", line 71, in __init__
    dir, v = self.load_from_repository(version, verbose)
  File "/home/fruch/projects/scylla-ccm/ccmlib/scylla_cluster.py", line 71, in load_from_repository
    install_dir, version = scylla_repository.setup(version, verbose)
  File "/home/fruch/projects/scylla-ccm/ccmlib/scylla_repository.py", line 203, in setup
    scylla_java_reloc = list(filter(re.compile(f'{scylla_product}-tools-[0-9].*.noarch.tar.gz').match, aws_files))[0]
IndexError: list index out of range
```

this is broken when recently #401 got merged, and seem to be causing failure in any place we are still trying to fetch older versions (i.e. python-driver still fetches from branch-5.0)

Ref: scylladb/python-driver#171