### PR TITLE
node.py: compact(): add keyspace and tables argument

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1336,8 +1336,12 @@ class Node(object):
             cmd += f" {table}"
         self.nodetool(cmd, **kwargs)
 
-    def compact(self):
-        self.nodetool("compact")
+    def compact(self, keyspace = "", tables = []):
+        compact_cmd = ["compact"]
+        if keyspace:
+            compact_cmd.append(keyspace)
+        compact_cmd += tables
+        self.nodetool(" ".join(compact_cmd))
 
     def drain(self, block_on_log=False):
         mark = self.mark_log()


### PR DESCRIPTION
To allow specifying the keyspace/table to compact, instead of compacting all of them.