### PR TITLE
ccmlib/node: run_sstable2json to handle non-exist files

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -985,7 +985,10 @@ class Node(object):
             args = sstable2json + [sstablefile]
             if enumerate_keys:
                 args = args + ["-e"]
-            res = subprocess.run(args, env=env, stdout=out_file, text=True, check=True)
+            res = subprocess.run(args, env=env, stdout=out_file, stderr=subprocess.PIPE, text=True)
+            if not res.returncode == 0 and "Cannot find file" not in res.stderr:
+                common.print_if_standalone(res.stderr, debug_callback=self.info, end='')
+                raise ToolError(args, exit_status=res.returncode, stdout=res.stdout, stderr=res.stderr)
             common.print_if_standalone(res.stdout if res.stdout else '', debug_callback=self.info, end='')
 
     def run_json2sstable(self, in_file, ks, cf, keyspace=None, datafiles=None, column_families=None, enumerate_keys=False):


### PR DESCRIPTION
seems like introducing of raising failure on any failure of sstabledump has started to fail some dtests
since it was used in some places right after compation and some of the sstable were deleted between listing them to using them with sstable dump, so we need to ignore failures from non existing files.