### PR TITLE
pin down urllib3<2 since botocore doesn't support it

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,7 +42,7 @@ jobs:
         
         pip install -U pip setuptools
 
-        python setup.py install
+        pip install .
 
         if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/pcmanus/ccm',
     packages=['ccmlib', 'ccmlib.cmds', 'ccmlib.utils'],
     scripts=[ccmscript],
-    install_requires=['pyYaml', 'psutil', 'requests', 'packaging', 'boto3', 'tqdm'],
+    install_requires=['pyYaml', 'psutil', 'requests', 'packaging', 'boto3', 'tqdm', 'urllib3<2'],
     tests_require=['pytest'],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Look like new version of requests is pulling newer versions of urllib3 which are not comptible with
botocore.

Ref: https://github.com/boto/botocore/issues/2926
Ref: https://github.com/psf/requests/issues/6443
Ref: https://github.com/urllib3/urllib3/issues/2168