### PR TITLE
ccmlib/common: support yaml syntax in updateconf command values

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -830,7 +830,10 @@ class ClusterUpdateconfCmd(Cmd):
         return "Update the cassandra config files for all nodes"
 
     def get_parser(self):
-        usage = "usage: ccm updateconf [options] [ new_setting | ...  ], where new_setting should be a string of the form 'compaction_throughput_mb_per_sec: 32'; nested options can be separated with a period like 'client_encryption_options.enabled: false'"
+        usage = ("usage: ccm updateconf [options] [ new_setting | ...  ], "
+                 "where new_setting should be a string of the form 'key:val'; "
+                 "where 'key' is the name of an option, 'val' is the YAML representation of its value, "
+                 "nested options can be separated with a period like 'client_encryption_options.enabled: false'")
         parser = self._get_default_parser(usage, self.description())
         parser.add_option('--no-hh', '--no-hinted-handoff', action="store_false",
                           dest="hinted_handoff", default=True, help="Disable hinted handoff")
@@ -870,7 +873,10 @@ class ClusterUpdatedseconfCmd(Cmd):
         return "Update the dse config files for all nodes"
 
     def get_parser(self):
-        usage = "usage: ccm updatedseconf [options] [ new_setting | ...  ], where new_setting should be a string of the form 'max_solr_concurrency_per_core: 2'; nested options can be separated with a period like 'cql_slow_log_options.enabled: true'"
+        usage = ("usage: ccm updatedseconf [options] [ new_setting | ...  ], "
+                 "where new_setting should be a string of the form 'key:val'; "
+                 "where 'key' is the name of an option, 'val' is the YAML representation of its value, "
+                 "nested options can be separated with a period like 'client_encryption_options.enabled: false'")
         parser = self._get_default_parser(usage, self.description())
         return parser
 

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -590,7 +590,10 @@ class NodeUpdateconfCmd(Cmd):
         return "Update the cassandra config files for this node (useful when updating cassandra)"
 
     def get_parser(self):
-        usage = "usage: ccm node_name updateconf [options] [ new_setting | ...  ], where new_setting should be a string of the form 'compaction_throughput_mb_per_sec: 32'"
+        usage = ("usage: ccm node_name updateconf [options] [ new_setting | ...  ], "
+                 "where new_setting should be a string of the form 'key:val'; "
+                 "where 'key' is the name of an option, 'val' is the YAML representation of its value, "
+                 "nested options can be separated with a period like 'client_encryption_options.enabled: false'")
         parser = self._get_default_parser(usage, self.description())
         parser.add_option('--no-hh', '--no-hinted-handoff', action="store_false",
                           dest="hinted_handoff", default=True, help="Disable hinted handoff")

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -769,11 +769,7 @@ def normalize_interface(itf):
 def parse_settings(args):
     settings = {}
     for s in args:
-        if is_win():
-            # Allow for absolute path on Windows for value in key/value pair
-            splitted = s.split(':', 1)
-        else:
-            splitted = s.split(':')
+        splitted = s.split(':', 1)
         if len(splitted) != 2:
             raise ArgumentError("A new setting should be of the form 'key: value', got " + s)
         key = splitted[0].strip()
@@ -784,10 +780,7 @@ def parse_settings(args):
         elif val.lower() == "false":
             val = False
         else:
-            try:
-                val = int(val)
-            except ValueError:
-                pass
+            val = yaml.safe_load(val)
         splitted = key.split('.')
         if len(splitted) == 2:
             try:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,10 @@
-from ccmlib.common import scylla_extract_mode, LockFile
 import tempfile
 import os
+
+import pytest
+import yaml
+
+from ccmlib.common import scylla_extract_mode, LockFile, parse_settings
 
 
 def test_scylla_extract_mode():
@@ -69,3 +73,25 @@ def test_lockfile_retain_status_by_default():
     assert lf.acquire(blocking=False)[0] is True
     assert lf.read_status() == 'some_status_1'
     lf.release()
+
+def test_parse_settings():
+    res = parse_settings(["number:12", "string:somthing", "bool:false"])
+    assert res == {'bool': False, 'number': 12, 'string': 'somthing'}
+
+    res = parse_settings(["nested.number:12", "nested.string:somthing", "nested.bool:false"])
+    assert res == {'nested': {'bool': False, 'number': 12, 'string': 'somthing'}}
+
+    # a fix that need to be backported from upstream
+    # https://github.com/riptano/ccm/commit/37afe6ab86fe03d5be7d0cf7a328dccac035a9a0
+    # res = parse_settings(["double.nested.number:12", "double.nested.string:somthing", "double.nested.bool:false"])
+    # assert res == {'double': {'nested': {'bool': False, 'number': 12, 'string': 'somthing'}}}
+
+    res = parse_settings(["experimental_features:[udf,tablets]"])
+    assert res == {'experimental_features': ['udf', 'tablets']}
+
+    res = parse_settings(["experimental_features:['udf',\"tablets\"]"])
+    assert res == {'experimental_features': ['udf', 'tablets']}
+
+    # would break if incorrect yaml format is passed in the value
+    with pytest.raises(yaml.parser.ParserError):
+        parse_settings(["experimental_features:['udf',\"tablets\""])


### PR DESCRIPTION
since in some place we need to be able to pass in a list
for example in `experimental_features`, ccm didn't support it
in the `ccm updateconf` command, now it would support it
but passing it via the command line, like the following:

```bash
> ccm updateconf experimental_features:[udf,tablets]
```