### PR TITLE
scylla_repository: re-raise exception on `run()`

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -45,11 +45,12 @@ ENTERPRISE_RELOCATABLE_URLS_BASE = ['https://s3.amazonaws.com/downloads.scylladb
 
 def run(cmd, cwd=None):
     try:
-        subprocess.run(['bash', '-c', cmd], cwd=cwd, check=True)
+        subprocess.run(['bash', '-c', cmd], cwd=cwd, check=True, capture_output=True)
     except subprocess.CalledProcessError as exp:
         print_if_standalone(str(exp), debug_callback=logging.error)
         print_if_standalone("stdout:\n%s" % exp.stdout, debug_callback=logging.error)
         print_if_standalone("stderr:\n%s" % exp.stderr, debug_callback=logging.error)
+        raise
 
 
 class RelocatablePackages(NamedTuple):


### PR DESCRIPTION
69d304 introduced change to `run()` so we can log
better the output of commands, but it failed
to raise the error after that.

that made the output a bit confusing and failed the whole idea.