### PR TITLE
scylla_node: start_scylla: fix wait for binary interface timeout path

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -230,9 +230,11 @@ class ScyllaNode(Node):
     # Possibly poll the log for long-running offline processes, like
     # bootstrap or resharding.
     # Return True iff detected bootstrap or resharding processes in the log
-    def wait_for_starting(self, from_mark=None, timeout=120):
+    def wait_for_starting(self, from_mark=None, timeout=None):
         if from_mark is None:
             from_mark = self.mark_log()
+        if timeout is None:
+            timeout = 120
         process=self._process_scylla
         starting_message = 'Starting listening for CQL clients'
         bootstrap_message = r'storage_service .* Starting to bootstrap'

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -311,7 +311,7 @@ class ScyllaNode(Node):
         if wait_for_binary_proto:
             t = timeout * 4 if timeout is not None else 420 if self.cluster.scylla_mode != 'debug' else 900
             try:
-                self.wait_for_binary_interface(from_mark=self.mark, process=self._process_scylla, timeout=60)
+                self.wait_for_binary_interface(from_mark=self.mark, process=self._process_scylla, timeout=timeout or 180)
             except TimeoutError as e:
                 if not self.wait_for_starting(from_mark=self.mark, timeout=t):
                     raise NodeError(f"{e}")

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -309,8 +309,8 @@ class ScyllaNode(Node):
                 node.watch_log_for_alive(self, from_mark=mark, timeout=t)
 
         if wait_for_binary_proto:
+            t = timeout * 4 if timeout is not None else 420 if self.cluster.scylla_mode != 'debug' else 900
             try:
-                t = timeout * 4 if timeout is not None else 420 if self.cluster.scylla_mode != 'debug' else 900
                 self.wait_for_binary_interface(from_mark=self.mark, process=self._process_scylla, timeout=60)
             except TimeoutError as e:
                 if not self.wait_for_starting(from_mark=self.mark, timeout=t):

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -310,12 +310,12 @@ class ScyllaNode(Node):
 
         if wait_for_binary_proto:
             t = timeout * 4 if timeout is not None else 420 if self.cluster.scylla_mode != 'debug' else 900
+            from_mark = self.mark
             try:
-                self.wait_for_binary_interface(from_mark=self.mark, process=self._process_scylla, timeout=timeout or 180)
+                self.wait_for_binary_interface(from_mark=from_mark, process=self._process_scylla, timeout=timeout or 180)
             except TimeoutError as e:
-                if not self.wait_for_starting(from_mark=self.mark, timeout=t):
-                    raise NodeError(f"{e}")
-                pass
+                self.wait_for_starting(from_mark=self.mark, timeout=t)
+                self.wait_for_binary_interface(from_mark=from_mark, process=self._process_scylla, timeout=0)
 
         return self._process_scylla
 


### PR DESCRIPTION
Looking at https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-daily-debug/135/testReport/, for example, we see that many tests in `resharding_test` and `materialized_views_test.py::TestInterruptBuildProcess` fail with
```
ccmlib.node.NodeError: 30 Jan 2023 05:31:16 [node1] Missing: ['Starting listening for CQL clients']:
Scylla version 5.3.0~dev-0.20230130.84a69b6adb3d w.....
See system.log for remainder
```

This is caused by a long standing bug (introduced in c1762841eec615ba315be1b4b841aaef5108281d):
```
            try:
                t = timeout * 4 if timeout is not None else 420 if self.cluster.scylla_mode != 'debug' else 900
                self.wait_for_binary_interface(from_mark=self.mark, process=self._process_scylla, timeout=60)
            except TimeoutError as e:
                if not self.wait_for_starting(from_mark=self.mark, timeout=t):
                    raise NodeError(f"{e}")
                pass
```

wait_for_starting return value indicates if bootstrap or resharding took place,
not if 'Starting listening for CQL clients' was found.
In addition there are secondary bugs related to the timeout passed to it
which this PR fixes.

Tested with `./scripts/run_test.sh --cassandra-dir=$CASSANDRA_DIR -n 6 resharding_test.py::TestReshardingVariants materialized_views_test.py::TestInterruptBuildProcess`