### PR TITLE
scylla_node: populate env variable when running scylla-sstable

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1414,7 +1414,11 @@ class ScyllaNode(Node):
                 stdout, stderr = json.dumps(empty_dump), ''
                 return (stdout, stderr)
             common_args = [scylla_path, "sstable", command] + additional_args
-            res = subprocess.run(common_args + sstables, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+            try:
+                env = self._launch_env
+            except AttributeError:
+                env = os.environ
+            res = subprocess.run(common_args + sstables, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True, env=env)
             return (res.stdout, res.stderr)
 
         if batch:


### PR DESCRIPTION
if scylla is built in a dtest environment, and the shared libraries which it is linked against cannot be found in the testbed's default ld.so.conf paths, the tests which run scylla-sstable would fail.

so, in this change. let's apply the `self._launch_env` when running scylla-sstable as well. previously, these env variables are only applied when launching scylla as a daemon.