### PR TITLE
ccmlib/node: fix `run_sstable2json` on exception case - yet again

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -986,10 +986,10 @@ class Node(object):
             if enumerate_keys:
                 args = args + ["-e"]
             try:
-                res = subprocess.run(args, env=env, stdout=out_file, text=True, check=True)
+                res = subprocess.run(args, env=env, stdout=out_file, stderr=subprocess.PIPE, text=True, check=True)
                 common.print_if_standalone(res.stdout if res.stdout else '', debug_callback=self.info, end='')
             except subprocess.CalledProcessError as e:
-                if 'Cannot find file' in e.stderr:
+                if e.stderr and 'Cannot find file' in e.stderr:
                     pass
                 else:
                     raise ToolError(e.cmd, e.returncode, e.stdout, e.stderr)


### PR DESCRIPTION
seems like 730e556bce9a74e2bee9f5e00ced3968e272b8db wasn't enough and it didn't handled cases command would fail and stderr is None

also seem like we are not pipeing stderr, as we should for this exception handling to work correctly.