### PR TITLE
scylla_extract_mode: fix regex pattern to match mode

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -626,7 +626,10 @@ def scylla_extract_mode(path):
     # path/url examples:
     #   /jenkins/data/relocatable/unstable/master/202001192256/scylla-package.tar.gz
     #   url=https://downloads.scylla.com/relocatable/unstable/master/202001192256/scylla-debug-package.tar.gz
-    m = re.search(r'(^|/)(scylla|scylla-enterprise)(-(?P<mode>\w+))?(-(\w+))?-package([-./][\w./]+|$)', path)
+    #   url=https://downloads.scylladb.com/unstable/scylla/master/relocatable/latest/scylla-debug-unified-5.4.0~dev-0.20230801.37b548f46365.x86_64.tar.gz
+    #   url=https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla-enterprise/enterprise/relocatable/latest/scylla-enterprise-debug-unstripped-2023.3.0~dev-0.20230806.6dc3aeaf312c.aarch64.tar.gz
+    name = os.path.split(path)[-1]
+    m = re.search(r'(^|/)(?P<product>scylla(?:-enterprise)?)(?:-(?P<mode>debug|dev|release))?-.*\.tar\.gz', name)
     if m:
         mode = m.groupdict().get('mode')
         return mode if mode in ('debug', 'dev') else 'release'

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -26,6 +26,9 @@ def test_scylla_extract_mode():
     assert scylla_extract_mode('url=https://s3.amazonaws.com/downloads.scylladb.com/downloads/scylla-enterprise/'
                                'relocatable/scylladb-2022.1/scylla-enterprise-debug-aarch64-package-2022.1.rc0.0.20220331.f3ee71fba.tar.gz') == 'debug'
 
+    assert scylla_extract_mode("url=https://downloads.scylla.com/relocatable/unstable/master/202001192256/scylla-debug-package.tar.gz") == 'debug'
+    assert scylla_extract_mode("url=https://downloads.scylladb.com/unstable/scylla/master/relocatable/latest/scylla-debug-unified-5.4.0~dev-0.20230801.37b548f46365.x86_64.tar.gz") == 'debug'
+    assert scylla_extract_mode("url=https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla-enterprise/enterprise/relocatable/latest/scylla-enterprise-debug-unstripped-2023.3.0~dev-0.20230806.6dc3aeaf312c.aarch64.tar.gz") == 'debug'
 
 # Those tests assume that LockFile uses fcntl.flock
 # If it switches to anything else, the tests need to be adjusted.


### PR DESCRIPTION
The current regular expression failed to match
the mode for e.g
`https://downloads.scylladb.com/unstable/scylla/master/relocatable/latest/scylla-debug-unified-5.4.0~dev-0.20230801.37b548f46365.x86_64.tar.gz`

See https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-debug/247/consoleText
```
[2023-08-06T05:45:02.790Z] SCYLLA_UNIFIED_PACKAGE=/jenkins/workspace/scylla-master/dtest-debug/scylla/build/debug/dist/tar/scylla-debug-unified-5.4.0~dev-0.20230801.37b548f46365.x86_64.tar.gz
```

https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-debug/247/artifact/logs-full.debug.052/dtest-gw0.log
```
07:54:08,036 790     errors                         ERROR    conftest.py         :208  | test_cluster_expansion_with_cdc[Single_cluster]: test failed:
...
            try:
>               self.wait_for_binary_interface(from_mark=from_mark, process=self._process_scylla, timeout=t)

../scylla/.local/lib/python3.11/site-packages/ccmlib/scylla_node.py:318:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../scylla/.local/lib/python3.11/site-packages/ccmlib/node.py:537: in wait_for_binary_interface
    self.watch_log_for("Starting listening for CQL clients", **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <ccmlib.scylla_node.ScyllaNode object at 0x7f4150514410>
exprs = 'Starting listening for CQL clients', from_mark = 0, timeout = 420
```

timeout should have been 900 seconds for debug mode if it was matched properly.