### PR TITLE
make_cassandra_env: hardcode java_home to jvm8

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -185,7 +185,7 @@ class Node(object):
         update_conf = not self.__conf_updated
         if update_conf:
             self.__conf_updated = True
-        return common.make_cassandra_env(self.get_install_dir(), self.get_path(), update_conf)
+        return common.make_cassandra_env(self.get_install_dir(), self.get_path(), update_conf, hardcode_java_version='8')
 
     def get_install_cassandra_root(self):
         return self.get_install_dir()

--- a/tests/test_scylla_download.py
+++ b/tests/test_scylla_download.py
@@ -29,10 +29,3 @@ class TestUtilsDownload:
         with pytest.raises(requests.exceptions.HTTPError, match='Not Found'):
             download_file("https://s3.amazonaws.com/downloads.scylladb.com/abcdefg",
                           target_path=pathlib.Path(tmpdir) / 'scylla-manager.repo')
-
-
-if __name__ == '__main__':
-    # demo of progress bar
-    download_version_from_s3(
-        'https://s3.amazonaws.com/downloads.scylladb.com/relocatable/unstable/master/2020-08-29T22:24:05Z/scylla-package.tar.gz',
-        target_path='tempfile', verbose=True)

--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -31,10 +31,6 @@ class TestScyllaRepository:
         cdir, version = scylla_setup(version="unstable/master:2021-01-18T15:48:13Z", verbose=True)
         assert version == '4.4.dev'
 
-    def test_setup_unstable_master_old_url(self):
-        cdir, version = scylla_setup(version="unstable/master:2020-08-29T22:24:05Z", verbose=True)
-        assert version == '3.0'
-
 
 class TestScyllaRepositoryRelease:
     @pytest.mark.parametrize(argnames=['version', 'expected_cdir'], argvalues=[
@@ -108,10 +104,3 @@ class TestScyllaRepositoryRelease:
         assert packages.scylla_tools_package == 'https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/master/relocatable/2021-01-18T15:48:13Z/scylla-tools-package.tar.gz'
         assert packages.scylla_jmx_package == 'https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/master/relocatable/2021-01-18T15:48:13Z/scylla-jmx-package.tar.gz'
 
-    def test_setup_unstable_master_old_url(self):
-        cdir, packages = scylla_setup(version="unstable/master:2020-08-29T22:24:05Z", verbose=True, skip_downloads=True)
-        assert '2020-08-29T22_24_05Z' in cdir
-        assert not packages.scylla_unified_package
-        assert packages.scylla_package
-        assert packages.scylla_tools_package
-        assert packages.scylla_jmx_package


### PR DESCRIPTION
since we are switching to use jvm11 for scylla, but still have test that are using cassandra 3.11 that works only with jvm8, we are hardwiring the code to always try to select the jvm8 for cassandra