### PR TITLE
ccmlib/node: cleanup unsealed system sstables for offline tools

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1891,8 +1891,10 @@ class Node(object):
         return files
 
     def __cleanup_sstables(self, keyspace, cf):
-        if keyspace != 'system_schema':
-            self.get_sstables('system_schema', '', cleanup_unsealed=True)
+        system_keyspace_names = ['system_schema', 'system']
+        if keyspace not in system_keyspace_names:
+            for system_keyspace_name in system_keyspace_names:
+                self.get_sstables(system_keyspace_name, '', cleanup_unsealed=True)
         try:
             return self.get_sstables(keyspace, cf, cleanup_unsealed=True)
         except common.ArgumentError:


### PR DESCRIPTION
see also 3616251066f8a520a7eec99d507dc16128e2926f

otherwise, `sstablelevelreset` would try to load the unsealed sstables and print out error messages in stderr if not all the components are available or is corrupted. this fails the test which checks for unexpected errors.

Fixes https://github.com/scylladb/scylladb/issues/15210