### PR TITLE
utils/sni_proxy.py: fix hostname regexes in tables

### DIFF
--- a/ccmlib/utils/sni_proxy.py
+++ b/ccmlib/utils/sni_proxy.py
@@ -96,12 +96,12 @@ def configure_sni_proxy(conf_dir, nodes_info, listen_port=443):
     tables = ""
     mapping = {}
     address, port, host_id = list(nodes_info)[0]
-    tables += f"  cql.cluster-id.scylla.com {address}:{port}\n"
+    tables += f"  ^cql.cluster-id.scylla.com$ {address}:{port}\n"
     mapping['FIRST_ADDRESS'] = address
     mapping['listen_port'] = listen_port
 
     for address, port, host_id in nodes_info:
-        tables += f"  {host_id}.cql.cluster-id.scylla.com {address}:{port}\n"
+        tables += f"  ^{host_id}.cql.cluster-id.scylla.com$ {address}:{port}\n"
 
     tmpl = string.Template(sniproxy_conf_tmpl)
     sniproxy_conf_path = os.path.join(conf_dir, 'sniproxy.conf')


### PR DESCRIPTION
Before this change, all requests to `{host_id}.cql.cluster-id.scylla.com` would get erroneously routed to the same node - the first node. The  reason for such behavior is explained by `sniproxy.conf` documentation:

"Each request's hostname is matched against entries in the table in  order, until a match is found and that server is used."

`cql.cluster-id.scylla.com` would match to `{host_id}.cql.cluster-id.scylla.com` and it was the first entry in the table, meaning all requests would get routed to `cql.cluster-id.scylla.com`.

Fix this issue by adding `^` and `$` to the regexes, to make sure that the entire request hostname matches the hostname in the entry.