### PR TITLE
node: manage all_pids as a set

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1836,7 +1836,7 @@ class Node(object):
                     self.pid = int(f.readline().strip().decode('utf-16'))
                 else:
                     self.pid = int(f.readline().strip())
-                self.all_pids.append(self.pid)
+                self.all_pids = list(set(self.all_pids) | {self.pid})
         except IOError as e:
             raise NodeError(f'Problem starting node {self.name} due to {e}', process)
         self.__update_status()


### PR DESCRIPTION
The following has been seen in
https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-debug/247/testReport/lwt_banking_load_test/TestLWTBankingLoad/Run_Dtest_Parallel_Cloud_Machines___HeavyDtest___heavy_split000___test_bank_with_nemesis/:
```
self = <lwt_banking_load_test.TestLWTBankingLoad object at 0x7f1aeef51890>
with_oracle = True

    def test_bank_with_nemesis(self, with_oracle=True):
        start = time()
>       session = self.prepare()

lwt_banking_load_test.py:1122:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <lwt_banking_load_test.TestLWTBankingLoad object at 0x7f1aeef51890>
num_nodes = 4

    def prepare(self, num_nodes=NODES):
        """Set up cluster, schema, tables"""
        cluster = self.cluster
        cluster.set_configuration_options(values={
            "hinted_handoff_enabled": False,
        })
        jvm_args = ["--smp", str(num_nodes)]
        if not cluster.nodelist():
            cluster.populate(num_nodes)
            cluster.start(wait_other_notice=True, wait_for_binary_proto=True, jvm_args=jvm_args)

        node_list = cluster.nodelist()
        for node in node_list:
>           assert len(node.all_pids) == 1
E           assert 2 == 1
E            +  where 2 = len([1022, 1022])
E            +    where [1022, 1022] = <ccmlib.scylla_node.ScyllaNode object at 0x7f1aee773590>.all_pids
```

Note that pid 1022 is repeated twice in the all_pids list.

This change makes sure that unique pids are squashed together.

Note that all_pids remains a list since there is code in dtest that treats it as such and changing the member to a set() will break that code.