### PR TITLE
node.py: change print to logging in `run_cqlsh`

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -817,3 +817,11 @@ def grouper(n, iterable, padvalue=None):
     idea from: https://stackoverflow.com/a/312644/459189
     """
     return zip_longest(*[iter(iterable)] * n, fillvalue=padvalue)
+
+
+def print_if_standalone(*args, debug_callback=None, **kwargs):
+    standalone = os.environ.get('SCYLLA_CCM_STANDALONE', None)
+    if standalone:
+        print_(*args, *kwargs, end='')
+    else:
+        debug_callback(*args, **kwargs)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -894,10 +894,11 @@ class Node(object):
             output = p.communicate()
 
             for err in output[1].split('\n'):
-                print_("(EE) ", err, end='')
+                if err.strip():
+                    common.print_if_standalone("(EE) %s" % err, debug_callback=self.debug)
 
             if show_output:
-                print_(output[0], end='')
+                common.print_if_standalone(output[0], debug_callback=self.debug)
 
             if return_output:
                 return output


### PR DESCRIPTION
in dtest we should be printing anything to stdout, everything should go into the logs.

when ccm is use as standalone (via cli), those would be printed to stdout.