### PR TITLE
Fix Python 3.8 compatibility

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,12 +14,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.11"]
+
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.11
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: ${{ matrix.python-version }}
 
     - name: Cache pip
       uses: actions/cache@v2

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -17,7 +17,7 @@ import tempfile
 import logging
 import pathlib
 from itertools import zip_longest
-from typing import Callable, Optional, TextIO, Union
+from typing import Callable, Optional, TextIO, Union, List
 
 import yaml
 from boto3.session import Session
@@ -943,7 +943,7 @@ def assert_jdk_valid_for_cassandra_version(cassandra_version):
         exit(1)
 
 
-def aws_bucket_ls(s3_url: str) -> list[str]:
+def aws_bucket_ls(s3_url: str) -> List[str]:
     bucket_object = s3_url.replace('https://s3.amazonaws.com/', '').split('/')
     prefix = '/'.join(bucket_object[1:])
 


### PR DESCRIPTION
Recent change introduced typing that is incompatible with Python < 3.9. There are other Scylla projects relying on CCM (e.g. most drivers) and for some of them this change caused CI failures (as of now - for Rust driver and Python driver).

This PR fixes the problem by making this typing compatible with older Python versions.
It also adds CI that runs on older Python. I wanted it to be 3.6, because that's the oldest version supported by Python driver, but it seems this version can't be installed by `setup-python@v4` action, so I bumped it to 3.8