### PR TITLE
Replace eu-west-1 with system.local data_center value

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -709,7 +709,7 @@ class ClusterStartCmd(Cmd):
                 else:
                     docker_id, listen_address, listen_port = \
                         start_sni_proxy(self.cluster.get_path(), nodes_info=nodes_info, listen_port=self.options.sni_port)
-                    create_cloud_config(self.cluster.get_path(), port=listen_port, address=listen_address)
+                    create_cloud_config(self.cluster.get_path(), port=listen_port, address=listen_address, nodes_info=nodes_info)
 
                     print('sni_proxy listening on: {}:{}'.format(listen_address, listen_port))
                     self.cluster.sni_proxy_docker_id = docker_id


### PR DESCRIPTION
The `create_cloud_config` function generates files config_data.yaml and config_path.yaml. The files were created with the hardcoded datacenter name eu-west-1 which is now replaced by fetching the real datacenter name from the node's `system.local` table.