### PR TITLE
readme: Add info on creating a build-id cluster 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://github.com/scylladb/scylla/wiki/Using-CCM
 
 Scylla usage examples:
 ---------------------------------------------------------------------
-### To create a 3-node Scylla cluster do:
+### Creating a 3-node Scylla cluster:
 ```bash
 $ ccm create my_cluster --scylla --vnodes -n 3 -v release:2022.2
 $ ccm start
@@ -29,7 +29,7 @@ node3: UP
 ```
 The nodes will be available at 127.0.0.1, 127.0.0.2 and 127.0.0.3.
 
-### To create a multi-datacenter cluster that has 3 nodes in dc1, 4 nodes in dc2 and 5 nodes in dc3 do:
+### Creating a multi-datacenter cluster that has 3 nodes in dc1, 4 nodes in dc2 and 5 nodes in dc3:
 ```bash
 $ ccm create my_multi_dc_cluster --scylla --vnodes -n 3:4:5 -v release:2022.2
 $ ccm start

--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ $ ccm start
 # Wait a lot...
 ```
 
+### Creating a cluster of nodes with a specific build-id:
+
+Let's say you want to create a cluster of Scylla with build id `f6e718548e76ccf3564ed2387b6582ba8d37793c` (it's `Scylla 2023.1.0~rc8-20230731.b6f7c5a6910c`).
+
+1. Go to https://backtrace.scylladb.com and find your desired Scylla version
+2. Click the arrow down symbol (\\/) to show all available download links
+3. Download the unified Scylla package (`unified-pack-url-x86_64`)
+4. Create a 3 node cluster:
+```bash
+# The unified package will be extracted to ~/.ccm/scylla-repository/my_custom_scylla
+# Make sure that the version name (my_custom_scylla) is different for each unified package you use, otherwise ccm will use the previously extracted version.
+ccm create my_cluster -n 3 --scylla --vnodes \
+    --version my_custom_scylla \
+    --scylla-unified-package-uri=/home/$USER/Downloads/scylla-enterprise-unified-2023.1.0\~rc8-0.20230731.b6f7c5a6910c.x86_64.tar.gz
+```
+
 Requirements
 ------------
 


### PR DESCRIPTION
Add instructions that describe how to create a cluster of Scylla nodes with a specific build-id.

It's not obvious how to achieve this - you have to download the right package from the right place, and then use the right combination of flags for `ccm`.

Let's add the instructions to make it easier for future users of `ccm`.
