### PR TITLE
ccmlib/common: check install_dir/SCYLLA-VERSION-FILE first

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -708,6 +708,7 @@ def get_version_from_build(install_dir=None, node_path=None):
 
 def _get_scylla_version(install_dir):
     scylla_version_files = [
+        os.path.join(install_dir, 'SCYLLA-VERSION-FILE'),
         os.path.join(install_dir, 'build', 'SCYLLA-VERSION-FILE'),
         os.path.join(install_dir, '..', '..', 'build', 'SCYLLA-VERSION-FILE'),
         os.path.join(install_dir, 'scylla-core-package', 'SCYLLA-VERSION-FILE'),


### PR DESCRIPTION
we have some dtests which are marked with "dtest_enterprise" mark. and they deselect themselves if ccm claims that the scylla build is not enterprise.

sometimes, we just want to run some of these dtest right from local build, whose SCYLLA-VERSION-FILE is co-located with the scylla executable binary, right under the "install_dir" instead of "install_dir/build/" or somewhere else. so, in this case, ccm would either fail to find the right SCYLLA-VERSION-FILE, or find a wrong one.

in this change, we add $install_dir/SCYLLA-VERSION-FILE at the front of the check list, so that ccm can check and use it if this file exists. this should address the pain of developers who want to test from the local build.