### PR TITLE
scylla_repository: patch systemctl calls out of install.sh 

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -819,9 +819,9 @@ def grouper(n, iterable, padvalue=None):
     return zip_longest(*[iter(iterable)] * n, fillvalue=padvalue)
 
 
-def print_if_standalone(*args, debug_callback=None, **kwargs):
+def print_if_standalone(*args, debug_callback=None, end='\n', **kwargs):
     standalone = os.environ.get('SCYLLA_CCM_STANDALONE', None)
     if standalone:
-        print_(*args, *kwargs, end='')
+        print_(*args, *kwargs, end=end)
     else:
         debug_callback(*args, **kwargs)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -895,10 +895,10 @@ class Node(object):
 
             for err in output[1].split('\n'):
                 if err.strip():
-                    common.print_if_standalone("(EE) %s" % err, debug_callback=self.debug)
+                    common.print_if_standalone("(EE) %s" % err, debug_callback=self.debug, end='')
 
             if show_output:
-                common.print_if_standalone(output[0], debug_callback=self.debug)
+                common.print_if_standalone(output[0], debug_callback=self.debug, end='')
 
             if return_output:
                 return output

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -26,7 +26,7 @@ import packaging.version
 
 from ccmlib.common import (
     ArgumentError, CCMError, get_default_path, rmdirs, validate_install_dir, get_scylla_version, aws_bucket_ls,
-    DOWNLOAD_IN_PROGRESS_FILE, wait_for_parallel_download_finish)
+    DOWNLOAD_IN_PROGRESS_FILE, wait_for_parallel_download_finish, print_if_standalone)
 from ccmlib.utils.download import download_file, download_version_from_s3
 from ccmlib.utils.version import parse_version
 
@@ -44,8 +44,12 @@ ENTERPRISE_RELOCATABLE_URLS_BASE = ['https://s3.amazonaws.com/downloads.scylladb
 
 
 def run(cmd, cwd=None):
-    subprocess.check_call(['bash', '-c', cmd], cwd=cwd,
-                          stderr=None, stdout=None)
+    try:
+        subprocess.run(['bash', '-c', cmd], cwd=cwd, check=True)
+    except subprocess.CalledProcessError as exp:
+        print_if_standalone(str(exp), debug_callback=logging.error)
+        print_if_standalone("stdout:\n%s" % exp.stdout, debug_callback=logging.error)
+        print_if_standalone("stderr:\n%s" % exp.stderr, debug_callback=logging.error)
 
 
 class RelocatablePackages(NamedTuple):

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -566,9 +566,10 @@ def run_scylla_unified_install_script(install_dir, target_dir, package_version):
     if package_version >= packaging.version.parse('2.2'):
         install_opt += ' --without-systemd'
     else:
-        # Patch the jmx install.sh to not use systemctl, in newer versions --without-systemd is covering it
-        run(r'''sed -i 's/systemctl --user.*/echo "commented out systemctl command"/' ./scylla-jmx/install.sh''',
+        # Patch the install.sh to not use systemctl, in newer versions --without-systemd is covering it
+        run(r'''sed -i 's/systemctl --user.*/echo "commented out systemctl command"/' ./install.sh ./**/install.sh''',
             cwd=install_dir)
+        run(r'''sed -i 's|/run/systemd/system|/run|' ./install.sh ./**/install.sh''',  cwd=install_dir)
 
     run('''{0}/install.sh --prefix {1} --nonroot{2}'''.format(
         install_dir, target_dir, install_opt), cwd=install_dir)

--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -8,9 +8,20 @@ from ccmlib.scylla_repository import setup as scylla_setup
 @pytest.mark.repo_tests
 @pytest.mark.skip("slow integration test")
 class TestScyllaRepository:
-    def test_setup_release_oss(self):
-        cdir, version = scylla_setup(version="release:4.2.1", verbose=True)
-        assert version == '4.2.1'
+    @pytest.mark.parametrize(argnames=['version', 'expected_version_string'], argvalues=[
+        ("release:5.1", '5.1'),
+        ("release:5.0", '5.0'),
+        ("release:4.6", '4.6'),
+        ("release:4.5", '4.5'),
+        ("release:4.4", '4.4'),
+        ("release:4.3", '4.3'),
+        ("release:4.2", '4.2'),
+        ("release:4.1", '4.1'),
+        ("release:4.0", '4.0'),
+    ])
+    def test_setup_release_oss(self, version, expected_version_string):
+        cdir, version = scylla_setup(version=version, verbose=True)
+        assert expected_version_string in version
 
     def test_setup_release_enterprise(self):
         cdir, version = scylla_setup(version="release:2020.1.5", verbose=True)


### PR DESCRIPTION
extend fix from https://github.com/scylladb/scylla-ccm/commit/424dd4445b6fc0c678e9505b00a0df0cdb39939b to
all `install.sh` scripts inside the unifed-package.

Fix: https://github.com/scylladb/scylla-dtest/issues/3060