### PR TITLE
scylla_cluster: fix handling of wait_other_notice

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -16,6 +16,7 @@ from ccmlib.scylla_node import ScyllaNode
 from ccmlib.node import NodeError
 from ccmlib import scylla_repository
 from ccmlib.utils.sni_proxy import stop_sni_proxy
+from ccmlib.node import Status
 
 SNITCH = 'org.apache.cassandra.locator.GossipingPropertyFileSnitch'
 
@@ -120,6 +121,7 @@ class ScyllaCluster(Cluster):
                     last_node.watch_log_for("node is now in normal status|Starting listening for CQL clients",
                                             verbose=verbose, from_mark=last_mark,
                                             process=last_node._process_scylla)
+                    last_node.status = Status.UP
                 mark = 0
                 if os.path.exists(node.logfilename()):
                     mark = node.mark_log()


### PR DESCRIPTION
After starting a multi-node cluster, it's important to wait until all nodes are aware that all other nodes are UP, otherwise the user sends a CL=ALL request to one node, it might not be aware that the other replicas are alive, and fail the request.

For this reason a cluster's start() has a wait_other_notice=True option, and dtests correctly use it. However, the implementation seems to have a bug: When ccm starts the Nth node, instead of waiting for all nodes 1..N-1 to learn that N is up, it only waits for the nodes among 1..N-1 which it *knows* are up (node.status == Status.UP). But this information appears to be delayed, so we often end up not waiting for some of the nodes to learn about node N!

The solution I propose is here simple: I note that the cluster-starting code *already* waits for each node to become UP before continuing to the next one. So after we waited for the node to become UP, let's mark it as UP immediately, without waiting for some background operation to notice it. This will allow the next iteration to realize that when we start the *next* node, the previous node is surely one of the nodes that will need to wait for it.

This patch is needed if Scylla is modified to boot up faster. We start seeing dtests which use RF=ALL in the beginning of a test failing, because the node we contact doesn't know that the other nodes are UP.