### PR TITLE
ccmlib/node: fix `run_sstable2json` on exception case

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -987,12 +987,12 @@ class Node(object):
                 args = args + ["-e"]
             try:
                 res = subprocess.run(args, env=env, stdout=out_file, text=True, check=True)
+                common.print_if_standalone(res.stdout if res.stdout else '', debug_callback=self.info, end='')
             except subprocess.CalledProcessError as e:
-                if 'Cannot find file' in res.stderr:
+                if 'Cannot find file' in e.stderr:
                     pass
                 else:
                     raise ToolError(e.cmd, e.returncode, e.stdout, e.stderr)
-            common.print_if_standalone(res.stdout if res.stdout else '', debug_callback=self.info, end='')
 
     def run_json2sstable(self, in_file, ks, cf, keyspace=None, datafiles=None, column_families=None, enumerate_keys=False):
         json2sstable = self._find_cmd('json2sstable')


### PR DESCRIPTION
a741f782bb4c9fef33bd3c42ac3bacb9a0f1cc42 has an issue it was looking into the wrong variable to check the stderr, and when there a failure would cause the
wrong failure

fix: scylladb/scylla-dtest#3454