### PR TITLE
scylla_node: find tool in $install_dir/tools/cqlsh/bin also

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -124,6 +124,7 @@ class ScyllaNode(Node):
         candidate_dirs = [
             os.path.join(self.node_install_dir, 'share', 'cassandra', BIN_DIR),
             os.path.join(self.get_tools_java_dir(), BIN_DIR),
+            os.path.join(self.get_cqlsh_dir(), BIN_DIR),
         ]
         for candidate_dir in candidate_dirs:
             candidate = shutil.which(toolname, path=candidate_dir)
@@ -896,6 +897,9 @@ class ScyllaNode(Node):
 
     def get_jmx_dir(self):
         return common.get_jmx_dir(self.node_install_dir, self._relative_repos_root or '..')
+
+    def get_cqlsh_dir(self):
+        return os.path.join(self.node_install_dir, 'tools', 'cqlsh')
 
     def __copy_logback_files(self):
         shutil.copy(os.path.join(self.get_tools_java_dir(), 'conf', 'logback-tools.xml'),

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -121,14 +121,15 @@ class ScyllaNode(Node):
         return os.path.join(self.get_path(), 'conf')
 
     def get_tool(self, toolname):
-        candidates = [
-            common.join_bin(Path(self.node_install_dir) / 'share' / 'cassandra', BIN_DIR, toolname),
-            common.join_bin(self.get_tools_java_dir(), BIN_DIR, toolname)
+        candidate_dirs = [
+            os.path.join(self.node_install_dir, 'share', 'cassandra', BIN_DIR),
+            os.path.join(self.get_tools_java_dir(), BIN_DIR),
         ]
-        for candidate in candidates:
-            if os.path.exists(candidate):
+        for candidate_dir in candidate_dirs:
+            candidate = shutil.which(toolname, path=candidate_dir)
+            if candidate:
                 return candidate
-        raise ValueError(f"tool {toolname} wasn't found in any path: {candidates}")
+        raise ValueError(f"tool {toolname} wasn't found in any path: {candidate_dirs}")
 
     def get_tool_args(self, toolname):
         raise NotImplementedError('ScyllaNode.get_tool_args')


### PR DESCRIPTION
there are chances that user installs the tool to be found in $PATH,
for instance, user might already install the specified tool using
`pip install scylla-cqlsh`. so we should use $PATH as a fallback
instead of assuming that they are located under the two candidate
directories.

so, in this change, in addition to the candidate directories, we
also search for the tool in $PATH, as `shutil.which()` search the
given cmd in $PATH if the specified `path` parameter is None.