### PR TITLE
test_scylla_cmds: test also with scylla master latest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,12 @@ def ccm_cassandra_cluster():
 
 
 @pytest.fixture(scope="session")
+def ccm_reloc_latest_cluster():
+    cluster = CCMCluster(test_id="reloc_master", relocatable_version="unstable/master:latest")
+    return cluster
+
+
+@pytest.fixture(scope="session")
 def cluster_under_test(request):
     cluster = request.getfixturevalue(request.param)
     return cluster

--- a/tests/test_scylla_cmds.py
+++ b/tests/test_scylla_cmds.py
@@ -16,6 +16,7 @@ cluster_params = pytest.mark.parametrize(
     'cluster_under_test',
     (pytest.param('ccm_docker_cluster', marks=[pytest.mark.docker, pytest.mark.skip(reason="ccm docker support broke in master, need to fix")]),
      pytest.param('ccm_reloc_cluster', marks=pytest.mark.reloc),
+     pytest.param('ccm_reloc_latest_cluster', marks=pytest.mark.reloc),
      pytest.param('ccm_cassandra_cluster', marks=pytest.mark.cassandra)
      ),
     indirect=True


### PR DESCRIPTION
since recent failure we had, adding few tests that would verify ccm is working as expcet with scylla
master latest version