### PR TITLE
ccmlib/scylla_repository.py: unified install don't unavailable arguments

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -507,7 +507,7 @@ def run_scylla_install_script(install_dir, target_dir, package_version):
 
 def run_scylla_unified_install_script(install_dir, target_dir, package_version):
     # to skip systemd check at https://github.com/scylladb/scylladb/blob/master/unified/install.sh#L102
-    install_opt = ' --supervisor'
+    install_opt = ' --supervisor' if '--supervisor' in (Path(install_dir) / 'install.sh').read_text() else ' '
 
     if package_version >= packaging.version.parse('2.2'):
         install_opt = ' --without-systemd'


### PR DESCRIPTION
code was using `--supervisor` to disable systemd checks, but this flag was introduced only in scylla 4.6
and it breaks installing older releases, for example `2021.1.16`

for other flags we check the installer version, but this specifc flag didn't come with a version change, hence we are looking for it in `install.sh`

Fixes: #413