### PR TITLE
hardcode_java_version: add check for for existence of java binary

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -252,11 +252,13 @@ def make_cassandra_env(install_dir, node_path, update_conf=True, hardcode_java_v
             f"hardcode_java_version={hardcode_java_version} not supported in:\n{known_jvm_names}"
 
         for java_path in pathlib.Path('/usr/lib/jvm/').iterdir():
-            if java_path.is_dir and any(name in java_path.name for name in known_jvm_names[hardcode_java_version]):
+            if (java_path.is_dir
+                    and any(name in java_path.name for name in known_jvm_names[hardcode_java_version])
+                    and list(java_path.rglob('java'))):
                 env['JAVA_HOME'] = str(java_path)
                 break
         else:
-            raise ArgumentError("java-8 wasn't found in /usr/lib/jvm/")
+            raise ArgumentError(f"java-8 wasn't found in /usr/lib/jvm/\n {list(pathlib.Path('/usr/lib/jvm/').iterdir())}")
 
     return env
 

--- a/tests/ccmcluster.py
+++ b/tests/ccmcluster.py
@@ -47,6 +47,9 @@ class CCMCluster:
     def get_remove_cmd(self):
         return [self.ccm_bin, "remove", self.name]
 
+    def get_stop_cmd(self):
+        return [self.ccm_bin, "stop", self.name]
+
     def get_list_cmd(self):
         return [self.ccm_bin, "list"]
 

--- a/tests/test_scylla_cmds.py
+++ b/tests/test_scylla_cmds.py
@@ -41,6 +41,8 @@ class TestCCMCreateCluster:
         try:
             yield
         finally:
+            cluster_under_test.run_command(cluster_under_test.get_stop_cmd())
+            cluster_under_test.process.wait()
             copy_cluster_data(request=request)
             cluster_under_test.run_command(cluster_under_test.get_remove_cmd())
             cluster_under_test.process.wait()
@@ -74,6 +76,8 @@ class TestCCMClusterStatus:
             cluster_under_test.validate_command_result()
             yield
         finally:
+            cluster_under_test.run_command(cluster_under_test.get_stop_cmd())
+            cluster_under_test.process.wait()
             copy_cluster_data(request)
             cluster_under_test.run_command(cluster_under_test.get_remove_cmd())
             cluster_under_test.process.wait()
@@ -100,6 +104,8 @@ class TestCCMClusterStart:
         try:
             yield
         finally:
+            cluster_under_test.run_command(cluster_under_test.get_stop_cmd())
+            cluster_under_test.process.wait()
             copy_cluster_data(request)
             cluster_under_test.run_command(cluster_under_test.get_remove_cmd())
             cluster_under_test.process.wait()
@@ -147,6 +153,8 @@ class TestCCMClusterNodetool:
             cluster_under_test.validate_command_result()
             yield
         finally:
+            cluster_under_test.run_command(cluster_under_test.get_stop_cmd())
+            cluster_under_test.process.wait()
             copy_cluster_data(request)
             cluster_under_test.run_command(cluster_under_test.get_remove_cmd())
             cluster_under_test.process.wait()
@@ -204,6 +212,8 @@ class TestCCMClusterManagerSctool:
             cluster_under_test.validate_command_result()
             yield
         finally:
+            cluster_under_test.run_command(cluster_under_test.get_stop_cmd())
+            cluster_under_test.process.wait()
             copy_cluster_data(request)
             cluster_under_test.run_command(cluster_under_test.get_remove_cmd())
             cluster_under_test.process.wait()


### PR DESCRIPTION
since in some distro or jvm manager we might have more folders
in `/usr/lib/jvm/` which are just information folders with ends with
`*.jinfo` but the same as the actual folder we are looking for.