### PR TITLE
ccmlib/node: add support for `cassandra-stress -cloudconf`

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1233,7 +1233,11 @@ class Node(object):
                 # cassandra-stress has version command
                 stress_options = [o.replace('limit=', 'throttle=') for o in stress_options]
 
-        if not ('-node' in stress_options or '-d' in stress_options):
+        options_implying_node = ['-d', '-node', '-cloudconf']
+        if any(opt in options_implying_node for opt in stress_options):
+            # no need to specify address
+            pass
+        else:
             if self.cluster.cassandra_version() < '2.1':
                 stress_options.append('-d')
                 stress_options.append(self.address())

--- a/tests/test_scylla_cmds.py
+++ b/tests/test_scylla_cmds.py
@@ -273,3 +273,15 @@ class TestCCMClusterSniProxy:
 
         assert not res[1], f"cqlsh command failed:\n\n{res[1]}"
 
+    def test_stress(self, cluster_under_test):
+        cmd = Cmd()
+        cmd.path = common.get_default_path()
+        cluster = cmd._load_current_cluster()
+        conf_dir = cluster.get_path()
+
+        cloud_bundle = Path(conf_dir) / 'config_data.yaml'
+
+        output = cluster.nodes['node1'].stress(['write', 'duration=5s', "no-warmup", '-rate',
+                                                'threads=2', '-cloudconf', f'file={cloud_bundle}'])
+
+        assert output.stdout.strip().endswith(("END", "DONE")), f"Run c-s failed: {output}"


### PR DESCRIPTION
since when we want to use `-cloudconf` flag
we shouldn't be appending address and port to the
commandline arguments.