### PR TITLE
enable tablets in kespaces created by node.stress

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -720,3 +720,7 @@ class Cluster(object):
     @staticmethod
     def is_docker():
         return False
+
+    @property
+    def tablets_enabled(self) -> bool:
+        return 'tablets' in self._config_options.get('experimental_features', [])

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -4,6 +4,7 @@
 import errno
 import glob
 import itertools
+import math
 import os
 import re
 import shutil
@@ -16,6 +17,7 @@ import warnings
 from datetime import datetime
 import locale
 from collections import namedtuple
+from typing import List, Optional
 
 import yaml
 
@@ -1277,7 +1279,14 @@ class Node(object):
                 # specify used jmx port if not already set
                 if not [opt for opt in stress_options if opt.startswith('jmx=')]:
                     stress_options.extend(['-port', 'jmx=' + self.jmx_port])
-
+        if self.cluster.tablets_enabled:
+            smp = sum([node._smp or 1 for node in self.cluster.nodes.values()])
+            # default initial tablets: 32 * `sum of SMPs in cluster` coerced to power of 2 (suitable for small number of tables)
+            initial_tablets = int(math.pow(2, math.ceil(math.log(smp*32, 2))))
+            self.debug("tablets enabled, adjusting stress options by replication strategy change.")
+            stress_options = self._set_keyspace_initial_tablets(
+                stress_options, datacenter=self.data_center, initial_tablets=initial_tablets
+            )
         args = stress + stress_options
         stdout_handle = kwargs.pop("stdout", subprocess.PIPE)
         stderr_handle = kwargs.pop("stderr", subprocess.PIPE)
@@ -1294,6 +1303,41 @@ class Node(object):
             return handle_external_tool_process(p, ['stress'] + stress_options)
         except KeyboardInterrupt:
             pass
+
+    @staticmethod
+    def _set_keyspace_initial_tablets(stress_options: List[str], initial_tablets:int = 8,
+                                      datacenter: Optional[str] = None, rf: int = 1) -> List[str]:
+        normalized_stress_options = []
+        for stress_option in stress_options:
+            # sometimes users pass schema params in one str, split it
+            if stress_option.startswith("-schema"):
+                if " " in stress_option:
+                    normalized_stress_options += stress_option.split()
+                    continue
+            normalized_stress_options.append(stress_option)
+        stress_options = normalized_stress_options
+        datacenter = datacenter or 'datacenter1'
+        default_replication = f"replication(strategy=NetworkTopologyStrategy,{datacenter}={rf},initial_tablets={initial_tablets})"
+        try:
+            idx = stress_options.index('-schema')
+            replication = stress_options[idx + 1]
+            if 'replication' in replication:
+                if 'NetworkTopologyStrategy' in replication:
+                    # if NTP already set, just prepend initial_tablets
+                    replication = re.sub(r'replication\(.+?\)',
+                                         lambda m: m.group(0).replace(')', f',initial_tablets={initial_tablets})'), replication)
+                else:
+                    replication = re.sub(r'replication\(.*factor=(\d+)\)',
+                                         f'replication(strategy=NetworkTopologyStrategy,{datacenter}=' + r'\1' + f',initial_tablets={initial_tablets})',
+                                         replication)
+                stress_options[idx + 1] = replication
+            else:
+                # no replication provided in -schema, use default
+                stress_options.insert(idx + 1, default_replication)
+        except ValueError:
+            # no -schema provided
+            stress_options += ['-schema', default_replication]
+        return stress_options
 
     @staticmethod
     def _set_stress_val(key, val, res):

--- a/tests/test_set_keyspace_initial_tablets.py
+++ b/tests/test_set_keyspace_initial_tablets.py
@@ -1,0 +1,30 @@
+import pytest
+from typing import List, Optional
+
+from ccmlib.node import Node
+
+
+@pytest.mark.parametrize("stress_options, initial_tablets, datacenter, rf, expected", [
+    # typical case
+    (['write', 'n=0', 'no-warmup', '-schema', 'replication(factor=1)', '-rate', 'threads=1'], 8, None, 3,
+     ['write', 'n=0', 'no-warmup', '-schema', 'replication(strategy=NetworkTopologyStrategy,datacenter1=1,initial_tablets=8)', '-rate', 'threads=1']),
+    # no replication
+    (['write', 'n=3500K', '-rate', 'threads=50', '-schema', 'compaction(strategy=SizeTieredCompactionStrategy)'], 8, None, 3,
+     ['write', 'n=3500K', '-rate', 'threads=50', '-schema', 'replication(strategy=NetworkTopologyStrategy,datacenter1=3,initial_tablets=8)', 'compaction(strategy=SizeTieredCompactionStrategy)']),
+    # replication and keyspace provided in one param
+    (['write', 'n=20000', 'no-warmup', '-schema', 'replication(factor=4) keyspace=ks1'], 8, None, 3,
+     ['write', 'n=20000', 'no-warmup', '-schema', 'replication(strategy=NetworkTopologyStrategy,datacenter1=4,initial_tablets=8) keyspace=ks1']),
+    # replication in one str with -schema
+    (['write', 'cl=QUORUM', 'n=100', "-schema replication(factor=3)", "-mode cql3 native", "-rate threads=10", "-pop seq=1..100"], 8, None, 3,
+     ['write', 'cl=QUORUM', 'n=100', "-schema", 'replication(strategy=NetworkTopologyStrategy,datacenter1=3,initial_tablets=8)', "-mode cql3 native", "-rate threads=10", "-pop seq=1..100"]),
+    # Different number of initial_tablets
+    (['write', 'n=0', 'no-warmup', '-schema', 'replication(factor=1)', '-rate', 'threads=1'], 10, None, 3,
+     ['write', 'n=0', 'no-warmup', '-schema', 'replication(strategy=NetworkTopologyStrategy,datacenter1=1,initial_tablets=10)', '-rate',
+      'threads=1']),
+    # Different datacenter
+    (['write', 'n=0', 'no-warmup', '-schema', 'replication(factor=1)', '-rate', 'threads=1'], 8, 'datacenter2', 3,
+     ['write', 'n=0', 'no-warmup', '-schema', 'replication(strategy=NetworkTopologyStrategy,datacenter2=1,initial_tablets=8)', '-rate',
+      'threads=1'])
+])
+def test_set_keyspace_initial_tablets(stress_options: List[str], initial_tablets:int, datacenter: Optional[str], rf: int, expected: List[str]):
+    assert Node._set_keyspace_initial_tablets(stress_options, initial_tablets, datacenter, rf) == expected


### PR DESCRIPTION
We want to test tablets functionality without need for test adaptation (creating keyspace with tablets enabled  before node.stress is run).

Modify `stress_options` by add `initial_tablets` option and change replication strategy to `NetworkTopologyStrategy` to support tablets tests.

fixes: https://github.com/scylladb/scylla-ccm/issues/509