### PR TITLE
scylla_node: expose ScyllaNode.smp()

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -103,6 +103,9 @@ class ScyllaNode(Node):
         self._smp =  smp
         self._smp_set_during_test = True
 
+    def smp(self):
+        return self._smp
+
     def set_mem_mb_per_cpu(self, mem):
         self._mem_mb_per_cpu = mem
         self._mem_set_during_test = True

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -100,7 +100,7 @@ class ScyllaNode(Node):
         return self.cluster.is_scylla_reloc()
 
     def set_smp(self, smp):
-        self._smp =  smp
+        self._smp = smp
         self._smp_set_during_test = True
 
     def smp(self):


### PR DESCRIPTION
so the dtest tests are able to acess the exact number of shard used
for testing. for instance, some of them might need to calculate the
exact total memory based on this option.