### PR TITLE
scylla_repository: Fix handling of full version release candidates

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -81,7 +81,9 @@ def release_packages(s3_url, version, arch='x86_64', scylla_product='scylla'):
     # examples of unified packages file names:
     # 'scylla-x86_64-unified-package-5.1.2-0.20221225.4c0f7ea09893-5.1.2.0.20221225.4c0f7ea09893.tar.gz'
     # 'scylla-x86_64-unified-package-5.1.3-0.20230112.addc4666d502-5.1.3.0.20230112.addc4666d502.tar.gz'
-    all_unified_packages = [name for name in files_in_bucket if f'{scylla_product}-{arch}-unified-package' in name or f'{scylla_product}-unified-package' in name]
+    all_unified_packages = [name for name in files_in_bucket if f'{scylla_product}-{arch}-unified-package' in name or
+                            (f'{scylla_product}-unified' in name and arch in name) or
+                            f'{scylla_product}-unified' in name]
     release_unified_packages = [package for package in all_unified_packages if version in package]
 
     def extract_version(filename):
@@ -204,7 +206,7 @@ def normalize_scylla_version(version):
         return version
 
     version = version.replace('-', '~').replace('.rc', '~rc')
-    version = version if re.match(r'\d*.\d*.0~rc', version) else version.replace('~rc', '.0~rc')
+    version = version if re.match(r'.*\d*.\d*.0~rc', version) else version.replace('~rc', '.0~rc')
 
     return version
 

--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -60,6 +60,7 @@ class TestScyllaRepositoryRelease:
         assert packages.scylla_jmx_package
 
     @pytest.mark.parametrize(argnames=['version', 'expected_cdir'], argvalues=[
+        ("release:2023.1.0~rc0", '2023.1.0~rc0'),
         ("release:2022.2", '2022.2'),
         ("release:2022.2~rc1", '2022.2.0~rc1'),
         ("release:2022.2.rc1", '2022.2.0~rc1'),


### PR DESCRIPTION
when ccm was pass `2023.1.0~rc0` it would fail like this:

```
  File ".../site-packages/ccmlib/scylla_repository.py", line 136, in release_packages
    raise ValueError(f"Not expected version number: {version}. S3_URL: {s3_url}")
ValueError: Not expected version number: 2023.1.0.0~rc0. S3_URL: https://s3.amazonaws.com/downloads.scylladb.com/downloads/scylla-enterprise/relocatable/scylladb-2023.1
```

it was a faulty regex that wasn't behaving correctly also fix the filtering of unified packages, since the nameing changed a bit, once again