### PR TITLE
scylla_node: expose ScyllaNode.smp()

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -104,6 +104,9 @@ class ScyllaNode(Node):
         self._smp =  smp
         self._smp_set_during_test = True
 
+    def smp(self):
+        return self._smp
+
     def set_mem_mb_per_cpu(self, mem):
         self._mem_mb_per_cpu = mem
         self._mem_set_during_test = True


### PR DESCRIPTION
so the dtest tests are able to acess the exact number of shard used for testing. for instance, some of them might need to calculate the exact total memory based on this option.

Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>
(cherry picked from commit 1362c33da05c9c566b7368c82ee87174cdc8b508)