### PR TITLE
ccmlib/common: remove prints from `wait_for`

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -512,7 +512,7 @@ def scylla_extract_install_dir_and_mode(install_dir):
     return install_dir, scylla_mode
 
 
-def wait_for(func: Callable, timeout: int, first: float = 0.0, step: float = 1.0, text: str = ""):
+def wait_for(func: Callable, timeout: int, first: float = 0.0, step: float = 1.0):
     """
     Wait until func() evaluates to True.
 
@@ -523,19 +523,16 @@ def wait_for(func: Callable, timeout: int, first: float = 0.0, step: float = 1.0
     param timeout: Timeout in seconds.
     param first: Time to sleep in seconds before first attempt.
     param step: Time to sleep in seconds between attempts in seconds.
-    param text: Text to print while waiting, for debug purposes.
     """
-    start_time = time.time()
     end_time = time.time() + timeout
 
     time.sleep(first)
 
     while time.time() < end_time:
-        if text:
-            print(f"{text} ({time.time() - start_time:f} secs)")
         if func():
             return True
         time.sleep(step)
+
     return False
 
 

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -678,7 +678,7 @@ class ScyllaNode(Node):
             raise NodeError(e_msg, scylla_process)
 
         self._update_pid(scylla_process)
-        wait_for(func=lambda: self.is_running(), timeout=10, step=0.01, text="Waiting for scylla process to be running")
+        wait_for(func=lambda: self.is_running(), timeout=10, step=0.01)
 
         if self.scylla_manager and self.scylla_manager.is_agent_available:
             self.start_scylla_manager_agent()


### PR DESCRIPTION
remove text parameter from `wait_for` it was spamming the outout for now real reason. we should be print to stdout during tests. for debug propuses we
should be using `logging.debug`, which in
this case isn't needed.

Fixes: #465