### PR TITLE
wait_for_starting: off strategy

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -246,8 +246,11 @@ class ScyllaNode(Node):
                     raise RuntimeError("The process is dead, returncode={}".format(process.returncode))
             pat = '|'.join([
                 r'repair - Repair \d+ out of \d+ ranges',
+                r'repair - .*: Started to repair',
                 r'range_streamer - Bootstrap .* streaming .* ranges',
                 r'(compaction|database) -.*Resharded',
+                r'compaction_manager - (Starting|Done with) off-strategy compaction',
+                r'compaction - .* Reshaped'
             ])
             if self.grep_log(pat, from_mark=prev_mark):
                 prev_mark = self.mark_log()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -244,10 +244,12 @@ class ScyllaNode(Node):
                 self.print_process_output(self.name, process, verbose=True)
                 if process.returncode != 0:
                     raise RuntimeError("The process is dead, returncode={}".format(process.returncode))
-            repair_pattern = r'repair - Repair \d+ out of \d+ ranges'
-            streaming_pattern = r'range_streamer - Bootstrap .* streaming .* ranges'
-            resharding_pattern = r'(compaction|database) -.*Resharded'
-            if self.grep_log("{}|{}|{}".format(repair_pattern, streaming_pattern, resharding_pattern), from_mark=prev_mark):
+            pat = '|'.join([
+                r'repair - Repair \d+ out of \d+ ranges',
+                r'range_streamer - Bootstrap .* streaming .* ranges',
+                r'(compaction|database) -.*Resharded',
+            ])
+            if self.grep_log(pat, from_mark=prev_mark):
                 prev_mark = self.mark_log()
                 prev_mark_time = time.time()
             elif time.time() - prev_mark_time >= timeout:


### PR DESCRIPTION
Extend the regular expression in wait_for_starting
to look for more messages indicating progress of repair and off-strategy compaction that follows it
to extend the time we wait for a starting node to start listening for CQL.