### PR TITLE
scylla_repository.py: fix the retrival of release canidates version

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -5,7 +5,6 @@ import random
 import shutil
 import threading
 import time
-from pkg_resources import parse_version
 from collections import OrderedDict, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 
@@ -16,6 +15,7 @@ from six.moves import xrange
 from ccmlib import common, repository
 from ccmlib.node import Node, NodeError
 from ccmlib.common import logger
+from ccmlib.utils.version import parse_version
 
 
 class Cluster(object):

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -15,7 +15,6 @@ import time
 import warnings
 from datetime import datetime
 import locale
-from pkg_resources import parse_version
 from collections import namedtuple
 
 import yaml
@@ -25,7 +24,7 @@ from six.moves import xrange
 from ccmlib import common
 from ccmlib.cli_session import CliSession
 from ccmlib.repository import setup
-
+from ccmlib.utils.version import parse_version
 
 class Status():
     UNINITIALIZED = "UNINITIALIZED"

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -13,8 +13,6 @@ import time
 import threading
 from pathlib import Path
 
-from pkg_resources import parse_version
-
 import psutil
 import yaml
 import glob
@@ -30,6 +28,7 @@ from ccmlib.node import Status
 from ccmlib.node import NodeError
 from ccmlib.node import TimeoutError
 from ccmlib.scylla_repository import setup, get_scylla_version
+from ccmlib.utils.version import parse_version
 
 
 class ScyllaNode(Node):

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -14,7 +14,6 @@ import subprocess
 import re
 import sys
 import glob
-from pkg_resources import parse_version
 
 import hashlib
 import requests
@@ -29,6 +28,7 @@ from ccmlib.common import (
     ArgumentError, CCMError, get_default_path, rmdirs, validate_install_dir, get_scylla_version, aws_bucket_ls,
     DOWNLOAD_IN_PROGRESS_FILE, wait_for_parallel_download_finish)
 from ccmlib.utils.download import download_file, download_version_from_s3
+from ccmlib.utils.version import parse_version
 
 GIT_REPO = "http://github.com/scylladb/scylla.git"
 

--- a/ccmlib/utils/version.py
+++ b/ccmlib/utils/version.py
@@ -1,0 +1,6 @@
+from packaging.version import parse, Version
+
+
+def parse_version(v: str) -> Version:
+    v = v.replace('~', '-')
+    return parse(v)

--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -12,7 +12,6 @@ class TestScyllaRepository:
         cdir, version = scylla_setup(version="release:4.2.1", verbose=True)
         assert version == '4.2.1'
 
-    @patch.dict('os.environ', {'SCYLLA_PRODUCT': 'scylla-enterprise'})
     def test_setup_release_enterprise(self):
         cdir, version = scylla_setup(version="release:2020.1.5", verbose=True)
         assert version == '2020.1.5'
@@ -24,3 +23,83 @@ class TestScyllaRepository:
     def test_setup_unstable_master_old_url(self):
         cdir, version = scylla_setup(version="unstable/master:2020-08-29T22:24:05Z", verbose=True)
         assert version == '3.0'
+
+
+class TestScyllaRepositoryRelease:
+    @pytest.mark.parametrize(argnames=['version', 'expected_cdir'], argvalues=[
+        ("release:5.1", 'release/5.1'),
+        ("release:5.1~rc1", '5.1.0~rc1'),
+        ("release:5.1.rc1", '5.1.0~rc1'),
+        ("release:5.1-rc1", '5.1.0~rc1'),
+        ("release:5.0", '5.0'),
+        ("release:5.0~rc2", '5.0.rc2'),
+        ("release:5.0.rc2", '5.0.rc2'),
+        ("release:5.0-rc2", '5.0.rc2'),
+        ("release:5.0.3", '5.0.3'),
+        ("release:4.6", '4.6'),
+        ("release:4.5", '4.5'),
+        ("release:4.4", '4.4'),
+        ("release:4.3", '4.3'),
+    ])
+    def test_setup_release_oss(self, version, expected_cdir):
+        cdir, packages = scylla_setup(version=version, verbose=True, skip_downloads=True)
+        assert expected_cdir in cdir
+        assert packages.scylla_unified_package
+
+    @pytest.mark.parametrize(argnames=['version', 'expected_cdir'], argvalues=[
+        ("release:4.2", '4.2'),
+        ("release:4.1", '4.1'),
+        ("release:4.0", '4.0'),
+    ])
+    def test_setup_release_oss_no_unified_package(self, version, expected_cdir):
+        cdir, packages = scylla_setup(version=version, verbose=True, skip_downloads=True)
+        assert expected_cdir in cdir
+        assert packages.scylla_unified_package is None
+        assert packages.scylla_package
+        assert packages.scylla_tools_package
+        assert packages.scylla_jmx_package
+
+    @pytest.mark.parametrize(argnames=['version', 'expected_cdir'], argvalues=[
+        ("release:2022.2", '2022.2'),
+        ("release:2022.2~rc1", '2022.2.0~rc1'),
+        ("release:2022.2.rc1", '2022.2.0~rc1'),
+        ("release:2022.2-rc1", '2022.2.0~rc1'),
+        ("release:2022.1", '2022.1'),
+        ("release:2022.1~rc5", '2022.1.rc5'),
+        ("release:2022.1.rc5", '2022.1.rc5'),
+        ("release:2022.1-rc5", '2022.1.rc5'),
+        ("release:2021.1", '2021.1'),
+        ("release:2021.1.10", '2021.1.10'),
+    ])
+    def test_setup_release_enterprise(self, version, expected_cdir):
+        cdir, packages = scylla_setup(version=version, verbose=True, skip_downloads=True)
+        assert expected_cdir in cdir
+        assert packages.scylla_unified_package
+
+    @pytest.mark.parametrize(argnames=['version', 'expected_cdir'], argvalues=[
+        ("release:2020.1", '2020.1'),
+        ("release:2020.1.10", '2020.1.10'),
+    ])
+    def test_setup_release_enterprise_no_unified_package(self, version, expected_cdir):
+        cdir, packages = scylla_setup(version=version, verbose=True, skip_downloads=True)
+        assert expected_cdir in cdir
+        assert packages.scylla_unified_package is None
+        assert packages.scylla_package
+        assert packages.scylla_tools_package
+        assert packages.scylla_jmx_package
+
+    def test_setup_unstable_master_new_url(self):
+        cdir, packages = scylla_setup(version="unstable/master:2021-01-18T15:48:13Z", verbose=True, skip_downloads=True)
+        assert '2021-01-18T15_48_13Z' in cdir
+        assert packages.scylla_unified_package is None
+        assert packages.scylla_package == 'https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/master/relocatable/2021-01-18T15:48:13Z/scylla-package.tar.gz'
+        assert packages.scylla_tools_package == 'https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/master/relocatable/2021-01-18T15:48:13Z/scylla-tools-package.tar.gz'
+        assert packages.scylla_jmx_package == 'https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/master/relocatable/2021-01-18T15:48:13Z/scylla-jmx-package.tar.gz'
+
+    def test_setup_unstable_master_old_url(self):
+        cdir, packages = scylla_setup(version="unstable/master:2020-08-29T22:24:05Z", verbose=True, skip_downloads=True)
+        assert '2020-08-29T22_24_05Z' in cdir
+        assert not packages.scylla_unified_package
+        assert packages.scylla_package
+        assert packages.scylla_tools_package
+        assert packages.scylla_jmx_package


### PR DESCRIPTION
since moving to using unifed package by default the retrival of release canidates were broken