### PR TITLE
Add experimental Nix Flake support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,58 @@
+name: CCM Integration tests (using Nix)
+
+on:
+  push:
+    branches:
+     - master
+     - next*
+
+  pull_request:
+    branches:
+     - next*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v20
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Cache binary versions
+      id: cache-versions
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.ccm/repository
+          ~/.ccm/scylla-repository
+        key: ${{ runner.os }}-binaries
+
+    - name: Download versions
+      if: steps.cache-versions.outputs.cache-hit != 'true'
+      run: |
+        if [ ! -f ~/.ccm/scylla-repository/unstable/master/2023-04-13T13_31_00Z ]; then
+          RELOC_VERSION="2023-04-13T13:31:00Z"
+        
+          nix develop --command ./ccm create temp -n 1 --scylla --version unstable/master:${RELOC_VERSION}
+          nix develop --command ./ccm remove
+        fi
+        nix develop --command ./ccm create temp-cas -n 1 --version 3.11.4 > /dev/null
+        nix develop --command ./ccm remove
+
+    - name: Test with pytest (python 3.9)
+      run: |
+        nix develop --command python3.9 -m pytest ./tests -x
+
+    - name: Test with pytest (python 3.11)
+      run: |
+        nix develop --command python3.11 -m pytest ./tests -x
+
+    - name: Copy logs/results
+      if: contains(github.event.pull_request.labels.*.name, 'PR-upload-log')
+      uses: actions/upload-artifact@v2
+      with:
+        name: ccm-tests-log
+        path: tests/test_results/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ccm.egg-info/
 .project
 .coverage
 tests/test_results
+.direnv/

--- a/README.md
+++ b/README.md
@@ -86,8 +86,40 @@ There is also a [Homebrew package][brew] available:
 
     brew install ccm
 
+You can also use ccm trough Nix.
+
+    Spawn new temporary shell with ccm present, without installing: `nix shell github:scylladb/scylla-ccm`
+    Install ccm: `nix profile install github:scylladb/scylla-ccm`
+    To remove / update ccm installed this way, first locate it's index in `nix profile list`.
+    To remove it, use `nix profile remove <index>`.
+    To update it use `nix profile upgrade <index>` - or `nix profile upgrade '.*'` to upgrade all Nix packages.
+
   [pip]: https://pypi.python.org/pypi/ccm
   [brew]: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/ccm.rb
+
+Nix
+-----------------------
+
+This project features experimental Nix flake.
+It allows ccm to be used as a dependency in other nix projects or to quickly launch a dev shell
+with all dependencies required to run and test the project.
+
+### How to setup Nix shell
+
+1. Install Nix: https://nixos.org/download.html - on Fedora you should probably use "Single-user installation",
+   as there are some problems with multi-user due to SELinux.
+2. Activate required experimental features:
+```
+mkdir -p ~/.config/nix
+echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+```
+   If you installed Nix in multi-user mode, you will need to restart Nix daemon.
+3. First option: using direnv. Install direnv (see: https://direnv.net/docs/installation.html ), `cd` into project directory and execute `direnv allow .`.
+   Now you will have dev env activated whenever you are in a project's directory - and automatically unloaded when you leave it.
+4. Second option: use `nix develop` command directly. This command will launch a bash session with loaded dev env. If you want to use your favourite shell,
+   pass `--command <shell>` flag to `nix develop` (in my case: `nix develop --command zsh`).
+
+If you want to install ccm using Nix, or launch a temporary shell with ccm - see "Installation" section.
 
 Usage
 -----

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1688221086,
+        "narHash": "sha256-cdW6qUL71cNWhHCpMPOJjlw0wzSRP0pVlRn2vqX/VVg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cd99c2b3c9f160cd004318e0697f90bbd5960825",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "A script/library to create, launch and remove an Scylla / Apache Cassandra cluster on
+localhost.";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      prepare_python_requirements = python: python.withPackages (ps: with ps; [ pytest pyyaml psutil six requests packaging boto3 tqdm setuptools ]);
+      make_ccm_package = {python, jdk, pkgs}: python.pkgs.buildPythonApplication {
+        pname = "scylla_ccm";
+        version = "0.1";
+
+        src = ./. ;
+
+        checkInputs = with python.pkgs; [ pytestCheckHook ];
+        buildInputs = [ pkgs.makeWrapper ];
+        propagatedBuildInputs =  [ (prepare_python_requirements python) jdk];
+        doCheck = false;
+
+        disabledTestPaths = [ "old_tests/*.py" ];
+
+        # Make `nix run` aware that the binary is called `ccm`.
+        meta.mainProgram = "ccm";
+
+        postInstall = ''
+          wrapProgram $out/bin/ccm \
+            --set JAVA_HOME "${jdk}"
+        '';
+      };
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+      let 
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      rec {
+        packages = rec {
+          scylla_ccm = python: make_ccm_package { inherit python pkgs ; jdk = pkgs.jdk8; };
+          default = scylla_ccm pkgs.python311;
+        };
+        devShell =
+          pkgs.mkShell {
+            buildInputs = [ pkgs.poetry pkgs.glibcLocales (prepare_python_requirements pkgs.python39) (prepare_python_requirements pkgs.python311) pkgs.jdk8];
+            shellHook = ''
+              set JAVA_HOME ${pkgs.jdk8}
+            '';
+        };
+      }
+    ) // rec {
+      overlays.default = final: prev: {
+        scylla_ccm = python: make_ccm_package { inherit python; jdk = final.jdk8; pkgs = final; };
+      };
+    };
+}


### PR DESCRIPTION
Nix is, citing their GH repo,  'a powerful package manager for Linux and other Unix systems that makes package management reliable and reproducible.'
See here for a more detailed description: https://serokell.io/blog/what-is-nix

We want to use Nix in drivers (starting with Java driver) to create reproducible, easy to use development environments, and later to extend this to CI and release process.
In order to do that, we need to create Nix package for CCM, as it's used by many drivers in integration tests. This PR accomplishes experimental version of it.

PR introduces Nix flake that can be used to add CCM as a dependency somewhere or to quickly enter a development environment where you can run and test CCM (with caveats due to Scylla using absolute paths when searching for Java - see commit messages / README / flake.nix).
There is also a CI pipeline running tests in Nix environment - marked with `continue-on-error` in order to not affect CCM's development process if something breaks in Nix. When we are sure everything is correct and stable, this parameter can be removed.