### PR TITLE
remove .envrc from source

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ ccm.egg-info/
 .coverage
 tests/test_results
 .direnv/
+
+.envrc


### PR DESCRIPTION
diffrent people are using direnv diffrently
we shouldn't put it on the source