### PR TITLE
scylla_node: Allow set JAVA_HOME to override scylla-jmx link

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1019,7 +1019,11 @@ class ScyllaNode(Node):
         scylla_jmx_file = os.path.join(self.get_bin_dir(), 'symlinks', 'scylla-jmx')
         if os.path.exists(scylla_jmx_file) and replace:
             os.remove(scylla_jmx_file)
-        os.symlink('/usr/bin/java', scylla_jmx_file)
+        java_exe = '/usr/bin/java'
+        java_home = os.environ.get('JAVA_HOME')
+        if java_home:
+            java_exe = os.path.join(java_home, 'bin', 'java')
+        os.symlink(java_exe, scylla_jmx_file)
 
         parent_dir = os.path.dirname(os.path.realpath(__file__))
         resources_bin_dir = os.path.join(parent_dir, 'resources', BIN_DIR)


### PR DESCRIPTION
Fixes #426

To smoothly use different scylla-jmx java executable w/o changing link in /usr/bin.