### PR TITLE
node: keep hostid result in self.node_hostid

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1362,16 +1362,18 @@ class Node(object):
         self.status = Status.DECOMMISSIONED
         self._update_config()
 
-    def hostid(self, timeout=60):
-        info = self.nodetool('info', capture_output=True, timeout=timeout)[0]
-        id_lines = [s for s in info.split('\n')
-                    if s.startswith('ID')]
-        if not len(id_lines) == 1:
-            msg = ('Expected output from `nodetool info` to contain exactly 1 '
-                   'line starting with "ID". Found:\n') + info
-            raise RuntimeError(msg)
-        id_line = id_lines[0].replace(":", "").split()
-        return id_line[1]
+    def hostid(self, timeout=60, force_refresh=False):
+        if not hasattr(self, 'node_hostid') or force_refresh:
+            info = self.nodetool('info', capture_output=True, timeout=timeout)[0]
+            id_lines = [s for s in info.split('\n')
+                        if s.startswith('ID')]
+            if not len(id_lines) == 1:
+                msg = ('Expected output from `nodetool info` to contain exactly 1 '
+                    'line starting with "ID". Found:\n') + info
+                raise RuntimeError(msg)
+            id_line = id_lines[0].replace(":", "").split()
+            self.node_hostid = id_line[1]
+        return self.node_hostid
 
     def get_datacenter_name(self):
         info = self.nodetool('info', capture_output=True)[0]


### PR DESCRIPTION
The hostid nver changes so there no reason to
use nodetool every time to get it.

Tests that want to exercise nodetool for that can do that by explicitly running nodetool, or passing force_refresh=True if they insist :)

Otherwise, cache the result in self.node_hostid
to be reused next time hostid() is called.

This is particularly needed for node operations
scenarios when an operation like replacenode
runs after removenode that happened to stop the
to-be-replaced node.

Since scylladb/scylla-dtest@97a341adc4adeb1a27e00db1bb4614b0d1f53618 the replace node operation operates on the node hostid and that cannot be retrieved if the node is already dead without this change.

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>