### PR TITLE
ccmlib/cmds/node_cmds: make versionfrombuild useful

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -929,13 +929,5 @@ class NodeVersionfrombuildCmd(Cmd):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
 
     def run(self):
-        version_from_nodetool = self.node.nodetool('version')[0].strip()
         version_from_build = common.get_version_from_build(self.node.get_install_dir())
-
-        if version_from_nodetool and (version_from_nodetool != version_from_build):
-            print('nodetool reports Cassandra version {ntv}; '
-                   'version from build.xml is {bv}'.format(ntv=version_from_nodetool,
-                                                           bv=version_from_build),
-                   file=sys.stderr)
-
         print(version_from_build)


### PR DESCRIPTION
make `versionfrombuild` command work without a running node we don't need to cross check with nodetool that the version is the correct one, the once mention in scylla package is enough for us.

we need this working for driver test that would be able to pick test base on the versions.