### PR TITLE
ccmlib/scylla_node: wait for scylla process to be running

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -677,7 +677,9 @@ class ScyllaNode(Node):
                      self.name, ip_addr, jmx_port)
             raise NodeError(e_msg, scylla_process)
 
-        self.is_running()
+        self._update_pid(scylla_process)
+        wait_for(func=lambda: self.is_running(), timeout=10, step=0.01, text="Waiting for scylla process to be running")
+
         if self.scylla_manager and self.scylla_manager.is_agent_available:
             self.start_scylla_manager_agent()
         return scylla_process


### PR DESCRIPTION
seem like there was a call to `node.is_running()` that wasn't checking the output, and assuming it would update the pid information, and wasn't always the case.

this was causing cases that the next node would identifed as running and not considered as part of the `wait_other_notice` check.