### PR TITLE
scylla_cluster: introduce `cluster.default_wait_*` properties

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -42,6 +42,8 @@ class ScyllaCluster(Cluster):
 
         self.started = False
         self.force_wait_for_cluster_start = (force_wait_for_cluster_start != False)
+        self.default_wait_other_notice_timeout = 120 if self.scylla_mode != 'debug' else 600
+        self.default_wait_for_binary_proto = 420 if self.scylla_mode != 'debug' else 900
         self._scylla_manager = None
         self.skip_manager_server = skip_manager_server
         self.scylla_version = cassandra_version
@@ -146,8 +148,7 @@ class ScyllaCluster(Cluster):
             for old_node, _ in marks:
                 for node, _, _ in started:
                     if old_node is not node:
-                        t = 120 if self.scylla_mode != 'debug' else 600
-                        old_node.watch_rest_for_alive(node, timeout=t)
+                        old_node.watch_rest_for_alive(node, timeout=self.default_wait_other_notice_timeout)
 
         return started
 

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -272,7 +272,7 @@ class ScyllaNode(Node):
         return bool(self.grep_log(f"{bootstrap_message}|{resharding_message}", from_mark=from_mark))
 
     def _start_scylla(self, args, marks, update_pid, wait_other_notice,
-                      wait_for_binary_proto, ext_env, timeout=None):
+                      wait_for_binary_proto, ext_env):
         log_file = os.path.join(self.get_path(), 'logs', 'system.log')
         # In case we are restarting a node
         # we risk reading the old cassandra.pid file
@@ -308,20 +308,20 @@ class ScyllaNode(Node):
                 raise NodeError(f"Error starting node {self.name}",
                                 self._process_scylla)
 
-        if wait_other_notice:
-            for node, _ in marks:
-                t = timeout if timeout is not None else 120 if self.cluster.scylla_mode != 'debug' else 600
-                node.watch_rest_for_alive(self, timeout=t)
-                self.watch_rest_for_alive(node, timeout=t)
-
         if wait_for_binary_proto:
-            t = timeout * 4 if timeout is not None else 420 if self.cluster.scylla_mode != 'debug' else 900
+            t = self.cluster.default_wait_for_binary_proto
             from_mark = self.mark
             try:
-                self.wait_for_binary_interface(from_mark=from_mark, process=self._process_scylla, timeout=timeout or 180)
-            except TimeoutError as e:
+                self.wait_for_binary_interface(from_mark=from_mark, process=self._process_scylla, timeout=t)
+            except TimeoutError:
                 self.wait_for_starting(from_mark=self.mark, timeout=t)
-                self.wait_for_binary_interface(from_mark=from_mark, process=self._process_scylla, timeout=0)
+                self.wait_for_binary_interface(from_mark=from_mark, process=self._process_scylla, timeout=t)
+
+        if wait_other_notice:
+            for node, _ in marks:
+                t = self.cluster.default_wait_other_notice_timeout
+                node.watch_rest_for_alive(self, timeout=t)
+                self.watch_rest_for_alive(node, timeout=t)
 
         return self._process_scylla
 


### PR DESCRIPTION
* moving the setting those default timeout into the cluster `__init__`
  and a user of the cluster (i.e. dtest) can set those higher
  if needed.

* removed `timeout` argument from `_start_scylla` since no
  code in ccm or dtest were using it.

* reversed the order of `wait_for_binary_proto` with `wait_other_notice`
  since it was agree that `wait_for_starting` should happen first
  and the chances that after `wait_for_binary_proto` would end,
  `wait_other_notice` could finish much faster (current assumption
  is that no test is calling wait_other_notice=True while
  wait_for_binary_proto=False)