### PR TITLE
node.py: disable commitlog O_DSYNC, preallocation

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -582,6 +582,12 @@ class ScyllaNode(Node):
         kernel_page_cache_supported |= current_node_is_enterprise and parse_version(current_node_version) >= parse_version('2022.1.dev')
         if kernel_page_cache_supported and '--kernel-page-cache' not in args:
             args += ['--kernel-page-cache', '1']
+        commitlog_o_dsync_supported = (
+            (not current_node_is_enterprise and parse_version(current_node_version) >= parse_version('3.2'))
+            or (current_node_is_enterprise and parse_version(current_node_version) >= parse_version('2020.1'))
+            )
+        if commitlog_o_dsync_supported:
+            args += ['--commitlog-use-o-dsync', '0']
 
         # The '--max-networking-io-control-blocks' was introduced by
         # https://github.com/scylladb/scylla/commit/2cfc517874e98c5780c1b1b4c38440a8123f86f6 from 4.6 version


### PR DESCRIPTION
Commitlog O_DSYNC is intended to make Raft and schema writes durable in the face of power loss. To make O_DSYNC performant, we preallocate the commitlog segments, so that the commitlog writes only change file data and not file metadata (which would require the filesystem to commit its own log).

However, in tests, this causes each ScyllaDB instance to write 384MB of commitlog segments. This overloads the disks and slows everything down.

Fix this by disabling O_DSYNC (and therefore preallocation) during the tests. They can't survive power loss, and run with --unsafe-bypass-fsync anyway.