### PR TITLE
node.nodetool: add verbose argument

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -768,7 +768,7 @@ class Node(object):
             time.sleep(1)
         raise TimeoutError(f"Waiting for compactions timed out after {idle_timeout} seconds with {pending_tasks} pending tasks remaining.")
 
-    def nodetool(self, cmd, capture_output=True, wait=True, timeout=None):
+    def nodetool(self, cmd, capture_output=True, wait=True, timeout=None, verbose=True):
         """
         Setting wait=False makes it impossible to detect errors,
         if capture_output is also False. wait=False allows us to return
@@ -790,7 +790,8 @@ class Node(object):
         # see https://www.oracle.com/java/technologies/javase/8u331-relnotes.html#JDK-8278972
         nodetool.extend(['-h', host, '-p', str(self.jmx_port), '-Dcom.sun.jndi.rmiURLParsing=legacy'])
         nodetool.extend(cmd.split())
-        self.debug(f"nodetool cmd={cmd} wait={wait} timeout={timeout}")
+        if verbose:
+            self.debug(f"nodetool cmd={cmd} wait={wait} timeout={timeout}")
         if capture_output:
             p = subprocess.Popen(nodetool, universal_newlines=True, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate(timeout=timeout)

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1213,11 +1213,11 @@ class ScyllaNode(Node):
     def _write_agent_log4j_properties(self, agent_dir):
         raise NotImplementedError('ScyllaNode._write_agent_log4j_properties')
 
-    def _wait_no_pending_flushes(self, wait_timeout=60):
+    def _wait_no_pending_flushes(self, wait_timeout=60, verbose=True):
         pending_flushes_re = re.compile(r"^\s*Pending flushes:\s*(?P<count>\d+)\s*$", flags=re.MULTILINE)
 
         def no_pending_flushes() -> bool:
-            stdout = self.nodetool('cfstats', timeout=wait_timeout)[0]
+            stdout = self.nodetool('cfstats', timeout=wait_timeout, verbose=verbose)[0]
             pending_flushes = False
             for match in pending_flushes_re.finditer(stdout):
                 if int(match.group("count")):
@@ -1231,7 +1231,7 @@ class ScyllaNode(Node):
 
     def flush(self, ks=None, table=None, **kwargs):
         super(ScyllaNode, self).flush(ks, table, **kwargs)
-        self._wait_no_pending_flushes()
+        self._wait_no_pending_flushes(verbose=kwargs.get('verbose', True))
 
     def _run_scylla_executable_with_option(self, option, scylla_exec_path=None):
         if not scylla_exec_path:


### PR DESCRIPTION
in some tests, we are using nodetool in high quentites and we don't want to fill the logs with that information (it's mostly preperation for the actul test)

see dtest `data.simulate_write_process_in_minutes`

so we are adding a way to disable the logging that was recently added to `node.nodetool`