### PR TITLE
node: run_cqlsh: add timeout parameter

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -863,7 +863,7 @@ class Node(object):
                         print(log, end='')
                     i = i + 1
 
-    def run_cqlsh(self, cmds=None, show_output=False, cqlsh_options=None, return_output=False):
+    def run_cqlsh(self, cmds=None, show_output=False, cqlsh_options=None, return_output=False, timeout=600):
         cqlsh_options = cqlsh_options or []
         cqlsh = self.get_tool('cqlsh')
         if not isinstance(cqlsh, list):
@@ -889,7 +889,7 @@ class Node(object):
                     p.stdin.write(cmd + ';\n')
             p.stdin.write("quit;\n")
 
-            output = p.communicate()
+            output = p.communicate(timeout=timeout)
 
             for err in output[1].split('\n'):
                 if err.strip():


### PR DESCRIPTION
Set by default to 10 minutes to prevent blocking in `communicate` forever.

Blocked run_cqlsh was seen in https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-daily-release/244/testReport/cqlsh_tests.cqlsh_copy_tests/TestCqlshCopy/Run_Dtest_Parallel_Cloud_Machines___FullDtest___full_split000___test_copy_to_with_child_process_crashing/

https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-daily-release/244/artifact/logs-full.release.000/dtest-gw3.log
```
13:13:59,598 751     cqlsh_tests.cqlsh_copy_tests   DEBUG    cqlsh_copy_tests.py :1525 | test_copy_to_with_child_process_crashing: Exporting to csv file: /tmp/tmpqskw5279 with {"exit_range": {"start": 0, "end": 5000000000000000000}}
...
13:58:50,244 751     errors                         ERROR    conftest.py         :203  | test_copy_to_with_child_process_crashing: test failed: 
```
