### PR TITLE
fix(unified-installer): handle inner direcoty

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -29,7 +29,7 @@ from ccmlib.node import Node, NodeUpgradeError
 from ccmlib.node import Status
 from ccmlib.node import NodeError
 from ccmlib.node import TimeoutError
-from ccmlib.scylla_repository import setup, CORE_PACKAGE_DIR_NAME, SCYLLA_VERSION_FILE
+from ccmlib.scylla_repository import setup, get_scylla_version
 
 
 class ScyllaNode(Node):
@@ -412,15 +412,7 @@ class ScyllaNode(Node):
     def node_install_dir_version(self):
         if not self.node_install_dir:
             return None
-
-        scylla_version_file_path = os.path.join(self.node_install_dir, CORE_PACKAGE_DIR_NAME, SCYLLA_VERSION_FILE)
-        if not os.path.exists(scylla_version_file_path):
-            self.debug(f"'{scylla_version_file_path}' wasn't found")
-            return None
-
-        with open(scylla_version_file_path, 'r') as f:
-            version = f.readline()
-        return version.strip()
+        return get_scylla_version(self.node_install_dir)
 
     # Scylla Overload start
     def start(self, join_ring=True, no_wait=False, verbose=False,

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -931,7 +931,7 @@ class ScyllaNode(Node):
                                    dst=os.path.join(self.get_bin_dir(), 'scylla'),
                                    extra_perms=stat.S_IEXEC,
                                    replace=replace)
-            os.environ['GNUTLS_SYSTEM_PRIORITY_FILE'] = os.path.join(self.node_install_dir, 'scylla-core-package/libreloc/gnutls.config')
+            os.environ['GNUTLS_SYSTEM_PRIORITY_FILE'] = self.gnutls_config_file
         else:
             self._relative_repos_root = '..'
             src = os.path.join(self.get_install_dir(), 'build', self.scylla_mode(), 'scylla')
@@ -1256,6 +1256,18 @@ class ScyllaNode(Node):
 
     def rollback(self, upgrade_to_version):
         self.upgrader.upgrade(upgrade_version=upgrade_to_version, recover_system_tables=True)
+
+    @property
+    def gnutls_config_file(self):
+        candidates = [
+            Path(self.node_install_dir) / 'scylla-core-package' / 'libreloc' / 'gnutls.config',
+            Path(self.node_install_dir) / 'libreloc' / 'gnutls.config',
+        ]
+        for candidate in candidates:
+            if candidate.exists():
+                return str(candidate)
+        raise ValueError(f"gnutls.config wasn't found in any path: {candidates}")
+
 
 class NodeUpgrader:
 


### PR DESCRIPTION
in recent fixes we added a check of the content
of `install.sh` it seems be conflicting with the change made to support `package_version==3.0` which means there a inner directory inside the tarball that
need to be leveled to align to the structure the
ccm code expects