### PR TITLE
scylla_node: wait_for_compactions: adjust timeout for debug mode

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1710,3 +1710,8 @@ class NodeUpgrader:
         if self.node.node_scylla_version != expected_version:
             raise NodeUpgradeError("Node hasn't been upgraded. Expected version after upgrade: %s, Got: %s" % (
                                     expected_version, self.node.node_scylla_version))
+
+    def wait_for_compactions(self, idle_timeout=None):
+        if idle_timeout is None:
+            idle_timeout = 300 if self.scylla_mode() != 'debug' else 900
+        super(ScyllaNode, self).wait_for_compactions(idle_timeout=idle_timeout)


### PR DESCRIPTION
As seen in https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-debug/254/artifact/logs-full.debug.041/1694933753003_compaction_additional_test.py%3A%3ATestLCSSSTablePromotion%3A%3Atest_lcs_sstable_promotion/node1.log the default 5 minutes timeout is insufficient in debug mode.