### PR TITLE
scylla_cluster,scylla_node: increase debug timeout for `watch_rest_for_alive`

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -146,7 +146,8 @@ class ScyllaCluster(Cluster):
             for old_node, _ in marks:
                 for node, _, _ in started:
                     if old_node is not node:
-                        old_node.watch_rest_for_alive(node)
+                        t = 120 if self.scylla_mode != 'debug' else 600
+                        old_node.watch_rest_for_alive(node, timeout=t)
 
         return started
 

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -309,7 +309,7 @@ class ScyllaNode(Node):
 
         if wait_other_notice:
             for node, _ in marks:
-                t = timeout if timeout is not None else 120 if self.cluster.scylla_mode != 'debug' else 360
+                t = timeout if timeout is not None else 120 if self.cluster.scylla_mode != 'debug' else 600
                 node.watch_rest_for_alive(self, timeout=t)
                 self.watch_rest_for_alive(node, timeout=t)
 


### PR DESCRIPTION
seems like the 360s default for debug for `watch_rest_for_alive` isn't enough as it was for `watch_log_for_alive`,
making it 600s (10min)

Fix: #477