### PR TITLE
treewide: drop python2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Requirements
 
 - A working python installation (tested to work with python 3.11).
 - pyYAML (http://pyyaml.org/ -- `sudo easy_install pyYaml`)
-- six (https://pypi.python.org/pypi/six -- `sudo easy_install six`)
 - ant (http://ant.apache.org/, on Mac OS X, `brew install ant`)
 - psutil (https://pypi.python.org/pypi/psutil)
 - Java (which version depends on the version of Cassandra you plan to use. If

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ ccm start
 Requirements
 ------------
 
-- A working python installation (tested to work with python 2.7).
+- A working python installation (tested to work with python 3.11).
 - pyYAML (http://pyyaml.org/ -- `sudo easy_install pyYaml`)
 - six (https://pypi.python.org/pypi/six -- `sudo easy_install six`)
 - ant (http://ant.apache.org/, on Mac OS X, `brew install ant`)

--- a/ccm
+++ b/ccm
@@ -2,7 +2,6 @@
 
 import sys
 
-from six import print_
 
 from ccmlib import common
 from ccmlib.cmds import command, cluster_cmds, node_cmds
@@ -20,31 +19,31 @@ def get_command(kind, cmd):
 
 
 def print_global_usage():
-    print_("Usage:")
-    print_("  ccm <cluster_cmd> [options]")
-    print_("  ccm <node_name> <node_cmd> [options]")
-    print_("")
-    print_("Where <cluster_cmd> is one of")
+    print("Usage:")
+    print("  ccm <cluster_cmd> [options]")
+    print("  ccm <node_name> <node_cmd> [options]")
+    print("")
+    print("Where <cluster_cmd> is one of")
     for cmd_name in cluster_cmds.cluster_cmds():
         cmd = get_command("cluster", cmd_name)
         if not cmd:
-            print_("Internal error, unknown command {0}".format(cmd_name))
+            print("Internal error, unknown command {0}".format(cmd_name))
             exit(1)
-        print_("  {0:14} {1}".format(cmd_name, cmd.description()))
-    print_("or <node_name> is the name of a node of the current cluster and <node_cmd> is one of")
+        print("  {0:14} {1}".format(cmd_name, cmd.description()))
+    print("or <node_name> is the name of a node of the current cluster and <node_cmd> is one of")
     for cmd_name in node_cmds.node_cmds():
         cmd = get_command("node", cmd_name)
         if not cmd:
-            print_("Internal error, unknown command {0}".format(cmd_name))
+            print("Internal error, unknown command {0}".format(cmd_name))
             exit(1)
-        print_("  {0:14} {1}".format(cmd_name, cmd.description()))
+        print("  {0:14} {1}".format(cmd_name, cmd.description()))
     exit(1)
 
 
 common.check_win_requirements()
 
 if len(sys.argv) <= 1:
-    print_("Missing arguments")
+    print("Missing arguments")
     print_global_usage()
 
 arg1 = sys.argv[1].lower()
@@ -55,7 +54,7 @@ if arg1 in cluster_cmds.cluster_cmds():
     cmd_args = sys.argv[2:]
 else:
     if len(sys.argv) <= 2:
-        print_("Missing arguments")
+        print("Missing arguments")
         print_global_usage()
     kind = 'node'
     node = arg1
@@ -64,7 +63,7 @@ else:
 
 cmd = get_command(kind, cmd)
 if not cmd:
-    print_("Unknown node or command: {0}".format(arg1))
+    print("Unknown node or command: {0}".format(arg1))
     exit(1)
 
 parser = cmd.get_parser()

--- a/ccmlib/cli_session.py
+++ b/ccmlib/cli_session.py
@@ -2,7 +2,7 @@ import sys
 from threading import Thread
 
 try:
-    from Queue import Queue, Empty
+    from queue import Queue, Empty
 except ImportError:
     from queue import Queue, Empty  # python 3.x
 

--- a/ccmlib/cli_session.py
+++ b/ccmlib/cli_session.py
@@ -1,10 +1,6 @@
 import sys
+from queue import Queue, Empty
 from threading import Thread
-
-try:
-    from queue import Queue, Empty
-except ImportError:
-    from queue import Queue, Empty  # python 3.x
 
 ON_POSIX = 'posix' in sys.builtin_module_names
 

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -9,8 +9,6 @@ from collections import OrderedDict, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 
 import yaml
-from six import iteritems, print_
-from six.moves import xrange
 
 from ccmlib import common, repository
 from ccmlib.node import Node, NodeError
@@ -409,15 +407,15 @@ class Cluster(object):
 
     def show(self, verbose):
         msg = f"Cluster: '{self.name}'"
-        print_(msg)
-        print_('-' * len(msg))
+        print(msg)
+        print('-' * len(msg))
         if len(list(self.nodes.values())) == 0:
-            print_("No node in this cluster yet")
+            print("No node in this cluster yet")
             return
         for node in list(self.nodes.values()):
             if (verbose):
                 node.show(show_cluster=False)
-                print_("")
+                print("")
             else:
                 node.show(only_status=True)
 
@@ -525,7 +523,7 @@ class Cluster(object):
     def stress(self, stress_options):
         livenodes = [node.network_interfaces['storage'][0] for node in list(self.nodes.values()) if node.is_live()]
         if len(livenodes) == 0:
-            print_("No live node")
+            print("No live node")
             return
         self.nodelist()[0].stress(stress_options=stress_options + ['-node', ','.join(livenodes)] )
         return self
@@ -539,7 +537,7 @@ class Cluster(object):
 
     def set_configuration_options(self, values=None, batch_commitlog=None):
         if values is not None:
-            for k, v in iteritems(values):
+            for k, v in values.items():
                 self._config_options[k] = v
         if batch_commitlog is not None:
             if batch_commitlog:

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -118,7 +118,7 @@ class Cluster(object):
             node.import_config_files()
 
         # if any nodes have a data center, let's update the topology
-        if any([node.data_center for node in self.nodes.values()]):
+        if any([node.data_center for node in list(self.nodes.values())]):
             self.__update_topology_files()
 
         return self
@@ -216,7 +216,7 @@ class Cluster(object):
         return False
 
     def nodelist(self):
-        return [self.nodes[name] for name in self.nodes.keys()]
+        return [self.nodes[name] for name in list(self.nodes.keys())]
 
     def version(self):
         return self.__version
@@ -263,13 +263,13 @@ class Cluster(object):
             for c in nodes:
                 i = i + 1
                 node_count = node_count + c
-                for x in xrange(0, c):
+                for x in range(0, c):
                     dcs.append('dc%d' % i)
 
         if node_count < 1:
             raise common.ArgumentError('invalid node count %s' % nodes)
 
-        for i in xrange(1, node_count + 1):
+        for i in range(1, node_count + 1):
             if 'node%s' % i in list(self.nodes.values()):
                 raise common.ArgumentError('Cannot create existing node node%s' % i)
 
@@ -279,7 +279,7 @@ class Cluster(object):
             else:
                 tokens = self.balanced_tokens_across_dcs(dcs)
 
-        for i in xrange(1, node_count + 1):
+        for i in range(1, node_count + 1):
             tk = None
             if tokens is not None and i - 1 < len(tokens):
                 tk = tokens[i - 1]
@@ -314,7 +314,7 @@ class Cluster(object):
     def get_ipformat(self):
         return self.ipformat if self.ipformat is not None else '{}%d'.format(self.get_ipprefix())
 
-    def get_node_ip(self,nodeid):
+    def get_node_ip(self, nodeid):
         return self.get_ipformat() % nodeid
 
     def get_binary_interface(self, nodeid):
@@ -326,7 +326,7 @@ class Cluster(object):
     def get_storage_interface(self, nodeid):
         return (self.get_node_ip(nodeid), 7000)
 
-    def get_node_jmx_port(self,nodeid):
+    def get_node_jmx_port(self, nodeid):
         return 7000 + nodeid * 100 + self.id;
 
     def get_debug_port(self, nodeid):
@@ -334,7 +334,7 @@ class Cluster(object):
 
     def balanced_tokens(self, node_count):
         if parse_version(self.version()) >= parse_version('1.2') and not self.partitioner:
-            ptokens = [(i * (2 ** 64 // node_count)) for i in xrange(0, node_count)]
+            ptokens = [(i * (2 ** 64 // node_count)) for i in range(0, node_count)]
             return [int(t - 2 ** 63) for t in ptokens]
         return [int(i * (2 ** 127 // node_count)) for i in range(0, node_count)]
 
@@ -585,7 +585,7 @@ class Cluster(object):
         self.nodetool("removeToken " + str(token))
 
     def bulkload(self, options):
-        livenodes = [node for node in self.nodes.values() if node.is_live()]
+        livenodes = [node for node in list(self.nodes.values()) if node.is_live()]
         if not livenodes:
             raise common.ArgumentError("No live node")
         random.choice(livenodes).bulkload(options)

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -79,7 +79,7 @@ class Cluster(object):
             if create_directory:
                 common.rmdirs(self.get_path())
             raise
-        self.debug("Started cluster '{}' version {} installed in {}".format(self.name, self.__version, self.__install_dir))
+        self.debug(f"Started cluster '{self.name}' version {self.__version} installed in {self.__install_dir}")
 
     def load_from_repository(self, version, verbose):
         return repository.setup(version, verbose)
@@ -226,7 +226,7 @@ class Cluster(object):
 
     def add(self, node, is_seed, data_center=None):
         if node.name in self.nodes:
-            raise common.ArgumentError('Cannot create existing node %s' % node.name)
+            raise common.ArgumentError(f'Cannot create existing node {node.name}')
         self.nodes[node.name] = node
         if is_seed:
             self.seeds.append(node)
@@ -267,11 +267,11 @@ class Cluster(object):
                     dcs.append('dc%d' % i)
 
         if node_count < 1:
-            raise common.ArgumentError('invalid node count %s' % nodes)
+            raise common.ArgumentError(f'invalid node count {nodes}')
 
         for i in range(1, node_count + 1):
-            if 'node%s' % i in list(self.nodes.values()):
-                raise common.ArgumentError('Cannot create existing node node%s' % i)
+            if f'node{i}' in list(self.nodes.values()):
+                raise common.ArgumentError(f'Cannot create existing node node{i}')
 
         if tokens is None and not use_vnodes:
             if dcs is None or len(dcs) <= 1:
@@ -293,7 +293,7 @@ class Cluster(object):
         binary = None
         if parse_version(self.version()) >= parse_version('1.2'):
             binary = self.get_binary_interface(i)
-        node = self.create_node(name='node{}'.format(i),
+        node = self.create_node(name=f'node{i}',
                                 auto_bootstrap=auto_bootstrap,
                                 thrift_interface=self.get_thrift_interface(i),
                                 storage_interface=self.get_storage_interface(i),
@@ -312,7 +312,7 @@ class Cluster(object):
         return self.ipprefix if self.ipprefix is not None else '127.0.0.'
 
     def get_ipformat(self):
-        return self.ipformat if self.ipformat is not None else '{}%d'.format(self.get_ipprefix())
+        return self.ipformat if self.ipformat is not None else f'{self.get_ipprefix()}%d'
 
     def get_node_ip(self, nodeid):
         return self.get_ipformat() % nodeid
@@ -408,7 +408,7 @@ class Cluster(object):
         return [s.network_interfaces['storage'][0] for s in self.seeds[:seed_index + 1]]
 
     def show(self, verbose):
-        msg = "Cluster: '%s'" % self.name
+        msg = f"Cluster: '{self.name}'"
         print_(msg)
         print_('-' * len(msg))
         if len(list(self.nodes.values())) == 0:
@@ -454,7 +454,7 @@ class Cluster(object):
 
         for node, p, _ in started:
             if not node.is_running():
-                raise NodeError("Error starting {0}.".format(node.name), p)
+                raise NodeError(f"Error starting {node.name}.", p)
 
         if not no_wait and parse_version(self.version()) >= parse_version("0.8"):
             # 0.7 gossip messages seems less predictible that from 0.8 onwards and
@@ -487,17 +487,17 @@ class Cluster(object):
         class_names = class_names or []
         known_level = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'OFF']
         if new_level not in known_level:
-            raise common.ArgumentError("Unknown log level %s (use one of %s)" % (new_level, " ".join(known_level)))
+            raise common.ArgumentError(f"Unknown log level {new_level} (use one of {' '.join(known_level)})")
 
         if class_names:
             for class_name in class_names:
                 if new_level == 'DEBUG':
                     if class_name in self._trace:
-                        raise common.ArgumentError("Class %s already in TRACE" % (class_name))
+                        raise common.ArgumentError(f"Class {class_name} already in TRACE")
                     self._debug.append(class_name)
                 if new_level == 'TRACE':
                     if class_name in self._debug:
-                        raise common.ArgumentError("Class %s already in DEBUG" % (class_name))
+                        raise common.ArgumentError(f"Class {class_name} already in DEBUG")
                     self._trace.append(class_name)
         else:
             self.__log_level = new_level
@@ -655,7 +655,7 @@ class Cluster(object):
 
         content = ""
         for k, v in dcs:
-            content = "%s%s=%s:r1\n" % (content, k, v)
+            content = f"{content}{k}={v}:r1\n"
 
         for node in self.nodelist():
             topology_file = os.path.join(node.get_conf_dir(), 'cassandra-topology.properties')
@@ -669,7 +669,7 @@ class Cluster(object):
                 dc = node.data_center
             rackdc_file = os.path.join(node.get_conf_dir(), 'cassandra-rackdc.properties')
             with open(rackdc_file, 'w') as f:
-                f.write("dc=%s\n" % dc)
+                f.write(f"dc={dc}\n")
                 f.write("rack=RAC1\n")
 
     def enable_ssl(self, ssl_path, require_client_auth):

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -3,7 +3,6 @@ import subprocess
 import sys
 import tempfile
 
-from six import print_
 
 from ccmlib import common, repository
 from ccmlib.cluster import Cluster
@@ -174,7 +173,7 @@ class ClusterCreateCmd(Cmd):
             parser.error(f"{parser.get_option('-i')} and {parser.get_option('-I')} may not be used together")
         self.nodes = parse_populate_count(options.nodes)
         if self.options.vnodes and self.nodes is None:
-            print_("Can't set --vnodes if not populating cluster in this command.")
+            print("Can't set --vnodes if not populating cluster in this command.")
             parser.print_help()
             sys.exit(1)
         if self.options.snitch and \
@@ -193,7 +192,7 @@ class ClusterCreateCmd(Cmd):
 
             common.assert_jdk_valid_for_cassandra_version(common.get_version_from_build(options.install_dir))
         if common.is_win() and os.path.exists(r'c:\windows\system32\java.exe'):
-            print_(r"""WARN: c:\windows\system32\java.exe exists.
+            print(r"""WARN: c:\windows\system32\java.exe exists.
                 This may cause registry issues, and jre7 to be used, despite jdk8 being installed.
                 """)
 
@@ -228,7 +227,7 @@ class ClusterCreateCmd(Cmd):
                 cluster = Cluster(self.path, self.name, install_dir=self.options.install_dir, version=self.options.version, verbose=True)
         except OSError as e:
             import traceback
-            print_(f'Cannot create cluster: {str(e)}\n{traceback.format_exc()}', file=sys.stderr)
+            print(f'Cannot create cluster: {str(e)}\n{traceback.format_exc()}', file=sys.stderr)
             sys.exit(1)
 
         if self.options.partitioner:
@@ -252,7 +251,7 @@ class ClusterCreateCmd(Cmd):
 
         if not self.options.no_switch:
             common.switch_cluster(self.path, self.name)
-            print_(f'Current cluster is now: {self.name}')
+            print(f'Current cluster is now: {self.name}')
 
         if not (self.options.ipprefix or self.options.ipformat):
             self.options.ipformat = '127.0.0.%d'
@@ -280,9 +279,9 @@ class ClusterCreateCmd(Cmd):
                         details = ""
                         if not self.options.debug_log:
                             details = " (you can use --debug-log for more information)"
-                        print_(f"Error starting nodes, see above for details{details}", file=sys.stderr)
+                        print(f"Error starting nodes, see above for details{details}", file=sys.stderr)
             except common.ArgumentError as e:
-                print_(str(e), file=sys.stderr)
+                print(str(e), file=sys.stderr)
                 sys.exit(1)
 
 
@@ -338,7 +337,7 @@ class ClusterAddCmd(Cmd):
         self.binary = common.parse_interface(options.binary_itf, 9042)
 
         if self.binary[0] != self.thrift[0]:
-            print_('Cannot set a binary address different from the thrift one', file=sys.stderr)
+            print('Cannot set a binary address different from the thrift one', file=sys.stderr)
             sys.exit(1)
 
         used_binary_ips = [node.network_interfaces['binary'][0] for node in self.cluster.nodelist()]
@@ -346,7 +345,7 @@ class ClusterAddCmd(Cmd):
         used_storage_ips = [node.network_interfaces['storage'][0] for node in self.cluster.nodelist()]
 
         if self.binary[0] in used_binary_ips or self.thrift[0] in used_thrift_ips or self.storage[0] in used_storage_ips:
-            print_("One of the ips is already in use choose another.", file=sys.stderr)
+            print("One of the ips is already in use choose another.", file=sys.stderr)
             parser.print_help()
             sys.exit(1)
 
@@ -355,7 +354,7 @@ class ClusterAddCmd(Cmd):
 
         used_jmx_ports = [node.jmx_port for node in self.cluster.nodelist()]
         if options.jmx_port in used_jmx_ports:
-            print_("This JMX port is already in use. Choose another.", file=sys.stderr)
+            print("This JMX port is already in use. Choose another.", file=sys.stderr)
             parser.print_help()
             sys.exit(1)
 
@@ -377,7 +376,7 @@ class ClusterAddCmd(Cmd):
                 node = Node(self.name, self.cluster, self.options.bootstrap, self.thrift, self.storage, self.jmx_port, self.remote_debug_port, self.initial_token, binary_interface=self.binary)
             self.cluster.add(node, self.options.is_seed, self.options.data_center)
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             sys.exit(1)
 
 
@@ -423,7 +422,7 @@ class ClusterPopulateCmd(Cmd):
 
             self.cluster.populate(self.nodes, self.options.debug, use_vnodes=self.options.vnodes, ipprefix=self.options.ipprefix, ipformat=self.options.ipformat)
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             sys.exit(1)
 
 
@@ -447,7 +446,7 @@ class ClusterListCmd(Cmd):
 
         for dir in os.listdir(self.path):
             if os.path.exists(os.path.join(self.path, dir, 'cluster.conf')):
-                print_(f" {'*' if current == dir else ' '}{dir}")
+                print(f" {'*' if current == dir else ' '}{dir}")
 
 
 class ClusterSwitchCmd(Cmd):
@@ -462,7 +461,7 @@ class ClusterSwitchCmd(Cmd):
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, cluster_name=True)
         if not os.path.exists(os.path.join(self.path, self.name, 'cluster.conf')):
-            print_(f"{self.name} does not appear to be a valid cluster (use ccm list to view valid clusters)", file=sys.stderr)
+            print(f"{self.name} does not appear to be a valid cluster (use ccm list to view valid clusters)", file=sys.stderr)
             sys.exit(1)
 
     def run(self):
@@ -506,7 +505,7 @@ class ClusterRemoveCmd(Cmd):
             self.other_cluster = args[0]
             if not os.path.exists(os.path.join(
                     self.path, self.other_cluster, 'cluster.conf')):
-                print_("%s does not appear to be a valid cluster"
+                print("%s does not appear to be a valid cluster"
                        " (use ccm list to view valid clusters)"
                        % self.other_cluster, file=sys.stderr)
                 sys.exit(1)
@@ -560,7 +559,7 @@ class ClusterLivesetCmd(Cmd):
 
     def run(self):
         storage_interfaces = [node.network_interfaces['storage'][0] for node in list(self.cluster.nodes.values()) if node.is_live()]
-        print_(",".join(storage_interfaces))
+        print(",".join(storage_interfaces))
 
 
 class ClusterSetdirCmd(Cmd):
@@ -588,11 +587,11 @@ class ClusterSetdirCmd(Cmd):
             if self.options.node:
                 target = self.cluster.nodes.get(self.options.node)
                 if not target:
-                    print_(f"Node not found: {self.options.node}")
+                    print(f"Node not found: {self.options.node}")
                     return
             target.set_install_dir(install_dir=self.options.install_dir, version=self.options.version, verbose=True)
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             sys.exit(1)
 
 
@@ -655,7 +654,7 @@ class ClusterStartCmd(Cmd):
                     profile_options['options'] = self.options.profile_options
 
             if len(self.cluster.nodes) == 0:
-                print_("No node in this cluster yet. Use the populate command before starting.")
+                print("No node in this cluster yet. Use the populate command before starting.")
                 sys.exit(1)
 
             ssl_port = self.cluster._config_options.get('native_transport_port_ssl', 9142)
@@ -694,7 +693,7 @@ class ClusterStartCmd(Cmd):
                 details = ""
                 if not self.options.verbose:
                     details = " (you can use --verbose for more information)"
-                print_(f"Error starting nodes, see above for details{details}", file=sys.stderr)
+                print(f"Error starting nodes, see above for details{details}", file=sys.stderr)
                 sys.exit(1)
             if self.options.sni_proxy:
                 nodes_info = get_cluster_info(self.cluster, port=ssl_port)
@@ -717,12 +716,12 @@ class ClusterStartCmd(Cmd):
                     self.cluster._update_config()
 
         except NodeError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             if e.process is not None:
                 if e.process.stderr is not None:
-                    print_("Standard error output is:", file=sys.stderr)
+                    print("Standard error output is:", file=sys.stderr)
                     for line in e.process.stderr:
-                        print_(line.rstrip('\n'), file=sys.stderr)
+                        print(line.rstrip('\n'), file=sys.stderr)
             sys.exit(1)
 
 
@@ -754,9 +753,9 @@ class ClusterStopCmd(Cmd):
                 sys.stdout.write("The following nodes were not running: ")
                 for node in not_running:
                     sys.stdout.write(node.name + " ")
-                print_("")
+                print("")
         except NodeError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             sys.exit(1)
 
 
@@ -812,7 +811,7 @@ class ClusterStressCmd(Cmd):
         try:
             self.cluster.stress(self.stress_options)
         except Exception as e:
-            print_(e, file=sys.stderr)
+            print(e, file=sys.stderr)
 
 
 class ClusterUpdateconfCmd(Cmd):
@@ -836,7 +835,7 @@ class ClusterUpdateconfCmd(Cmd):
         try:
             self.setting = common.parse_settings(args)
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             sys.exit(1)
 
     def run(self):
@@ -870,7 +869,7 @@ class ClusterUpdatedseconfCmd(Cmd):
         try:
             self.setting = common.parse_settings(args)
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             sys.exit(1)
 
     def run(self):
@@ -902,17 +901,17 @@ class ClusterUpdatelog4jCmd(Cmd):
             if self.log4jpath is None:
                 raise KeyError("[Errno] -p or --path <path of new log4j congiguration file> is not provided")
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             sys.exit(1)
         except KeyError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             sys.exit(1)
 
     def run(self):
         try:
             self.cluster.update_log4j(self.log4jpath)
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             sys.exit(1)
 
 
@@ -1007,7 +1006,7 @@ class ClusterSetlogCmd(Cmd):
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, load_cluster=True)
         if len(args) == 0:
-            print_('Missing log level', file=sys.stderr)
+            print('Missing log level', file=sys.stderr)
             parser.print_help()
             sys.exit(1)
         self.level = args[0]
@@ -1016,7 +1015,7 @@ class ClusterSetlogCmd(Cmd):
         try:
             self.cluster.set_log_level(self.level, self.options.class_name)
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             sys.exit(1)
 
 
@@ -1037,8 +1036,8 @@ class ClusterInvalidatecacheCmd(Cmd):
         try:
             common.invalidate_cache()
         except Exception as e:
-            print_(str(e), file=sys.stderr)
-            print_("Error while deleting cache. Please attempt manually.")
+            print(str(e), file=sys.stderr)
+            print("Error while deleting cache. Please attempt manually.")
             sys.exit(1)
 
 
@@ -1060,7 +1059,7 @@ class ClusterChecklogerrorCmd(Cmd):
             errors = node.grep_log_for_errors()
             for mylist in errors:
                 for line in mylist:
-                    print_(line)
+                    print(line)
 
 
 class ClusterShowlastlogCmd(Cmd):
@@ -1098,7 +1097,7 @@ class ClusterJconsoleCmd(Cmd):
         try:
             subprocess.call(cmds, stderr=sys.stderr)
         except OSError:
-            print_("Could not start jconsole. Please make sure jconsole can be found in your $PATH.")
+            print("Could not start jconsole. Please make sure jconsole can be found in your $PATH.")
             sys.exit(1)
 
 class ClusterSctoolCmd(Cmd):
@@ -1120,5 +1119,5 @@ class ClusterSctoolCmd(Cmd):
 
     def run(self):
         stdout, stderr = self.cluster.sctool(self.sctool_options)
-        print_(stderr)
-        print_(stdout)
+        print(stderr)
+        print(stdout)

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -171,7 +171,7 @@ class ClusterCreateCmd(Cmd):
         Cmd.validate(self, parser, options, args, cluster_name=True)
         if options.ipprefix and options.ipformat:
             parser.print_help()
-            parser.error("%s and %s may not be used together" % (parser.get_option('-i'), parser.get_option('-I')))
+            parser.error(f"{parser.get_option('-i')} and {parser.get_option('-I')} may not be used together")
         self.nodes = parse_populate_count(options.nodes)
         if self.options.vnodes and self.nodes is None:
             print_("Can't set --vnodes if not populating cluster in this command.")
@@ -189,7 +189,7 @@ class ClusterCreateCmd(Cmd):
                 common.validate_install_dir(options.install_dir)
             except ArgumentError:
                 parser.print_help()
-                parser.error("%s is not a valid cassandra directory. You must define a cassandra dir or version." % options.install_dir)
+                parser.error(f"{options.install_dir} is not a valid cassandra directory. You must define a cassandra dir or version.")
 
             common.assert_jdk_valid_for_cassandra_version(common.get_version_from_build(options.install_dir))
         if common.is_win() and os.path.exists(r'c:\windows\system32\java.exe'):
@@ -228,7 +228,7 @@ class ClusterCreateCmd(Cmd):
                 cluster = Cluster(self.path, self.name, install_dir=self.options.install_dir, version=self.options.version, verbose=True)
         except OSError as e:
             import traceback
-            print_('Cannot create cluster: %s\n%s' % (str(e), traceback.format_exc()), file=sys.stderr)
+            print_(f'Cannot create cluster: {str(e)}\n{traceback.format_exc()}', file=sys.stderr)
             sys.exit(1)
 
         if self.options.partitioner:
@@ -252,7 +252,7 @@ class ClusterCreateCmd(Cmd):
 
         if not self.options.no_switch:
             common.switch_cluster(self.path, self.name)
-            print_('Current cluster is now: %s' % self.name)
+            print_(f'Current cluster is now: {self.name}')
 
         if not (self.options.ipprefix or self.options.ipformat):
             self.options.ipformat = '127.0.0.%d'
@@ -280,7 +280,7 @@ class ClusterCreateCmd(Cmd):
                         details = ""
                         if not self.options.debug_log:
                             details = " (you can use --debug-log for more information)"
-                        print_("Error starting nodes, see above for details%s" % details, file=sys.stderr)
+                        print_(f"Error starting nodes, see above for details{details}", file=sys.stderr)
             except common.ArgumentError as e:
                 print_(str(e), file=sys.stderr)
                 sys.exit(1)
@@ -405,7 +405,7 @@ class ClusterPopulateCmd(Cmd):
         Cmd.validate(self, parser, options, args, load_cluster=True)
         if options.ipprefix and options.ipformat:
             parser.print_help()
-            parser.error("%s and %s may not be used together" % (parser.get_option('-i'), parser.get_option('-I')))
+            parser.error(f"{parser.get_option('-i')} and {parser.get_option('-I')} may not be used together")
 
         self.nodes = parse_populate_count(options.nodes)
         if self.nodes is None:
@@ -447,7 +447,7 @@ class ClusterListCmd(Cmd):
 
         for dir in os.listdir(self.path):
             if os.path.exists(os.path.join(self.path, dir, 'cluster.conf')):
-                print_(" %s%s" % ('*' if current == dir else ' ', dir))
+                print_(f" {'*' if current == dir else ' '}{dir}")
 
 
 class ClusterSwitchCmd(Cmd):
@@ -462,7 +462,7 @@ class ClusterSwitchCmd(Cmd):
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, cluster_name=True)
         if not os.path.exists(os.path.join(self.path, self.name, 'cluster.conf')):
-            print_("%s does not appear to be a valid cluster (use ccm list to view valid clusters)" % self.name, file=sys.stderr)
+            print_(f"{self.name} does not appear to be a valid cluster (use ccm list to view valid clusters)", file=sys.stderr)
             sys.exit(1)
 
     def run(self):
@@ -588,7 +588,7 @@ class ClusterSetdirCmd(Cmd):
             if self.options.node:
                 target = self.cluster.nodes.get(self.options.node)
                 if not target:
-                    print_("Node not found: %s" % self.options.node)
+                    print_(f"Node not found: {self.options.node}")
                     return
             target.set_install_dir(install_dir=self.options.install_dir, version=self.options.version, verbose=True)
         except common.ArgumentError as e:
@@ -694,7 +694,7 @@ class ClusterStartCmd(Cmd):
                 details = ""
                 if not self.options.verbose:
                     details = " (you can use --verbose for more information)"
-                print_("Error starting nodes, see above for details%s" % details, file=sys.stderr)
+                print_(f"Error starting nodes, see above for details{details}", file=sys.stderr)
                 sys.exit(1)
             if self.options.sni_proxy:
                 nodes_info = get_cluster_info(self.cluster, port=ssl_port)
@@ -711,7 +711,7 @@ class ClusterStartCmd(Cmd):
                         start_sni_proxy(self.cluster.get_path(), nodes_info=nodes_info, listen_port=self.options.sni_port)
                     create_cloud_config(self.cluster.get_path(), port=listen_port, address=listen_address, nodes_info=nodes_info)
 
-                    print(('sni_proxy listening on: {}:{}'.format(listen_address, listen_port)))
+                    print(f'sni_proxy listening on: {listen_address}:{listen_port}')
                     self.cluster.sni_proxy_docker_id = docker_id
                     self.cluster.sni_proxy_listen_port = listen_port
                     self.cluster._update_config()
@@ -1094,7 +1094,7 @@ class ClusterJconsoleCmd(Cmd):
         Cmd.validate(self, parser, options, args, load_cluster=True)
 
     def run(self):
-        cmds = ["jconsole"] + ["localhost:%s" % node.jmx_port for node in list(self.cluster.nodes.values())]
+        cmds = ["jconsole"] + [f"localhost:{node.jmx_port}" for node in list(self.cluster.nodes.values())]
         try:
             subprocess.call(cmds, stderr=sys.stderr)
         except OSError:

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -17,7 +17,7 @@ from ccmlib.scylla_node import ScyllaNode
 from ccmlib.dse_node import DseNode
 from ccmlib.node import Node, NodeError
 from ccmlib.utils.ssl_utils import generate_ssl_stores
-from ccmlib.utils.sni_proxy import get_cluster_info, start_sni_proxy, configure_sni_proxy, reload_sni_proxy,refresh_certs, create_cloud_config
+from ccmlib.utils.sni_proxy import get_cluster_info, start_sni_proxy, configure_sni_proxy, reload_sni_proxy, refresh_certs, create_cloud_config
 
 os.environ['SCYLLA_CCM_STANDALONE'] = '1'
 
@@ -711,7 +711,7 @@ class ClusterStartCmd(Cmd):
                         start_sni_proxy(self.cluster.get_path(), nodes_info=nodes_info, listen_port=self.options.sni_port)
                     create_cloud_config(self.cluster.get_path(), port=listen_port, address=listen_address, nodes_info=nodes_info)
 
-                    print('sni_proxy listening on: {}:{}'.format(listen_address, listen_port))
+                    print(('sni_proxy listening on: {}:{}'.format(listen_address, listen_port)))
                     self.cluster.sni_proxy_docker_id = docker_id
                     self.cluster.sni_proxy_listen_port = listen_port
                     self.cluster._update_config()
@@ -1094,7 +1094,7 @@ class ClusterJconsoleCmd(Cmd):
         Cmd.validate(self, parser, options, args, load_cluster=True)
 
     def run(self):
-        cmds = ["jconsole"] + ["localhost:%s" % node.jmx_port for node in self.cluster.nodes.values()]
+        cmds = ["jconsole"] + ["localhost:%s" % node.jmx_port for node in list(self.cluster.nodes.values())]
         try:
             subprocess.call(cmds, stderr=sys.stderr)
         except OSError:
@@ -1111,7 +1111,7 @@ class ClusterSctoolCmd(Cmd):
 
     def get_parser(self):
         usage = "usage: ccm sctool [options]"
-        parser = self._get_default_parser(usage, self.description(),ignore_unknown_options=True)
+        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
         return parser
 
     def validate(self, parser, options, args):

--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -80,7 +80,7 @@ class Cmd(object):
                 try:
                     self.node = self.cluster.nodes[self.name]
                 except KeyError:
-                    print_('Unknown node %s in cluster %s' % (self.name, self.cluster.name), file=sys.stderr)
+                    print_(f'Unknown node {self.name} in cluster {self.cluster.name}', file=sys.stderr)
                     exit(1)
 
     def run(self):
@@ -92,7 +92,7 @@ class Cmd(object):
         else:
             parser = OptionParser(usage=usage, description=description, formatter=formatter)
         parser.add_option('--config-dir', type="string", dest="config_dir",
-                          help="Directory for the cluster files [default to {0}]".format(common.get_default_path_display_name()))
+                          help=f"Directory for the cluster files [default to {common.get_default_path_display_name()}]")
         return parser
 
     def description(self):

--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -1,7 +1,6 @@
 import sys
 from optparse import BadOptionError, Option, OptionParser, IndentedHelpFormatter
 
-from six import print_
 
 from ccmlib import common
 from ccmlib.cluster_factory import ClusterFactory
@@ -61,13 +60,13 @@ class Cmd(object):
 
         if cluster_name:
             if len(args) == 0:
-                print_('Missing cluster name', file=sys.stderr)
+                print('Missing cluster name', file=sys.stderr)
                 parser.print_help()
                 exit(1)
             self.name = args[0]
         if node_name:
             if len(args) == 0:
-                print_('Missing node name', file=sys.stderr)
+                print('Missing node name', file=sys.stderr)
                 parser.print_help()
                 exit(1)
             self.name = args[0]
@@ -80,7 +79,7 @@ class Cmd(object):
                 try:
                     self.node = self.cluster.nodes[self.name]
                 except KeyError:
-                    print_(f'Unknown node {self.name} in cluster {self.cluster.name}', file=sys.stderr)
+                    print(f'Unknown node {self.name} in cluster {self.cluster.name}', file=sys.stderr)
                     exit(1)
 
     def run(self):
@@ -101,10 +100,10 @@ class Cmd(object):
     def _load_current_cluster(self):
         name = common.current_cluster_name(self.path)
         if name is None:
-            print_('No currently active cluster (use ccm cluster switch)')
+            print('No currently active cluster (use ccm cluster switch)')
             exit(1)
         try:
             return ClusterFactory.load(self.path, name)
         except common.LoadError as e:
-            print_(str(e))
+            print(str(e))
             exit(1)

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -241,7 +241,7 @@ class NodeStopCmd(Cmd):
     def run(self):
         try:
             if not self.node.stop(not self.options.no_wait, gently=self.options.gently):
-                print_("%s is not running" % self.name, file=sys.stderr)
+                print_(f"{self.name} is not running", file=sys.stderr)
                 exit(1)
         except NodeError as e:
             print_(str(e), file=sys.stderr)
@@ -899,7 +899,7 @@ class NodeJconsoleCmd(Cmd):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
 
     def run(self):
-        cmds = ["jconsole", "localhost:%s" % self.node.jmx_port]
+        cmds = ["jconsole", f"localhost:{self.node.jmx_port}"]
         try:
             subprocess.call(cmds)
         except OSError:

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import sys
 
-from six import print_
 
 from ccmlib import common
 from ccmlib.cmds.command import Cmd
@@ -123,14 +122,14 @@ class NodeSetlogCmd(Cmd):
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
         if len(args) == 1:
-            print_('Missing log level', file=sys.stderr)
+            print('Missing log level', file=sys.stderr)
             parser.print_help()
         self.level = args[1]
 
         try:
             self.class_name = options.class_name
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             exit(1)
 
     def run(self):
@@ -138,7 +137,7 @@ class NodeSetlogCmd(Cmd):
             self.node.set_log_level(self.level, self.class_name)
 
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             exit(1)
 
 
@@ -212,10 +211,10 @@ class NodeStartCmd(Cmd):
                 reload_sni_proxy(self.cluster.sni_proxy_docker_id)
 
         except NodeError as e:
-            print_(str(e), file=sys.stderr)
-            print_("Standard error output is:", file=sys.stderr)
+            print(str(e), file=sys.stderr)
+            print("Standard error output is:", file=sys.stderr)
             for line in e.process.stderr:
-                print_(line.rstrip('\n'), file=sys.stderr)
+                print(line.rstrip('\n'), file=sys.stderr)
             exit(1)
 
 
@@ -241,10 +240,10 @@ class NodeStopCmd(Cmd):
     def run(self):
         try:
             if not self.node.stop(not self.options.no_wait, gently=self.options.gently):
-                print_(f"{self.name} is not running", file=sys.stderr)
+                print(f"{self.name} is not running", file=sys.stderr)
                 exit(1)
         except NodeError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             exit(1)
 
 
@@ -262,8 +261,8 @@ class _NodeToolCmd(Cmd):
 
     def run(self):
         stdout, stderr = self.node.nodetool(self.nodetool_cmd + " " + " ".join((self.args[1:])))
-        print_(stderr)
-        print_(stdout)
+        print(stderr)
+        print(stdout)
 
 
 class NodeNodetoolCmd(_NodeToolCmd):
@@ -272,8 +271,8 @@ class NodeNodetoolCmd(_NodeToolCmd):
 
     def run(self):
         stdout, stderr = self.node.nodetool(" ".join(self.args[1:]))
-        print_(stderr)
-        print_(stdout)
+        print(stderr)
+        print(stdout)
 
 
 class NodeRingCmd(_NodeToolCmd):
@@ -475,11 +474,11 @@ class NodeJsonCmd(Cmd):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
         self.keyspace = options.keyspace
         if len(args) < 2:
-            print_("You must specify an output file.")
+            print("You must specify an output file.")
             parser.print_help()
             exit(1)
         if self.keyspace is None:
-            print_("You must specify a keyspace.")
+            print("You must specify a keyspace.")
             parser.print_help()
             exit(1)
         self.outfile = args[-1]
@@ -493,7 +492,7 @@ class NodeJsonCmd(Cmd):
                                            column_families=self.column_families,
                                            enumerate_keys=self.options.enumerate_keys)
         except common.ArgumentError as e:
-            print_(e, file=sys.stderr)
+            print(e, file=sys.stderr)
 
 
 class NodeSstablesplitCmd(Cmd):
@@ -523,13 +522,13 @@ class NodeSstablesplitCmd(Cmd):
         self.datafiles = None
         if options.cfs is not None:
             if self.keyspace is None:
-                print_("You need a keyspace (option -k) if you specify column families", file=sys.stderr)
+                print("You need a keyspace (option -k) if you specify column families", file=sys.stderr)
                 exit(1)
             self.column_families = options.cfs.split(',')
 
         if len(args) > 1:
             if self.column_families is None:
-                print_("You need a column family (option -c) if you specify datafiles", file=sys.stderr)
+                print("You need a column family (option -c) if you specify datafiles", file=sys.stderr)
                 exit(1)
             self.datafiles = args[1:]
 
@@ -560,20 +559,20 @@ class NodeGetsstablesCmd(Cmd):
         self.datafiles = None
         if options.tables is not None:
             if self.keyspace is None:
-                print_("You need a keyspace (option -k) if you specify tables", file=sys.stderr)
+                print("You need a keyspace (option -k) if you specify tables", file=sys.stderr)
                 exit(1)
             self.tables = options.tables.split(',')
 
         if len(args) > 1:
             if self.tables is None:
-                print_("You need a tables (option -t) if you specify datafiles", file=sys.stderr)
+                print("You need a tables (option -t) if you specify datafiles", file=sys.stderr)
                 exit(1)
             self.datafiles = args[1:]
 
     def run(self):
         sstablefiles = self.node.get_sstablespath(datafiles=self.datafiles, keyspace=self.keyspace,
                                                   tables=self.tables)
-        print_('\n'.join(sstablefiles))
+        print('\n'.join(sstablefiles))
 
 
 class NodeUpdateconfCmd(Cmd):
@@ -598,7 +597,7 @@ class NodeUpdateconfCmd(Cmd):
         try:
             self.setting = common.parse_settings(args)
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             exit(1)
 
     def run(self):
@@ -640,17 +639,17 @@ class NodeUpdatelog4jCmd(Cmd):
             if self.log4jpath is None:
                 raise KeyError("[Errno] -p or --path <path of new log4j configuration file> is not provided")
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             exit(1)
         except KeyError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             exit(1)
 
     def run(self):
         try:
             self.node.update_log4j(self.log4jpath)
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             exit(1)
 
 
@@ -672,7 +671,7 @@ class NodeStressCmd(Cmd):
         try:
             self.node.stress(self.stress_options)
         except OSError:
-            print_("Could not find stress binary (you may need to build it)", file=sys.stderr)
+            print("Could not find stress binary (you may need to build it)", file=sys.stderr)
 
 
 class NodeShuffleCmd(Cmd):
@@ -714,7 +713,7 @@ class NodeSetdirCmd(Cmd):
         try:
             self.node.set_install_dir(install_dir=self.options.install_dir, version=self.options.version, verbose=True)
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             exit(1)
 
 
@@ -733,14 +732,14 @@ class NodeSetworkloadCmd(Cmd):
         self.workload = args[1]
         workloads = ['cassandra', 'solr', 'hadoop', 'spark', 'cfs']
         if self.workload not in workloads:
-            print_(self.workload, ' is not a valid workload')
+            print(self.workload, ' is not a valid workload')
             exit(1)
 
     def run(self):
         try:
             self.node.set_workload(workload=self.workload)
         except common.ArgumentError as e:
-            print_(str(e), file=sys.stderr)
+            print(str(e), file=sys.stderr)
             exit(1)
 
 
@@ -903,7 +902,7 @@ class NodeJconsoleCmd(Cmd):
         try:
             subprocess.call(cmds)
         except OSError:
-            print_("Could not start jconsole. Please make sure jconsole can be found in your $PATH.")
+            print("Could not start jconsole. Please make sure jconsole can be found in your $PATH.")
             exit(1)
 
 
@@ -925,9 +924,9 @@ class NodeVersionfrombuildCmd(Cmd):
         version_from_build = common.get_version_from_build(self.node.get_install_dir())
 
         if version_from_nodetool and (version_from_nodetool != version_from_build):
-            print_('nodetool reports Cassandra version {ntv}; '
+            print('nodetool reports Cassandra version {ntv}; '
                    'version from build.xml is {bv}'.format(ntv=version_from_nodetool,
                                                            bv=version_from_build),
                    file=sys.stderr)
 
-        print_(version_from_build)
+        print(version_from_build)

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -188,7 +188,7 @@ def replaces_or_add_into_file_tail(file, replacement_list):
 def rmdirs(path):
     if is_win():
         # Handle Windows 255 char limit
-        shutil.rmtree(u"\\\\?\\" + path, ignore_errors=True)
+        shutil.rmtree("\\\\?\\" + path, ignore_errors=True)
     else:
         shutil.rmtree(path, ignore_errors=True)
 
@@ -204,7 +204,7 @@ def make_cassandra_env(install_dir, node_path, update_conf=True):
     if not update_conf and not os.path.exists(dst):
         time.sleep(1)
         if not os.path.exists(dst):
-            print("Warning: make_cassandra_env: install_dir={} node_path={} missing {}. Recreating...".format(install_dir, node_path, dst))
+            print(("Warning: make_cassandra_env: install_dir={} node_path={} missing {}. Recreating...".format(install_dir, node_path, dst)))
 
     if not os.path.exists(dst):
         replacements = ""

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -14,14 +14,13 @@ import sys
 import time
 import tempfile
 import logging
+from itertools import zip_longest
 from typing import Callable
 
 import yaml
 from boto3.session import Session
 from botocore import UNSIGNED
 from botocore.client import Config
-from six import print_
-from six.moves import zip_longest
 
 BIN_DIR = "bin"
 CASSANDRA_CONF_DIR = "conf"
@@ -291,7 +290,7 @@ def is_ps_unrestricted():
             p = subprocess.Popen(['powershell', 'Get-ExecutionPolicy'], stdout=subprocess.PIPE)
         # pylint: disable=E0602
         except WindowsError:
-            print_("ERROR: Could not find powershell. Is it in your path?")
+            print("ERROR: Could not find powershell. Is it in your path?")
         if "Unrestricted" in p.communicate()[0]:
             return True
         else:
@@ -514,7 +513,7 @@ def wait_for(func: Callable, timeout: int, first: float = 0.0, step: float = 1.0
 
     while time.time() < end_time:
         if text:
-            print_(f"{text} ({time.time() - start_time:f} secs)")
+            print(f"{text} ({time.time() - start_time:f} secs)")
         if func():
             return True
         time.sleep(step)
@@ -655,7 +654,7 @@ def copy_file(src_file, dst_file):
     try:
         shutil.copy2(src_file, dst_file)
     except (IOError, shutil.Error) as e:
-        print_(str(e), file=sys.stderr)
+        print(str(e), file=sys.stderr)
         exit(1)
 
 
@@ -789,7 +788,7 @@ def get_jdk_version():
 
 def assert_jdk_valid_for_cassandra_version(cassandra_version):
     if cassandra_version >= '3.0' and get_jdk_version() < '1.8':
-        print_(f'ERROR: Cassandra 3.0+ requires Java >= 1.8, found Java {get_jdk_version()}')
+        print(f'ERROR: Cassandra 3.0+ requires Java >= 1.8, found Java {get_jdk_version()}')
         exit(1)
 
 
@@ -822,6 +821,6 @@ def grouper(n, iterable, padvalue=None):
 def print_if_standalone(*args, debug_callback=None, end='\n', **kwargs):
     standalone = os.environ.get('SCYLLA_CCM_STANDALONE', None)
     if standalone:
-        print_(*args, *kwargs, end=end)
+        print(*args, *kwargs, end=end)
     else:
         debug_callback(*args, **kwargs)

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -204,20 +204,20 @@ def make_cassandra_env(install_dir, node_path, update_conf=True):
     if not update_conf and not os.path.exists(dst):
         time.sleep(1)
         if not os.path.exists(dst):
-            print(("Warning: make_cassandra_env: install_dir={} node_path={} missing {}. Recreating...".format(install_dir, node_path, dst)))
+            print(f"Warning: make_cassandra_env: install_dir={install_dir} node_path={node_path} missing {dst}. Recreating...")
 
     if not os.path.exists(dst):
         replacements = ""
         if is_win() and get_version_from_build(node_path=node_path) >= '2.1':
             replacements = [
-                ('env:CASSANDRA_HOME =', '        $env:CASSANDRA_HOME="%s"' % install_dir),
+                ('env:CASSANDRA_HOME =', f'        $env:CASSANDRA_HOME="{install_dir}"'),
                 ('env:CASSANDRA_CONF =', '    $env:CCM_DIR="' + node_path + '\\conf"\n    $env:CASSANDRA_CONF="$env:CCM_DIR"'),
                 ('cp = ".*?env:CASSANDRA_HOME.conf', '    $cp = """$env:CASSANDRA_CONF"""')
             ]
         else:
             replacements = [
-                ('CASSANDRA_HOME=', '\tCASSANDRA_HOME=%s' % install_dir),
-                ('CASSANDRA_CONF=', '\tCASSANDRA_CONF=%s' % os.path.join(node_path, 'conf'))
+                ('CASSANDRA_HOME=', f'\tCASSANDRA_HOME={install_dir}'),
+                ('CASSANDRA_CONF=', f"\tCASSANDRA_CONF={os.path.join(node_path, 'conf')}")
             ]
         (fd, tmp) = tempfile.mkstemp(dir=node_path)
         replaces_in_files(orig, tmp, replacements)
@@ -401,7 +401,7 @@ def get_stress_bin(install_dir):
             else:
                 os.chmod(stress, os.stat(stress).st_mode | stat.S_IXUSR)
         except:
-            raise Exception("stress binary is not executable: %s" % (stress,))
+            raise Exception(f"stress binary is not executable: {stress}")
 
     return stress
 
@@ -413,7 +413,7 @@ def isDse(install_dir):
     bin_dir = os.path.join(install_dir, BIN_DIR)
 
     if not os.path.exists(bin_dir):
-        raise ArgumentError('Installation directory does not contain a bin directory: %s' % install_dir)
+        raise ArgumentError(f'Installation directory does not contain a bin directory: {install_dir}')
 
     dse_script = os.path.join(bin_dir, 'dse')
     return os.path.exists(dse_script)
@@ -514,7 +514,7 @@ def wait_for(func: Callable, timeout: int, first: float = 0.0, step: float = 1.0
 
     while time.time() < end_time:
         if text:
-            print_("%s (%f secs)" % (text, (time.time() - start_time)))
+            print_(f"{text} ({time.time() - start_time:f} secs)")
         if func():
             return True
         time.sleep(step)
@@ -538,7 +538,7 @@ def validate_install_dir(install_dir):
     # Windows requires absolute pathing on installation dir - abort if specified cygwin style
     if is_win():
         if ':' not in install_dir:
-            raise ArgumentError('%s does not appear to be a cassandra or dse installation directory.  Please use absolute pathing (e.g. C:/cassandra.' % install_dir)
+            raise ArgumentError(f'{install_dir} does not appear to be a cassandra or dse installation directory.  Please use absolute pathing (e.g. C:/cassandra.')
 
     bin_dir = os.path.join(install_dir, BIN_DIR)
     if isScylla(install_dir):
@@ -558,7 +558,7 @@ def validate_install_dir(install_dir):
     elif not isOpscenter(install_dir):
         cnd = cnd and os.path.exists(os.path.join(conf_dir, CASSANDRA_CONF))
     if not cnd:
-        raise ArgumentError('%s does not appear to be a cassandra or dse installation directory' % install_dir)
+        raise ArgumentError(f'{install_dir} does not appear to be a cassandra or dse installation directory')
 
 
 def check_socket_available(itf):
@@ -576,7 +576,7 @@ def check_socket_available(itf):
     except socket.error as msg:
         s.close()
         addr, port = itf
-        raise UnavailableSocketError("Inet address %s:%s is not available: %s" % (addr, port, msg))
+        raise UnavailableSocketError(f"Inet address {addr}:{port} is not available: {msg}")
 
 
 def check_socket_listening(itf, timeout=60):
@@ -789,7 +789,7 @@ def get_jdk_version():
 
 def assert_jdk_valid_for_cassandra_version(cassandra_version):
     if cassandra_version >= '3.0' and get_jdk_version() < '1.8':
-        print_('ERROR: Cassandra 3.0+ requires Java >= 1.8, found Java {}'.format(get_jdk_version()))
+        print_(f'ERROR: Cassandra 3.0+ requires Java >= 1.8, found Java {get_jdk_version()}')
         exit(1)
 
 

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -85,8 +85,8 @@ class DseCluster(Cluster):
                 seed_jmx = seed.jmx_port
                 with open(os.path.join(cluster_conf, self.name + '.conf'), 'w+') as f:
                     f.write('[jmx]\n')
-                    f.write('port = %s\n' % seed_jmx)
+                    f.write(f'port = {seed_jmx}\n')
                     f.write('[cassandra]\n')
-                    f.write('seed_hosts = %s\n' % seed_ip)
-                    f.write('api_port = %s\n' % seed_port)
+                    f.write(f'seed_hosts = {seed_ip}\n')
+                    f.write(f'api_port = {seed_port}\n')
                     f.close()

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -4,7 +4,6 @@ import shutil
 import signal
 import subprocess
 
-from six import iteritems
 
 from ccmlib import common, repository
 from ccmlib.cluster import Cluster
@@ -49,7 +48,7 @@ class DseCluster(Cluster):
 
     def set_dse_configuration_options(self, values=None):
         if values is not None:
-            for k, v in iteritems(values):
+            for k, v in values.items():
                 self._dse_config_options[k] = v
         self._update_config()
         for node in list(self.nodes.values()):

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -10,7 +10,6 @@ import subprocess
 import time
 
 import yaml
-from six import print_
 
 from ccmlib import common
 from ccmlib.node import Node, NodeError
@@ -111,7 +110,7 @@ class DseNode(Node):
             cmd = f"-agentpath:{config['yourkit_agent']}"
             if 'options' in profile_options:
                 cmd = cmd + '=' + profile_options['options']
-            print_(cmd)
+            print(cmd)
             # Yes, it's fragile as shit
             pattern = r'cassandra_parms="-Dlog4j.configuration=log4j-server.properties -Dlog4j.defaultInitOverride=true'
             common.replace_in_file(launch_bin, pattern, '    ' + pattern + ' ' + cmd + '"')
@@ -164,7 +163,7 @@ class DseNode(Node):
             else:
                 for line in process.stdout:
                     if verbose:
-                        print_(line.rstrip('\n'))
+                        print(line.rstrip('\n'))
 
             self._update_pid(process)
 

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -1,5 +1,5 @@
 # ccm node
-from __future__ import with_statement
+
 
 import os
 import re

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -85,7 +85,7 @@ class DseNode(Node):
             jvm_args = []
 
         if self.is_running():
-            raise NodeError("%s is already running" % self.name)
+            raise NodeError(f"{self.name} is already running")
 
         for itf in list(self.network_interfaces.values()):
             if itf is not None and replace_address is None:
@@ -107,8 +107,8 @@ class DseNode(Node):
         if profile_options is not None:
             config = common.get_config()
             if 'yourkit_agent' not in config:
-                raise NodeError("Cannot enable profile. You need to set 'yourkit_agent' to the path of your agent in a {0}/config".format(common.get_default_path_display_name()))
-            cmd = '-agentpath:%s' % config['yourkit_agent']
+                raise NodeError(f"Cannot enable profile. You need to set 'yourkit_agent' to the path of your agent in a {common.get_default_path_display_name()}/config")
+            cmd = f"-agentpath:{config['yourkit_agent']}"
             if 'options' in profile_options:
                 cmd = cmd + '=' + profile_options['options']
             print_(cmd)
@@ -135,11 +135,11 @@ class DseNode(Node):
                 args.append('-k')
             if 'cfs' in self.workload:
                 args.append('-c')
-        args += ['-p', pidfile, '-Dcassandra.join_ring=%s' % str(join_ring)]
+        args += ['-p', pidfile, f'-Dcassandra.join_ring={str(join_ring)}']
         if replace_token is not None:
-            args.append('-Dcassandra.replace_token=%s' % str(replace_token))
+            args.append(f'-Dcassandra.replace_token={str(replace_token)}')
         if replace_address is not None:
-            args.append('-Dcassandra.replace_address=%s' % str(replace_address))
+            args.append(f'-Dcassandra.replace_address={str(replace_address)}')
         if use_jna is False:
             args.append('-Dcassandra.boot_without_jna=true')
         args = args + jvm_args
@@ -169,7 +169,7 @@ class DseNode(Node):
             self._update_pid(process)
 
             if not self.is_running():
-                raise NodeError("Error starting node %s" % self.name, process)
+                raise NodeError(f"Error starting node {self.name}", process)
 
         if wait_other_notice:
             for node, mark in marks:
@@ -342,7 +342,7 @@ class DseNode(Node):
         with open(server_xml, 'w+') as f:
             f.write('<Server port="8005" shutdown="SHUTDOWN">\n')
             f.write('  <Service name="Solr">\n')
-            f.write('    <Connector port="8983" address="%s" protocol="HTTP/1.1" connectionTimeout="20000" maxThreads = "200" URIEncoding="UTF-8"/>\n' % self.network_interfaces['thrift'][0])
+            f.write(f"    <Connector port=\"8983\" address=\"{self.network_interfaces['thrift'][0]}\" protocol=\"HTTP/1.1\" connectionTimeout=\"20000\" maxThreads = \"200\" URIEncoding=\"UTF-8\"/>\n")
             f.write('    <Engine name="Solr" defaultHost="localhost">\n')
             f.write('      <Host name="localhost"  appBase="../solr/web"\n')
             f.write('            unpackWARs="true" autoDeploy="true"\n')
@@ -395,14 +395,14 @@ class DseNode(Node):
                 (ip, port) = self.network_interfaces['thrift']
                 jmx = self.jmx_port
                 f.write('stomp_interface: 127.0.0.1\n')
-                f.write('local_interface: %s\n' % ip)
-                f.write('agent_rpc_interface: %s\n' % ip)
-                f.write('agent_rpc_broadcast_address: %s\n' % ip)
-                f.write('cassandra_conf: %s\n' % os.path.join(self.get_path(), 'resources', 'cassandra', 'conf', 'cassandra.yaml'))
-                f.write('cassandra_install: %s\n' % self.get_path())
-                f.write('cassandra_logs: %s\n' % os.path.join(self.get_path(), 'logs'))
-                f.write('thrift_port: %s\n' % port)
-                f.write('jmx_port: %s\n' % jmx)
+                f.write(f'local_interface: {ip}\n')
+                f.write(f'agent_rpc_interface: {ip}\n')
+                f.write(f'agent_rpc_broadcast_address: {ip}\n')
+                f.write(f"cassandra_conf: {os.path.join(self.get_path(), 'resources', 'cassandra', 'conf', 'cassandra.yaml')}\n")
+                f.write(f'cassandra_install: {self.get_path()}\n')
+                f.write(f"cassandra_logs: {os.path.join(self.get_path(), 'logs')}\n")
+                f.write(f'thrift_port: {port}\n')
+                f.write(f'jmx_port: {jmx}\n')
                 f.close()
 
     def _write_agent_log4j_properties(self, agent_dir):

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1,5 +1,5 @@
 # ccm node
-from __future__ import with_statement
+
 
 import errno
 import glob
@@ -293,7 +293,7 @@ class Node(object):
         Print infos on this node configuration.
         """
         self.__update_status()
-        indent = ''.join([" " for i in xrange(0, len(self.name) + 2)])
+        indent = ''.join([" " for i in range(0, len(self.name) + 2)])
         print_("%s: %s" % (self.name, self.__get_status_string()))
         if not only_status:
             if show_cluster:
@@ -729,7 +729,7 @@ class Node(object):
                 # is 2**7-1 (=127). So to sleep an arbitrary wait_seconds
                 # we need the first sleep to be wait_seconds/(2**7-1).
                 wait_time_sec = wait_seconds/(2**7-1.0)
-                for i in xrange(0, 7):
+                for i in range(0, 7):
                     # we'll double the wait time each try and cassandra should
                     # not take more than 1 minute to shutdown
                     time.sleep(wait_time_sec)
@@ -1484,7 +1484,7 @@ class Node(object):
         dir_name = self.get_path()
         if not os.path.exists(dir_name):
             os.mkdir(dir_name)
-            for _, dir in self._get_directories().items():
+            for _, dir in list(self._get_directories().items()):
                 if not os.path.exists(dir):
                     os.mkdir(dir)
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -18,8 +18,6 @@ import locale
 from collections import namedtuple
 
 import yaml
-from six import iteritems, print_, string_types
-from six.moves import xrange
 
 from ccmlib import common
 from ccmlib.cli_session import CliSession
@@ -271,7 +269,7 @@ class Node(object):
         commitlog (since it requires setting 2 options and unsetting one).
         """
         if values is not None:
-            for k, v in iteritems(values):
+            for k, v in values.items():
                 self.__config_options[k] = v
         if batch_commitlog is not None:
             if batch_commitlog:
@@ -294,20 +292,20 @@ class Node(object):
         """
         self.__update_status()
         indent = ''.join([" " for i in range(0, len(self.name) + 2)])
-        print_(f"{self.name}: {self.__get_status_string()}")
+        print(f"{self.name}: {self.__get_status_string()}")
         if not only_status:
             if show_cluster:
-                print_(f"{indent}{'cluster'}={self.cluster.name}")
-            print_(f"{indent}{'auto_bootstrap'}={self.auto_bootstrap}")
-            print_(f"{indent}{'thrift'}={self.network_interfaces['thrift']}")
+                print(f"{indent}{'cluster'}={self.cluster.name}")
+            print(f"{indent}{'auto_bootstrap'}={self.auto_bootstrap}")
+            print(f"{indent}{'thrift'}={self.network_interfaces['thrift']}")
             if self.network_interfaces['binary'] is not None:
-                print_(f"{indent}{'binary'}={self.network_interfaces['binary']}")
-            print_(f"{indent}{'storage'}={self.network_interfaces['storage']}")
-            print_(f"{indent}{'jmx_port'}={self.jmx_port}")
-            print_(f"{indent}{'remote_debug_port'}={self.remote_debug_port}")
-            print_(f"{indent}{'initial_token'}={self.initial_token}")
+                print(f"{indent}{'binary'}={self.network_interfaces['binary']}")
+            print(f"{indent}{'storage'}={self.network_interfaces['storage']}")
+            print(f"{indent}{'jmx_port'}={self.jmx_port}")
+            print(f"{indent}{'remote_debug_port'}={self.remote_debug_port}")
+            print(f"{indent}{'initial_token'}={self.initial_token}")
             if self.pid:
-                print_(f"{indent}{'pid'}={self.pid}")
+                print(f"{indent}{'pid'}={self.pid}")
 
     def is_running(self):
         """
@@ -425,7 +423,7 @@ class Node(object):
         if stderr is None:
             stderr = ''
         if len(stderr) > 1:
-            print_(f"[{name} ERROR] {stderr.strip()}")
+            print(f"[{name} ERROR] {stderr.strip()}")
 
     # This will return when exprs are found or it timeouts
     def watch_log_for(self, exprs, from_mark=None, timeout=600, process=None, verbose=False, filename='system.log'):
@@ -436,7 +434,7 @@ class Node(object):
         a list of pair (line matched, match object) is returned.
         """
         elapsed = 0
-        tofind = [exprs] if isinstance(exprs, string_types) else exprs
+        tofind = [exprs] if isinstance(exprs, str) else exprs
         tofind = [re.compile(e) for e in tofind]
         matchings = []
         reads = ""
@@ -482,7 +480,7 @@ class Node(object):
                             tofind.remove(e)
 
                             if len(tofind) == 0:
-                                return matchings[0] if isinstance(exprs, string_types) else matchings
+                                return matchings[0] if isinstance(exprs, str) else matchings
                             break
                 else:
                     # yep, it's ugly
@@ -573,7 +571,7 @@ class Node(object):
             raise NodeError("PS Execution Policy must be unrestricted when running C* 2.1+")
 
         if not common.is_win() and quiet_start:
-            print_("WARN: Tried to set Windows quiet start behavior, but we're not running on Windows.")
+            print("WARN: Tried to set Windows quiet start behavior, but we're not running on Windows.")
 
         if self.is_running():
             raise NodeError(f"{self.name} is already running")
@@ -604,7 +602,7 @@ class Node(object):
             cmd = f"-agentpath:{config['yourkit_agent']}"
             if 'options' in profile_options:
                 cmd = cmd + '=' + profile_options['options']
-            print_(cmd)
+            print(cmd)
             # Yes, it's fragile as shit
             pattern = r'cassandra_parms="-Dlog4j.configuration=log4j-server.properties -Dlog4j.defaultInitOverride=true'
             common.replace_in_file(launch_bin, pattern, '    ' + pattern + ' ' + cmd + '"')
@@ -650,13 +648,13 @@ class Node(object):
 
         if verbose:
             stdout, stderr = process.communicate()
-            print_(stdout)
-            print_(stderr)
+            print(stdout)
+            print(stderr)
 
         if common.is_win():
             self.__clean_win_pid()
             self._update_pid(process)
-            print_(f"Started: {self.name} with pid: {self.pid}", file=sys.stderr, flush=True)
+            print(f"Started: {self.name} with pid: {self.pid}", file=sys.stderr, flush=True)
         elif update_pid:
             self._update_pid(process)
 
@@ -705,12 +703,12 @@ class Node(object):
                     try:
                         self.flush()
                     except:
-                        print_(f"WARN: Failed to flush node: {self.name} on shutdown.")
+                        print(f"WARN: Failed to flush node: {self.name} on shutdown.")
                         pass
 
                 os.system("taskkill /F /PID " + str(self.pid))
                 if self._find_pid_on_windows():
-                    print_(f"WARN: Failed to terminate node: {self.name} with pid: {self.pid}")
+                    print(f"WARN: Failed to terminate node: {self.name} with pid: {self.pid}")
             else:
                 if gently:
                     os.kill(self.pid, signal.SIGTERM)
@@ -856,13 +854,13 @@ class Node(object):
             p.stdin.write("quit;\n")
             p.wait()
             for err in p.stderr.readlines():
-                print_("(EE) ", err, end='')
+                print("(EE) ", err, end='')
             if show_output:
                 i = 0
                 for log in p.stdout.readlines():
                     # first four lines are not interesting
                     if i >= 4:
-                        print_(log, end='')
+                        print(log, end='')
                     i = i + 1
 
     def run_cqlsh(self, cmds=None, show_output=False, cqlsh_options=None, return_output=False):
@@ -976,20 +974,20 @@ class Node(object):
         self._create_directory()
 
     def run_sstable2json(self, out_file=None, keyspace=None, datafiles=None, column_families=None, enumerate_keys=False):
-        print_("running")
+        print("running")
         if out_file is None:
             out_file = sys.stdout
         sstable2json = self._find_cmd('sstabledump')
         env = self.get_env()
         sstablefiles = self.__gather_sstables(datafiles, keyspace, column_families)
-        print_(sstablefiles)
+        print(sstablefiles)
         for sstablefile in sstablefiles:
-            print_(f"-- {os.path.basename(sstablefile)} -----")
+            print(f"-- {os.path.basename(sstablefile)} -----")
             args = sstable2json + [sstablefile]
             if enumerate_keys:
                 args = args + ["-e"]
             subprocess.call(args, env=env, stdout=out_file)
-            print_("")
+            print("")
 
     def run_json2sstable(self, in_file, ks, cf, keyspace=None, datafiles=None, column_families=None, enumerate_keys=False):
         json2sstable = self._find_cmd('json2sstable')
@@ -1010,7 +1008,7 @@ class Node(object):
         results = []
 
         def do_split(f):
-            print_(f"-- {os.path.basename(f)}-----")
+            print(f"-- {os.path.basename(f)}-----")
             cmd = sstablesplit
             if size is not None:
                 cmd += ['-s', str(size)]
@@ -1147,8 +1145,8 @@ class Node(object):
         try:
             os.chmod(fcmd, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
         except:
-            print_(f"WARN: Couldn't change permissions to use {cmd}.")
-            print_("WARN: If it didn't work, you will have to do so manually.")
+            print(f"WARN: Couldn't change permissions to use {cmd}.")
+            print("WARN: If it didn't work, you will have to do so manually.")
         return [fcmd]
 
     def list_keyspaces(self):
@@ -1198,11 +1196,11 @@ class Node(object):
                 files.remove(f)
             if (ignore_unsealed or cleanup_unsealed) and os.path.exists(f.replace('Data.db', 'TOC.txt.tmp')):
                 if cleanup_unsealed:
-                    print_(f"get_sstables: Cleaning up unsealed SSTable: {f}")
+                    print(f"get_sstables: Cleaning up unsealed SSTable: {f}")
                     for i in glob.glob(f.replace('Data.db', '*')):
                         os.remove(i)
                 else:
-                    print_(f"get_sstables: Ignoring unsealed SSTable: {f}")
+                    print(f"get_sstables: Ignoring unsealed SSTable: {f}")
                 files.remove(f)
         return files
 
@@ -1720,7 +1718,7 @@ class Node(object):
             import psutil
             found = psutil.pid_exists(self.pid)
         except ImportError:
-            print_("WARN: psutil not installed. Pid tracking functionality will suffer. See README for details.")
+            print("WARN: psutil not installed. Pid tracking functionality will suffer. See README for details.")
             cmd = 'tasklist /fi "PID eq ' + str(self.pid) + '"'
             proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, universal_newlines=True)
 
@@ -1796,7 +1794,7 @@ class Node(object):
                                         self.get_path() +
                                         '/dirty_pid.tmp. Manually kill it and check logs - ccm will be out of sync.')
             except Exception as e:
-                print_("ERROR: Problem starting " + self.name + " (" + str(e) + ")")
+                print("ERROR: Problem starting " + self.name + " (" + str(e) + ")")
                 raise Exception('Error while parsing <node>/dirty_pid.tmp in path: ' + self.get_path())
 
     def _delete_old_pid(self):
@@ -1810,7 +1808,7 @@ class Node(object):
         start = time.time()
         while not (os.path.isfile(pidfile) and os.stat(pidfile).st_size > 0):
             if (time.time() - start > 30.0):
-                print_("Timed out waiting for pidfile {} to be filled (current time is %s): File {} size={}".format(
+                print("Timed out waiting for pidfile {} to be filled (current time is %s): File {} size={}".format(
                         pidfile,
                         datetime.now(),
                         'exists' if os.path.isfile(pidfile) else 'does not exist' if not os.path.exists(pidfile) else 'is not a file',
@@ -1906,7 +1904,7 @@ class Node(object):
             p.suspend()
         except ImportError:
             if common.is_win():
-                print_("WARN: psutil not installed. Pause functionality will not work properly on Windows.")
+                print("WARN: psutil not installed. Pause functionality will not work properly on Windows.")
             else:
                 os.kill(self.pid, signal.SIGSTOP)
 
@@ -1917,7 +1915,7 @@ class Node(object):
             p.resume()
         except ImportError:
             if common.is_win():
-                print_("WARN: psutil not installed. Resume functionality will not work properly on Windows.")
+                print("WARN: psutil not installed. Resume functionality will not work properly on Windows.")
             else:
                 os.kill(self.pid, signal.SIGCONT)
 

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -1,5 +1,5 @@
 # downloaded sources handling
-from __future__ import with_statement
+
 
 import json
 import os

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -64,8 +64,8 @@ def setup(version, verbose=False):
             # We don't do this if binary: or source: were
             # explicitly specified.
             if fallback:
-                print_("WARN:Downloading {} failed, due to {}. Trying to build from git instead.".format(version, e))
-                version = 'git:cassandra-{}'.format(version)
+                print_(f"WARN:Downloading {version} failed, due to {e}. Trying to build from git instead.")
+                version = f'git:cassandra-{version}'
                 clone_development(GIT_REPO, version, verbose=verbose)
                 return (version_directory(version), None)
             else:
@@ -146,18 +146,18 @@ def clone_development(git_repo, version, verbose=False):
                     branches = [b.strip() for b in branch_listing.replace('remotes/origin/', '').split()]
                     is_branch = git_branch in branches
                 except subprocess.CalledProcessError as cpe:
-                    print_("Error Running Branch Filter: {}\nAssumming request is not for a branch".format(cpe.output))
+                    print_(f"Error Running Branch Filter: {cpe.output}\nAssumming request is not for a branch")
 
                 # now check out the right version
                 if verbose:
                     branch_or_sha_tag = 'branch' if is_branch else 'SHA/tag'
-                    print_("Checking out requested {} ({})".format(branch_or_sha_tag, git_branch))
+                    print_(f"Checking out requested {branch_or_sha_tag} ({git_branch})")
                 if is_branch:
                     # we use checkout -B with --track so we can specify that we want to track a specific branch
                     # otherwise, you get errors on branch names that are also valid SHAs or SHA shortcuts, like 10360
                     # we use -B instead of -b so we reset branches that already exist and create a new one otherwise
                     out = subprocess.call(['git', 'checkout', '-B', git_branch,
-                                           '--track', 'origin/{git_branch}'.format(git_branch=git_branch)],
+                                           '--track', f'origin/{git_branch}'],
                                           cwd=target_dir, stdout=lf, stderr=lf)
                 else:
                     out = subprocess.call(['git', 'checkout', git_branch], cwd=target_dir, stdout=lf, stderr=lf)
@@ -187,9 +187,9 @@ def clone_development(git_repo, version, verbose=False):
             # wipe out the directory if anything goes wrong. Otherwise we will assume it has been compiled the next time it runs.
             try:
                 rmdirs(target_dir)
-                print_("Deleted %s due to error" % target_dir)
+                print_(f"Deleted {target_dir} due to error")
             except:
-                raise CCMError("Building C* version %s failed. Attempted to delete %s but failed. This will need to be manually deleted" % (version, target_dir))
+                raise CCMError(f"Building C* version {version} failed. Attempted to delete {target_dir} but failed. This will need to be manually deleted")
             raise
 
 
@@ -199,7 +199,7 @@ def download_dse_version(version, username, password, verbose=False):
     try:
         __download(url, target, username=username, password=password, show_progress=verbose)
         if verbose:
-            print_("Extracting %s as version %s ..." % (target, version))
+            print_(f"Extracting {target} as version {version} ...")
         tar = tarfile.open(target)
         dir = tar.next().name.split("/")[0]
         tar.extractall(path=__get_dir())
@@ -209,11 +209,11 @@ def download_dse_version(version, username, password, verbose=False):
             rmdirs(target_dir)
         shutil.move(os.path.join(__get_dir(), dir), target_dir)
     except urllib.error.URLError as e:
-        msg = "Invalid version %s" % version if url is None else "Invalid url %s" % url
-        msg = msg + " (underlying error is: %s)" % str(e)
+        msg = f"Invalid version {version}" if url is None else f"Invalid url {url}"
+        msg = msg + f" (underlying error is: {str(e)})"
         raise ArgumentError(msg)
     except tarfile.ReadError as e:
-        raise ArgumentError("Unable to uncompress downloaded file: %s" % str(e))
+        raise ArgumentError(f"Unable to uncompress downloaded file: {str(e)}")
 
 
 def download_opscenter_version(version, target_version, verbose=False):
@@ -222,7 +222,7 @@ def download_opscenter_version(version, target_version, verbose=False):
     try:
         __download(url, target, show_progress=verbose)
         if verbose:
-            print_("Extracting %s as version %s ..." % (target, target_version))
+            print_(f"Extracting {target} as version {target_version} ...")
         tar = tarfile.open(target)
         dir = tar.next().name.split("/")[0]
         tar.extractall(path=__get_dir())
@@ -232,11 +232,11 @@ def download_opscenter_version(version, target_version, verbose=False):
             rmdirs(target_dir)
         shutil.move(os.path.join(__get_dir(), dir), target_dir)
     except urllib.error.URLError as e:
-        msg = "Invalid version %s" % version if url is None else "Invalid url %s" % url
-        msg = msg + " (underlying error is: %s)" % str(e)
+        msg = f"Invalid version {version}" if url is None else f"Invalid url {url}"
+        msg = msg + f" (underlying error is: {str(e)})"
         raise ArgumentError(msg)
     except tarfile.ReadError as e:
-        raise ArgumentError("Unable to uncompress downloaded file: %s" % str(e))
+        raise ArgumentError(f"Unable to uncompress downloaded file: {str(e)}")
 
 
 def download_version(version, url=None, verbose=False, binary=False):
@@ -247,14 +247,14 @@ def download_version(version, url=None, verbose=False, binary=False):
     assert_jdk_valid_for_cassandra_version(version)
 
     if binary:
-        u = "%s/%s/apache-cassandra-%s-bin.tar.gz" % (ARCHIVE, version.split('-')[0], version) if url is None else url
+        u = f"{ARCHIVE}/{version.split('-')[0]}/apache-cassandra-{version}-bin.tar.gz" if url is None else url
     else:
-        u = "%s/%s/apache-cassandra-%s-src.tar.gz" % (ARCHIVE, version.split('-')[0], version) if url is None else url
+        u = f"{ARCHIVE}/{version.split('-')[0]}/apache-cassandra-{version}-src.tar.gz" if url is None else url
     _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
     try:
         __download(u, target, show_progress=verbose)
         if verbose:
-            print_("Extracting %s as version %s ..." % (target, version))
+            print_(f"Extracting {target} as version {version} ...")
         tar = tarfile.open(target)
         dir = tar.next().name.split("/")[0]
         tar.extractall(path=__get_dir())
@@ -274,18 +274,18 @@ def download_version(version, url=None, verbose=False, binary=False):
             compile_version(version, target_dir, verbose=verbose)
 
     except urllib.error.URLError as e:
-        msg = "Invalid version %s" % version if url is None else "Invalid url %s" % url
-        msg = msg + " (underlying error is: %s)" % str(e)
+        msg = f"Invalid version {version}" if url is None else f"Invalid url {url}"
+        msg = msg + f" (underlying error is: {str(e)})"
         raise ArgumentError(msg)
     except tarfile.ReadError as e:
-        raise ArgumentError("Unable to uncompress downloaded file: %s" % str(e))
+        raise ArgumentError(f"Unable to uncompress downloaded file: {str(e)}")
     except CCMError as e:
         # wipe out the directory if anything goes wrong. Otherwise we will assume it has been compiled the next time it runs.
         try:
             rmdirs(target_dir)
-            print_("Deleted %s due to error" % target_dir)
+            print_(f"Deleted {target_dir} due to error")
         except:
-            raise CCMError("Building C* version %s failed. Attempted to delete %s but failed. This will need to be manually deleted" % (version, target_dir))
+            raise CCMError(f"Building C* version {version} failed. Attempted to delete {target_dir} but failed. This will need to be manually deleted")
         raise e
 
 
@@ -295,7 +295,7 @@ def compile_version(version, target_dir, verbose=False):
     # compiling cassandra and the stress tool
     logfile = lastlogfilename()
     if verbose:
-        print_("Compiling Cassandra %s ..." % version)
+        print_(f"Compiling Cassandra {version} ...")
     with open(logfile, 'w') as lf:
         lf.write("--- Cassandra Build -------------------\n")
         try:
@@ -305,14 +305,14 @@ def compile_version(version, target_dir, verbose=False):
             ret_val = 1
             while attempt < 3 and ret_val != 0:
                 if attempt > 0:
-                    lf.write("\n\n`ant jar` failed. Retry #%s...\n\n" % attempt)
+                    lf.write(f"\n\n`ant jar` failed. Retry #{attempt}...\n\n")
                 ret_val = subprocess.call([platform_binary('ant'), 'jar'], cwd=target_dir, stdout=lf, stderr=lf)
                 attempt += 1
             if ret_val != 0:
                 raise CCMError('Error compiling Cassandra. See {logfile} or run '
                                '"ccm showlastlog" for details'.format(logfile=logfile))
         except OSError as e:
-            raise CCMError("Error compiling Cassandra. Is ant installed? See %s for details" % logfile)
+            raise CCMError(f"Error compiling Cassandra. Is ant installed? See {logfile} for details")
 
         lf.write("\n\n--- cassandra/stress build ------------\n")
         stress_dir = os.path.join(target_dir, "tools", "stress") if (
@@ -350,7 +350,7 @@ def github_username_and_branch_name(version):
 
 
 def github_repo_for_user(username):
-    return 'git@github.com:{username}/cassandra.git'.format(username=username)
+    return f'git@github.com:{username}/cassandra.git'
 
 
 def version_directory(version):
@@ -404,7 +404,7 @@ def get_tagged_version_numbers(series='stable'):
     elif series == 'oldstable':
         return [r.vstring for r in oldstable_releases]
     else:
-        raise AssertionError("unknown release series: {series}".format(series=series))
+        raise AssertionError(f"unknown release series: {series}")
 
 
 def __download(url, target, username=None, password=None, show_progress=False):
@@ -420,7 +420,7 @@ def __download(url, target, username=None, password=None, show_progress=False):
     meta = u.info()
     file_size = int(meta.get("Content-Length"))
     if show_progress:
-        print_("Downloading %s to %s (%.3fMB)" % (url, target, float(file_size) / (1024 * 1024)))
+        print_(f"Downloading {url} to {target} ({float(file_size) / (1024 * 1024):.3f}MB)")
 
     file_size_dl = 0
     block_sz = 8192

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -75,7 +75,7 @@ class ScyllaCluster(Cluster):
     # override get_node_jmx_port for scylla-jmx
     # scylla-jmx listens on the unique node address (127.0.<cluster.id><node.id>)
     # so there's no need to listen on a different port for every jmx instance
-    def get_node_jmx_port(self,nodeid):
+    def get_node_jmx_port(self, nodeid):
         return 7199
 
     def create_node(self, name, auto_bootstrap, thrift_interface,
@@ -106,10 +106,10 @@ class ScyllaCluster(Cluster):
 
         marks = []
         if wait_other_notice:
-            marks = [(node, node.mark_log()) for node in self.nodes.values() if node.is_running()]
+            marks = [(node, node.mark_log()) for node in list(self.nodes.values()) if node.is_running()]
 
         if nodes is None:
-            nodes = self.nodes.values()
+            nodes = list(self.nodes.values())
         elif isinstance(nodes, ScyllaNode):
             nodes = [nodes]
 
@@ -165,14 +165,14 @@ class ScyllaCluster(Cluster):
 
     def stop_nodes(self, nodes=None, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=None):
         if nodes is None:
-            nodes = self.nodes.values()
+            nodes = list(self.nodes.values())
         elif isinstance(nodes, ScyllaNode):
             nodes = [nodes]
 
         marks = []
         if wait_other_notice:
             if not other_nodes:
-                other_nodes = [node for node in self.nodes.values() if not node in nodes]
+                other_nodes = [node for node in list(self.nodes.values()) if not node in nodes]
             marks = [(node, node.mark_log()) for node in other_nodes if node.is_live()]
 
         # stop all nodes in parallel
@@ -351,7 +351,7 @@ class ScyllaManager:
             src = os.path.join(install_dir, name)
             if not os.path.exists(src):
                 raise Exception("%s not found in scylla-manager install dir" % src)
-            shutil.copy(src,os.path.join(self._get_path(), 'bin', name))
+            shutil.copy(src, os.path.join(self._get_path(), 'bin', name))
 
     @property
     def is_agent_available(self):
@@ -399,7 +399,7 @@ class ScyllaManager:
             except OSError as err:
                 pass
 
-        log_file = os.path.join(self._get_path(),'scylla-manager.log')
+        log_file = os.path.join(self._get_path(), 'scylla-manager.log')
         scylla_log = open(log_file, 'a')
 
         if os.path.isfile(self._get_pid_file()):
@@ -415,7 +415,7 @@ class ScyllaManager:
             pid_file.write(str(self._process_scylla_manager.pid))
 
         api_interface = common.parse_interface(self._get_api_address(), 5080)
-        if not common.check_socket_listening(api_interface,timeout=180):
+        if not common.check_socket_listening(api_interface, timeout=180):
             raise Exception("scylla manager interface %s:%s is not listening after 180 seconds, scylla manager may have failed to start."
                           % (api_interface[0], api_interface[1]))
 

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -8,7 +8,6 @@ import yaml
 import uuid
 import datetime
 
-from six import print_
 from distutils.version import LooseVersion
 
 from ccmlib import common
@@ -371,7 +370,7 @@ class ScyllaManager:
         pidfile = self._get_pid_file()
         while not (os.path.isfile(pidfile) and os.stat(pidfile).st_size > 0):
             if time.time() - start > 30.0:
-                print_("Timed out waiting for pidfile {} to be filled (current time is %s): File {} size={}".format(
+                print("Timed out waiting for pidfile {} to be filled (current time is %s): File {} size={}".format(
                         pidfile,
                         datetime.now(),
                         'exists' if os.path.isfile(pidfile) else 'does not exist' if not os.path.exists(pidfile) else 'is not a file',

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -136,7 +136,7 @@ class ScyllaCluster(Cluster):
 
         for node, p, _ in started:
             if not node.is_running():
-                raise NodeError("Error starting {0}.".format(node.name), p)
+                raise NodeError(f"Error starting {node.name}.", p)
 
         if wait_for_binary_proto:
             for node, _, mark in started:
@@ -291,7 +291,7 @@ class ScyllaManager:
         self._update_config(install_dir)
 
     def _get_api_address(self):
-        return "%s:5080" % self.scylla_cluster.get_node_ip(1)
+        return f"{self.scylla_cluster.get_node_ip(1)}:5080"
 
     def _update_config(self, install_dir=None):
         conf_file = os.path.join(self._get_path(), common.SCYLLAMANAGER_CONF)
@@ -318,10 +318,10 @@ class ScyllaManager:
             data['repair'] = {}
         if self.version < LooseVersion("2.2"):
             data['repair']['segments_per_repair'] = 16
-        data['prometheus'] = "{}:56091".format(self.scylla_cluster.get_node_ip(1))
+        data['prometheus'] = f"{self.scylla_cluster.get_node_ip(1)}:56091"
         # Changing port to 56091 since the manager and the first node share the same ip and 56090 is already in use
         # by the first node's manager agent
-        data["debug"] = "{}:5611".format(self.scylla_cluster.get_node_ip(1))
+        data["debug"] = f"{self.scylla_cluster.get_node_ip(1)}:5611"
         # Since both the manager server and the first node use the same address, the manager can't use port
         # 56112, as node 1's agent already seized it
         if 'ssh' in data:
@@ -338,7 +338,7 @@ class ScyllaManager:
     def _copy_config_files(self, install_dir):
         conf_dir = os.path.join(install_dir, 'etc')
         if not os.path.exists(conf_dir):
-            raise Exception("%s is not a valid scylla-manager install dir" % install_dir)
+            raise Exception(f"{install_dir} is not a valid scylla-manager install dir")
         for name in os.listdir(conf_dir):
             filename = os.path.join(conf_dir, name)
             if os.path.isfile(filename):
@@ -350,7 +350,7 @@ class ScyllaManager:
         for name in files:
             src = os.path.join(install_dir, name)
             if not os.path.exists(src):
-                raise Exception("%s not found in scylla-manager install dir" % src)
+                raise Exception(f"{src} not found in scylla-manager install dir")
             shutil.copy(src, os.path.join(self._get_path(), 'bin', name))
 
     @property
@@ -384,8 +384,7 @@ class ScyllaManager:
             with open(self._get_pid_file(), 'r') as f:
                 self._pid = int(f.readline().strip())
         except IOError as e:
-            raise NodeError('Problem starting scylla-manager due to %s' %
-                            (e))
+            raise NodeError(f'Problem starting scylla-manager due to {e}')
 
     def start(self):
         # some configurations are set post initialisation (cluster id) so
@@ -443,7 +442,7 @@ class ScyllaManager:
 
     def sctool(self, cmd, ignore_exit_status=False):
         sctool = os.path.join(self._get_path(), 'bin', 'sctool')
-        args = [sctool, '--api-url', "http://%s/api/v1" % self._get_api_address()]
+        args = [sctool, '--api-url', f"http://{self._get_api_address()}/api/v1"]
         args += cmd
         p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         stdout, stderr = p.communicate()

--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -238,24 +238,24 @@ class ScyllaDockerNode(ScyllaNode):
         """
         self.__update_status()
         indent = ''.join([" " for i in range(0, len(self.name) + 2)])
-        print(("%s: %s" % (self.name, self.__get_status_string())))
+        print(f"{self.name}: {self.__get_status_string()}")
         if not only_status:
             if show_cluster:
-                print(("%s%s=%s" % (indent, 'cluster', self.cluster.name)))
-            print(("%s%s=%s" % (indent, 'auto_bootstrap', self.auto_bootstrap)))
-            print(("%s%s=%s" % (indent, 'thrift', self.network_interfaces['thrift'])))
+                print(f"{indent}{'cluster'}={self.cluster.name}")
+            print(f"{indent}{'auto_bootstrap'}={self.auto_bootstrap}")
+            print(f"{indent}{'thrift'}={self.network_interfaces['thrift']}")
             if self.network_interfaces['binary'] is not None:
-                print(("%s%s=%s" % (indent, 'binary', self.network_interfaces['binary'])))
-            print(("%s%s=%s" % (indent, 'storage', self.network_interfaces['storage'])))
-            print(("%s%s=%s" % (indent, 'jmx_port', self.jmx_port)))
-            print(("%s%s=%s" % (indent, 'remote_debug_port', self.remote_debug_port)))
-            print(("%s%s=%s" % (indent, 'initial_token', self.initial_token)))
+                print(f"{indent}{'binary'}={self.network_interfaces['binary']}")
+            print(f"{indent}{'storage'}={self.network_interfaces['storage']}")
+            print(f"{indent}{'jmx_port'}={self.jmx_port}")
+            print(f"{indent}{'remote_debug_port'}={self.remote_debug_port}")
+            print(f"{indent}{'initial_token'}={self.initial_token}")
             if self.pid:
-                print(("%s%s=%s" % (indent, 'pid', self.pid)))
+                print(f"{indent}{'pid'}={self.pid}")
 
     def __get_status_string(self):
         if self.status == Status.UNINITIALIZED:
-            return "%s (%s)" % (Status.DOWN, "Not initialized")
+            return f"{Status.DOWN} ({'Not initialized'})"
         else:
             return self.status
 

--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -131,7 +131,7 @@ class ScyllaDockerNode(ScyllaNode):
         server_encryption_options = data.get("server_encryption_options", {})
         if server_encryption_options:
             keys_dir_path = os.path.join(self.get_path(), "keys")
-            for key, file_path in server_encryption_options.items():
+            for key, file_path in list(server_encryption_options.items()):
                 if os.path.isfile(file_path):
                     file_name = os.path.split(file_path)[1]
                     copyfile(src=file_path, dst=os.path.join(keys_dir_path, file_name))
@@ -206,7 +206,7 @@ class ScyllaDockerNode(ScyllaNode):
         # replace addresses
         network = run(['bash', '-c', f"docker inspect --format='{{{{ .NetworkSettings.IPAddress }}}}' {self.pid}"], stdout=PIPE, stderr=PIPE, universal_newlines=True)
         address = network.stdout.strip() if network.stdout else None
-        self.network_interfaces = {k: (address, v[1]) for k, v in self.network_interfaces.items()}
+        self.network_interfaces = {k: (address, v[1]) for k, v in list(self.network_interfaces.items())}
 
     def service_start(self, service_name):
         res = run(['bash', '-c', f'docker exec {self.pid} /bin/bash -c "supervisorctl start {service_name}"'],
@@ -238,20 +238,20 @@ class ScyllaDockerNode(ScyllaNode):
         """
         self.__update_status()
         indent = ''.join([" " for i in range(0, len(self.name) + 2)])
-        print("%s: %s" % (self.name, self.__get_status_string()))
+        print(("%s: %s" % (self.name, self.__get_status_string())))
         if not only_status:
             if show_cluster:
-                print("%s%s=%s" % (indent, 'cluster', self.cluster.name))
-            print("%s%s=%s" % (indent, 'auto_bootstrap', self.auto_bootstrap))
-            print("%s%s=%s" % (indent, 'thrift', self.network_interfaces['thrift']))
+                print(("%s%s=%s" % (indent, 'cluster', self.cluster.name)))
+            print(("%s%s=%s" % (indent, 'auto_bootstrap', self.auto_bootstrap)))
+            print(("%s%s=%s" % (indent, 'thrift', self.network_interfaces['thrift'])))
             if self.network_interfaces['binary'] is not None:
-                print("%s%s=%s" % (indent, 'binary', self.network_interfaces['binary']))
-            print("%s%s=%s" % (indent, 'storage', self.network_interfaces['storage']))
-            print("%s%s=%s" % (indent, 'jmx_port', self.jmx_port))
-            print("%s%s=%s" % (indent, 'remote_debug_port', self.remote_debug_port))
-            print("%s%s=%s" % (indent, 'initial_token', self.initial_token))
+                print(("%s%s=%s" % (indent, 'binary', self.network_interfaces['binary'])))
+            print(("%s%s=%s" % (indent, 'storage', self.network_interfaces['storage'])))
+            print(("%s%s=%s" % (indent, 'jmx_port', self.jmx_port)))
+            print(("%s%s=%s" % (indent, 'remote_debug_port', self.remote_debug_port)))
+            print(("%s%s=%s" % (indent, 'initial_token', self.initial_token)))
             if self.pid:
-                print("%s%s=%s" % (indent, 'pid', self.pid))
+                print(("%s%s=%s" % (indent, 'pid', self.pid)))
 
     def __get_status_string(self):
         if self.status == Status.UNINITIALIZED:

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -630,7 +630,7 @@ class ScyllaNode(Node):
                 try:
                     [k, v] = s.split('=', 1)
                 except ValueError as e:
-                    print(("Bad SCYLLA_EXT_ENV variable: {}: {}", s, e))
+                    print(f"Bad SCYLLA_EXT_ENV variable: {s}: {e}")
                 else:
                     ext_env[k] = v
 

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -19,8 +19,6 @@ import glob
 import re
 
 from ccmlib.common import CASSANDRA_SH, BIN_DIR, wait_for, copy_directory
-from six import print_
-from six.moves import xrange
 
 from ccmlib import common
 from ccmlib.node import Node, NodeUpgradeError
@@ -694,7 +692,7 @@ class ScyllaNode(Node):
             elapsed = time.time() - start
             if elapsed > 30.0 or not wait:
                 if wait:
-                    print_("Timed out waiting for pidfile {} to be filled (after {} seconds): File {} size={}".format(
+                    print("Timed out waiting for pidfile {} to be filled (after {} seconds): File {} size={}".format(
                             pidfile,
                             elapsed,
                             'exists' if os.path.isfile(pidfile) else 'does not exist' if not os.path.exists(pidfile) else 'is not a file',
@@ -735,7 +733,7 @@ class ScyllaNode(Node):
         start = time.time()
         while not (os.path.isfile(pidfile) and os.stat(pidfile).st_size > 0):
             if time.time() - start > 30.0:
-                print_("Timed out waiting for pidfile {} to be filled (current time is %s): File {} size={}".format(
+                print("Timed out waiting for pidfile {} to be filled (current time is %s): File {} size={}".format(
                         pidfile,
                         datetime.now(),
                         'exists' if os.path.isfile(pidfile) else 'does not exist' if not os.path.exists(pidfile) else 'is not a file',

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1,5 +1,5 @@
 # ccm node
-from __future__ import with_statement
+
 
 from datetime import datetime
 import errno
@@ -167,7 +167,7 @@ class ScyllaNode(Node):
         allocated_cpus = psutil.cpu_count() - 1
         start_id = (id * count + cluster_id) % allocated_cpus
         cpuset = []
-        for cpuid in xrange(start_id, start_id + count):
+        for cpuid in range(start_id, start_id + count):
             cpuset.append(str(cpuid % allocated_cpus))
         return cpuset
 
@@ -434,7 +434,7 @@ class ScyllaNode(Node):
                         'M': 20,
                         'G': 30,
                         'T': 40}
-        for prefix, power in iec_prefixes.items():
+        for prefix, power in list(iec_prefixes.items()):
             if s.endswith(prefix):
                 return int(s[:-1]) * pow(2, power)
         return int(s)
@@ -510,10 +510,10 @@ class ScyllaNode(Node):
                     try:
                         common.check_socket_available(itf)
                     except Exception as msg:
-                        print("{}. Looking for offending processes...".format(msg))
+                        print(("{}. Looking for offending processes...".format(msg)))
                         for proc in psutil.process_iter():
                             if any(self.cluster.ipprefix in cmd for cmd in proc.cmdline()):
-                                print("name={} pid={} cmdline={}".format(proc.name(), proc.pid, proc.cmdline()))
+                                print(("name={} pid={} cmdline={}".format(proc.name(), proc.pid, proc.cmdline())))
                         raise msg
 
         marks = []
@@ -632,7 +632,7 @@ class ScyllaNode(Node):
                 try:
                     [k, v] = s.split('=', 1)
                 except ValueError as e:
-                    print("Bad SCYLLA_EXT_ENV variable: {}: {}", s, e)
+                    print(("Bad SCYLLA_EXT_ENV variable: {}: {}", s, e))
                 else:
                     ext_env[k] = v
 

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -14,13 +14,12 @@ import subprocess
 import re
 import sys
 import glob
+import urllib
 
 import hashlib
 import requests
 import yaml
 
-from six import print_
-from six.moves import urllib
 
 import packaging.version
 
@@ -469,7 +468,7 @@ def download_version(version, url=None, verbose=False, target_dir=None, unified=
                 f"unsupported url or file doesn't exist\n\turl={url}")
 
         if verbose:
-            print_(f"Extracting {target} ({url}, {target_dir}) as version {version} ...")
+            print(f"Extracting {target} ({url}, {target_dir}) as version {version} ...")
         tar = tarfile.open(target)
         tar.extractall(path=target_dir)
         tar.close()

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -371,7 +371,7 @@ def setup(version, verbose=True, skip_downloads=False):
     scylla_manager_package = os.environ.get('SCYLLA_MANAGER_PACKAGE')
     if scylla_manager_package:
         manager_install_dir = setup_scylla_manager(scylla_manager_package)
-        scylla_ext_opts += ' --scylla-manager={}'.format(manager_install_dir)
+        scylla_ext_opts += f' --scylla-manager={manager_install_dir}'
         os.environ['SCYLLA_EXT_OPTS'] = scylla_ext_opts
 
     return version_dir, get_scylla_version(version_dir)
@@ -466,7 +466,7 @@ def download_version(version, url=None, verbose=False, target_dir=None, unified=
                 download_file(url=url, target_path=target, verbose=verbose)
         else:
             raise ArgumentError(
-                "unsupported url or file doesn't exist\n\turl={}".format(url))
+                f"unsupported url or file doesn't exist\n\turl={url}")
 
         if verbose:
             print_(f"Extracting {target} ({url}, {target_dir}) as version {version} ...")
@@ -475,8 +475,8 @@ def download_version(version, url=None, verbose=False, target_dir=None, unified=
         tar.close()
 
         # if relocatable package format >= 2, need to extract files under subdir
-        package_version_files = glob.glob("{}/.relocatable_package_version".format(Path(target_dir))) + \
-                                glob.glob("{}/**/.relocatable_package_version".format(Path(target_dir)))
+        package_version_files = glob.glob(f"{Path(target_dir)}/.relocatable_package_version") + \
+                                glob.glob(f"{Path(target_dir)}/**/.relocatable_package_version")
         if package_version_files and os.path.exists(package_version_files[0]):
             with open(package_version_files[0]) as f:
                 package_version = packaging.version.parse(f.read().strip())
@@ -485,7 +485,7 @@ def download_version(version, url=None, verbose=False, target_dir=None, unified=
                 sys.exit(1)
             print(f'Relocatable package format version {package_version} detected.')
             if not unified:
-                pkg_dir = glob.glob('{}/*/'.format(target_dir))[0]
+                pkg_dir = glob.glob(f'{target_dir}/*/')[0]
                 shutil.move(str(pkg_dir), target_dir + '.new')
                 shutil.rmtree(target_dir)
                 shutil.move(target_dir + '.new', target_dir)
@@ -498,17 +498,17 @@ def download_version(version, url=None, verbose=False, target_dir=None, unified=
         # find  ~/.ccm/scylla-repository/*/ -iname source.txt | xargs cat
         source_breadcrumb_file = os.path.join(target_dir, 'source.txt')
         with open(source_breadcrumb_file, 'w') as f:
-            f.write("version=%s\n" % version)
-            f.write("url=%s\n" % url)
+            f.write(f"version={version}\n")
+            f.write(f"url={url}\n")
 
         return package_version
     except urllib.error.URLError as e:
-        msg = "Invalid version %s" % version if url is None else "Invalid url %s" % url
-        msg = msg + " (underlying error is: %s)" % str(e)
+        msg = f"Invalid version {version}" if url is None else f"Invalid url {url}"
+        msg = msg + f" (underlying error is: {str(e)})"
         raise ArgumentError(msg)
     except tarfile.ReadError as e:
         raise ArgumentError(
-            "Unable to uncompress downloaded file: %s" % str(e))
+            f"Unable to uncompress downloaded file: {str(e)}")
 
 
 def directory_name(version):
@@ -553,8 +553,8 @@ def run_scylla_install_script(install_dir, target_dir, package_version):
         install_dir, scylla_target_dir, install_opt), cwd=install_dir)
     run('''mkdir -p {0}/conf; cp ./conf/scylla.yaml {0}/conf'''.format(
         scylla_target_dir), cwd=install_dir)
-    run('''ln -s {}/bin .'''.format(scylla_target_dir), cwd=target_dir)
-    run('''ln -s {}/conf .'''.format(scylla_target_dir), cwd=target_dir)
+    run(f'''ln -s {scylla_target_dir}/bin .''', cwd=target_dir)
+    run(f'''ln -s {scylla_target_dir}/conf .''', cwd=target_dir)
 
 
 def run_scylla_unified_install_script(install_dir, target_dir, package_version):
@@ -574,4 +574,4 @@ def run_scylla_unified_install_script(install_dir, target_dir, package_version):
 
     run('''{0}/install.sh --prefix {1} --nonroot{2}'''.format(
         install_dir, target_dir, install_opt), cwd=install_dir)
-    run('''ln -s {}/scylla/conf conf'''.format(install_dir), cwd=target_dir)
+    run(f'''ln -s {install_dir}/scylla/conf conf''', cwd=target_dir)

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -1,4 +1,4 @@
-from __future__ import with_statement
+
 
 import logging
 import random
@@ -165,7 +165,7 @@ def release_packages(s3_url, version, arch='x86_64', scylla_product='scylla'):
             if package_type in package:
                 release_packages_dict[package_type] = package
 
-    if not release_packages or ( set(['jmx', 'tools', scylla_package_mark]) != set(release_packages_dict.keys())):
+    if not release_packages or ( {'jmx', 'tools', scylla_package_mark} != set(release_packages_dict.keys())):
         raise ValueError(
             f"Release packages have not been found.\nDebug info: all packages: {all_packages}; "
             f"candidates packages: {candidates}; last version: {latest_candidate}")
@@ -461,9 +461,9 @@ def download_version(version, url=None, verbose=False, target_dir=None, unified=
             target = url
         elif is_valid(url):
             _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
-            res = download_version_from_s3(url=url, target_path=target,verbose=verbose)
+            res = download_version_from_s3(url=url, target_path=target, verbose=verbose)
             if not res:
-                download_file(url=url, target_path=target,verbose=verbose)
+                download_file(url=url, target_path=target, verbose=verbose)
         else:
             raise ArgumentError(
                 "unsupported url or file doesn't exist\n\turl={}".format(url))

--- a/ccmlib/utils/__init__.py
+++ b/ccmlib/utils/__init__.py
@@ -13,7 +13,7 @@ class global_injector:
         except KeyError:
             # Python 3
             self.__dict__['builtin'] = sys.modules['builtins'].__dict__
-    def __setattr__(self,name,value):
+    def __setattr__(self, name, value):
         self.builtin[name] = value
 
 Global = global_injector()

--- a/ccmlib/utils/sni_proxy.py
+++ b/ccmlib/utils/sni_proxy.py
@@ -155,7 +155,7 @@ def get_cluster_info(cluster, port=9142):
 def refresh_certs(cluster, nodes_info):
     with tempfile.TemporaryDirectory() as tmp_dir:
         dns_names = ['cql.cluster-id.scylla.com'] + \
-                    ['{}.cql.cluster-id.scylla.com'.format(host_id) for _, _, host_id, _ in nodes_info]
+                    [f'{host_id}.cql.cluster-id.scylla.com' for _, _, host_id, _ in nodes_info]
         generate_ssl_stores(tmp_dir, dns_names=dns_names)
         distutils.dir_util.copy_tree(tmp_dir, cluster.get_path())
 

--- a/ccmlib/utils/ssl_utils.py
+++ b/ccmlib/utils/ssl_utils.py
@@ -25,27 +25,27 @@ def generate_ssl_stores(base_dir, passphrase='cassandra', dns_names=None):
                                                         universal_newlines=True, stderr=subprocess.PIPE).stderr else []
     dns_names = dns_names or ['any.cluster-id.scylla.com']
     ext = ",".join(["dns:{}".format(name) for name in dns_names])
-    print("generating keystore.jks in [{0}]".format(base_dir))
+    print(("generating keystore.jks in [{0}]".format(base_dir)))
     subprocess.check_call(['keytool', '-genkeypair', '-alias', 'ccm_node', '-keyalg', 'RSA', '-validity', '365',
                            '-keystore', os.path.join(base_dir, 'keystore.jks'), '-storepass', passphrase,
                            '-dname', 'cn=Cassandra Node,ou=CCMnode,o=DataStax,c=US', '-keypass', passphrase,
                            '-ext', 'san={}'.format(ext)])
 
-    print("exporting cert from keystore.jks in [{0}]".format(base_dir))
+    print(("exporting cert from keystore.jks in [{0}]".format(base_dir)))
     subprocess.check_call(['keytool', '-export', '-rfc', '-alias', 'ccm_node',
                            '-keystore', os.path.join(base_dir, 'keystore.jks'),
                            '-file', os.path.join(base_dir, 'ccm_node.cer'), '-storepass', passphrase])
-    print("importing cert into truststore.jks in [{0}]".format(base_dir))
+    print(("importing cert into truststore.jks in [{0}]".format(base_dir)))
     subprocess.check_call(['keytool', '-import', '-file', os.path.join(base_dir, 'ccm_node.cer'),
                            '-alias', 'ccm_node', '-keystore', os.path.join(base_dir, 'truststore.jks'),
                            '-storepass', passphrase, '-noprompt'])
     # Added for scylla: Generate pem format cert/key
-    print("exporting cert to pks12 from keystore.jks in [{0}]".format(base_dir))
+    print(("exporting cert to pks12 from keystore.jks in [{0}]".format(base_dir)))
     subprocess.check_call(['keytool', '-importkeystore', '-srckeystore', os.path.join(base_dir, 'keystore.jks'),
                            '-srcstorepass', passphrase, '-srckeypass', passphrase, '-destkeystore',
                            os.path.join(base_dir, 'ccm_node.p12'), '-deststoretype', 'PKCS12',
                            '-srcalias', 'ccm_node', '-deststorepass', passphrase, '-destkeypass', passphrase])
-    print("Using openssl to split pks12 in [{0}] to pem format".format(base_dir))
+    print(("Using openssl to split pks12 in [{0}] to pem format".format(base_dir)))
     subprocess.check_call(['openssl', 'pkcs12', '-in', os.path.join(base_dir, 'ccm_node.p12'),
                            '-passin', 'pass:{0}'.format(passphrase), '-nokeys',
                            '-out', os.path.join(base_dir, 'ccm_node.pem')] + legacy)

--- a/ccmlib/utils/ssl_utils.py
+++ b/ccmlib/utils/ssl_utils.py
@@ -24,43 +24,43 @@ def generate_ssl_stores(base_dir, passphrase='cassandra', dns_names=None):
     legacy = ['-legacy'] if '-legacy' in subprocess.run(['openssl', 'pkcs12', '--help'],
                                                         universal_newlines=True, stderr=subprocess.PIPE).stderr else []
     dns_names = dns_names or ['any.cluster-id.scylla.com']
-    ext = ",".join(["dns:{}".format(name) for name in dns_names])
-    print(("generating keystore.jks in [{0}]".format(base_dir)))
+    ext = ",".join([f"dns:{name}" for name in dns_names])
+    print(f"generating keystore.jks in [{base_dir}]")
     subprocess.check_call(['keytool', '-genkeypair', '-alias', 'ccm_node', '-keyalg', 'RSA', '-validity', '365',
                            '-keystore', os.path.join(base_dir, 'keystore.jks'), '-storepass', passphrase,
                            '-dname', 'cn=Cassandra Node,ou=CCMnode,o=DataStax,c=US', '-keypass', passphrase,
-                           '-ext', 'san={}'.format(ext)])
+                           '-ext', f'san={ext}'])
 
-    print(("exporting cert from keystore.jks in [{0}]".format(base_dir)))
+    print(f"exporting cert from keystore.jks in [{base_dir}]")
     subprocess.check_call(['keytool', '-export', '-rfc', '-alias', 'ccm_node',
                            '-keystore', os.path.join(base_dir, 'keystore.jks'),
                            '-file', os.path.join(base_dir, 'ccm_node.cer'), '-storepass', passphrase])
-    print(("importing cert into truststore.jks in [{0}]".format(base_dir)))
+    print(f"importing cert into truststore.jks in [{base_dir}]")
     subprocess.check_call(['keytool', '-import', '-file', os.path.join(base_dir, 'ccm_node.cer'),
                            '-alias', 'ccm_node', '-keystore', os.path.join(base_dir, 'truststore.jks'),
                            '-storepass', passphrase, '-noprompt'])
     # Added for scylla: Generate pem format cert/key
-    print(("exporting cert to pks12 from keystore.jks in [{0}]".format(base_dir)))
+    print(f"exporting cert to pks12 from keystore.jks in [{base_dir}]")
     subprocess.check_call(['keytool', '-importkeystore', '-srckeystore', os.path.join(base_dir, 'keystore.jks'),
                            '-srcstorepass', passphrase, '-srckeypass', passphrase, '-destkeystore',
                            os.path.join(base_dir, 'ccm_node.p12'), '-deststoretype', 'PKCS12',
                            '-srcalias', 'ccm_node', '-deststorepass', passphrase, '-destkeypass', passphrase])
-    print(("Using openssl to split pks12 in [{0}] to pem format".format(base_dir)))
+    print(f"Using openssl to split pks12 in [{base_dir}] to pem format")
     subprocess.check_call(['openssl', 'pkcs12', '-in', os.path.join(base_dir, 'ccm_node.p12'),
-                           '-passin', 'pass:{0}'.format(passphrase), '-nokeys',
+                           '-passin', f'pass:{passphrase}', '-nokeys',
                            '-out', os.path.join(base_dir, 'ccm_node.pem')] + legacy)
     # Key with password. We want without...
     subprocess.check_call(['openssl', 'pkcs12', '-in', os.path.join(base_dir, 'ccm_node.p12'),
-                           '-passin', 'pass:{0}'.format(passphrase),
-                           '-passout', 'pass:{0}'.format(passphrase), '-nocerts',
+                           '-passin', f'pass:{passphrase}',
+                           '-passout', f'pass:{passphrase}', '-nocerts',
                            '-out', os.path.join(base_dir, 'ccm_node.tmp')] + legacy)
     subprocess.check_call(['openssl', 'pkcs8', '-in', os.path.join(base_dir, 'ccm_node.tmp'),
-                           '-passin', 'pass:{0}'.format(passphrase),
-                           '-passout', 'pass:{0}'.format(passphrase),
+                           '-passin', f'pass:{passphrase}',
+                           '-passout', f'pass:{passphrase}',
                            '-topk8',
                            '-out', os.path.join(base_dir, 'ccm_node.pkcs8')])
     subprocess.check_call(['openssl', 'rsa', '-in', os.path.join(base_dir, 'ccm_node.tmp'),
-                           '-passin', 'pass:{0}'.format(passphrase),
+                           '-passin', f'pass:{passphrase}',
                            '-out', os.path.join(base_dir, 'ccm_node.key')])
 
 

--- a/old_tests/test_cmds.py
+++ b/old_tests/test_cmds.py
@@ -36,10 +36,10 @@ class TestCCMCreate(TestCCMCmd):
     def validate_output(self, process):
         stdout, stderr = process.communicate()
         try:
-            print_("[OUT] %s" % stdout)
+            print_(f"[OUT] {stdout}")
             self.assertEqual(len(stderr), 0)
         except AssertionError:
-            print_("[ERROR] %s" % stderr.strip())
+            print_(f"[ERROR] {stderr.strip()}")
             raise
 
     def cluster_create_version_test(self):
@@ -83,7 +83,7 @@ class TestCCMCreate(TestCCMCmd):
         p = self.create_cmd(args)
         stdout, stderr = p.communicate()
 
-        print_("[OUT] %s" % stdout)
+        print_(f"[OUT] {stdout}")
         self.assertGreater(len(stdout), 18000)
         self.assertEqual(len(stderr), 0)
 

--- a/old_tests/test_cmds.py
+++ b/old_tests/test_cmds.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 
 import yaml
-from six import print_
 
 from ccmlib import common
 from . import TEST_DIR
@@ -36,10 +35,10 @@ class TestCCMCreate(TestCCMCmd):
     def validate_output(self, process):
         stdout, stderr = process.communicate()
         try:
-            print_(f"[OUT] {stdout}")
+            print(f"[OUT] {stdout}")
             self.assertEqual(len(stderr), 0)
         except AssertionError:
-            print_(f"[ERROR] {stderr.strip()}")
+            print(f"[ERROR] {stderr.strip()}")
             raise
 
     def cluster_create_version_test(self):
@@ -83,7 +82,7 @@ class TestCCMCreate(TestCCMCmd):
         p = self.create_cmd(args)
         stdout, stderr = p.communicate()
 
-        print_(f"[OUT] {stdout}")
+        print(f"[OUT] {stdout}")
         self.assertGreater(len(stdout), 18000)
         self.assertEqual(len(stderr), 0)
 

--- a/old_tests/test_lib.py
+++ b/old_tests/test_lib.py
@@ -2,12 +2,12 @@ import sys
 sys.path = [".."] + sys.path
 
 import decimal
+from io import StringIO
 
 from . import TEST_DIR
 from . import ccmtest
 from ccmlib.cluster import Cluster
 import ccmlib
-from six import StringIO
 
 CLUSTER_PATH = TEST_DIR
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/pcmanus/ccm',
     packages=['ccmlib', 'ccmlib.cmds', 'ccmlib.utils'],
     scripts=[ccmscript],
-    install_requires=['pyYaml', 'psutil', 'six >=1.12.0', 'requests', 'packaging', 'boto3', 'tqdm'],
+    install_requires=['pyYaml', 'psutil', 'requests', 'packaging', 'boto3', 'tqdm'],
     tests_require=['pytest'],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,6 @@ setup(
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4'

--- a/tests/ccmcluster.py
+++ b/tests/ccmcluster.py
@@ -86,12 +86,12 @@ class CCMCluster:
             stdout = stdout.strip()
             stderr = stderr.strip()
 
-            LOGGER.debug("[stdout] %s" % stdout)
-            LOGGER.debug("[stderr] %s" % stderr)
+            LOGGER.debug(f"[stdout] {stdout}")
+            LOGGER.debug(f"[stderr] {stderr}")
             assert status_code == expected_status_code
             return stdout, stderr
         except AssertionError:
-            LOGGER.error("[ERROR] %s" % stderr.strip())
+            LOGGER.error(f"[ERROR] {stderr.strip()}")
             raise
 
     def parse_cluster_status(self, stdout):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def results_dir():
 @pytest.fixture(scope="session")
 def test_id():
     ccm_test_id = TEST_ID or datetime.now().strftime("%Y%m%d-%H%M%S")
-    LOGGER.info("Using test id: '{}'".format(ccm_test_id))
+    LOGGER.info(f"Using test id: '{ccm_test_id}'")
     return ccm_test_id
 
 
@@ -34,15 +34,15 @@ def test_dir(test_id, results_dir):
     max_test_dirs, dir_count = 100, 1
     test_dir = results_dir / Path("ccm-" + test_id)
     while test_dir.exists() and dir_count <= max_test_dirs:
-        test_dir = results_dir / Path("ccm-{}-{}".format(test_id, dir_count))
+        test_dir = results_dir / Path(f"ccm-{test_id}-{dir_count}")
         dir_count += 1
 
     if dir_count >= max_test_dirs:
-        LOGGER.critical("Number of test directories is '{}'. Max allowed: '{}'".format(dir_count, max_test_dirs))
+        LOGGER.critical(f"Number of test directories is '{dir_count}'. Max allowed: '{max_test_dirs}'")
         assert dir_count >= max_test_dirs
     test_dir = os.getcwd() / test_dir
     test_dir.mkdir()
-    LOGGER.info("Test directory '{}' created.".format(test_dir))
+    LOGGER.info(f"Test directory '{test_dir}' created.")
     return test_dir
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ envlist = py34
 [testenv]
 commands = nosetests --where tests/ --with-coverage --cover-package ccmlib --cover-tests --traverse-namespace --all-modules 
 deps =
-    six
-    pyyaml 
+    pyyaml
     nose
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34
+envlist = py34
 
 [testenv]
 commands = nosetests --where tests/ --with-coverage --cover-package ccmlib --cover-tests --traverse-namespace --all-modules 


### PR DESCRIPTION
- setup, tox.ini: do not claim the python2.x support
- treewide: run 2to3 to the tree
- treewide: use f-string when appropriate
- treewide: do not use six module

Fixes #432