### PR TITLE
ccmlib/node: capture the output of sstable2json command in logging file

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -974,20 +974,19 @@ class Node(object):
         self._create_directory()
 
     def run_sstable2json(self, out_file=None, keyspace=None, datafiles=None, column_families=None, enumerate_keys=False):
-        print("running")
         if out_file is None:
-            out_file = sys.stdout
+            out_file = subprocess.PIPE
         sstable2json = self._find_cmd('sstabledump')
         env = self.get_env()
         sstablefiles = self.__gather_sstables(datafiles, keyspace, column_families)
-        print(sstablefiles)
+        common.print_if_standalone(str(sstablefiles), debug_callback=self.info, end='')
         for sstablefile in sstablefiles:
-            print(f"-- {os.path.basename(sstablefile)} -----")
+            common.print_if_standalone(f"-- {os.path.basename(sstablefile)} -----", debug_callback=self.info, end='')
             args = sstable2json + [sstablefile]
             if enumerate_keys:
                 args = args + ["-e"]
-            subprocess.call(args, env=env, stdout=out_file)
-            print("")
+            res = subprocess.run(args, env=env, stdout=out_file, text=True, check=True)
+            common.print_if_standalone(res.stdout if res.stdout else '', debug_callback=self.info, end='')
 
     def run_json2sstable(self, in_file, ks, cf, keyspace=None, datafiles=None, column_families=None, enumerate_keys=False):
         json2sstable = self._find_cmd('json2sstable')


### PR DESCRIPTION
After recent changes to scylla, we fount that:
* this call was failing silently
* was printing to stdout, and not into logging

exmple of such failure, that some test failed to notice:
```
[2023-07-26T06:42:39.223Z] Exception in thread "main" java.lang.NumberFormatException: For input string: "3g7z_0in1_5tmap2bezca73ozy4m"
[2023-07-26T06:42:39.224Z] 	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
[2023-07-26T06:42:39.224Z] 	at java.base/java.lang.Integer.parseInt(Integer.java:652)
[2023-07-26T06:42:39.224Z] 	at java.base/java.lang.Integer.parseInt(Integer.java:770)
[2023-07-26T06:42:39.224Z] 	at org.apache.cassandra.io.sstable.Descriptor.fromFilename(Descriptor.java:280)
[2023-07-26T06:42:39.224Z] 	at org.apache.cassandra.io.sstable.Descriptor.fromFilename(Descriptor.java:228)
[2023-07-26T06:42:39.224Z] 	at org.apache.cassandra.io.sstable.Descriptor.fromFilename(Descriptor.java:217)
[2023-07-26T06:42:39.224Z] 	at org.apache.cassandra.tools.SSTableExport.run(SSTableExport.java:188)
[2023-07-26T06:42:39.224Z] 	at com.scylladb.tools.SSTableExport.main(SSTableExport.java:44)
```