### PR TITLE
node: match with uuid-based sstable identifier

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -347,7 +347,7 @@ class Node(object):
             assert result.stdout, f"Empty command '\"{find_cmd}\" output"
             all_sstable_files = result.stdout.splitlines()
 
-            sstable_version_regex = re.compile(r'(\w+)-\d+-(.+)\.(db|txt|sha1|crc32)')
+            sstable_version_regex = re.compile(r'(\w+)-[^-]+-(.+)\.(db|txt|sha1|crc32)')
 
             sstable_versions = {sstable_version_regex.search(f).group(1) for f in all_sstable_files if
                                 sstable_version_regex.search(f)}


### PR DESCRIPTION
this change enables Node.check_node_sstables_format() to match sstable component files which use uuid-based sstable identifier. this should pave the road of dtest to test with
uuid_sstable_identifiers_enabled set.