### PR TITLE
node.py: generalize expected message in watch_log_for_death

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -513,7 +513,7 @@ class Node(object):
         the log is watched from the beginning.
         """
         tofind = nodes if isinstance(nodes, list) else [nodes]
-        tofind = [f"{node.address()} is now (dead|DOWN)" for node in tofind]
+        tofind = [f"{node.address()}.* now (dead|DOWN)" for node in tofind]
         self.watch_log_for(tofind, from_mark=from_mark, timeout=timeout, filename=filename)
 
     def watch_log_for_alive(self, nodes, from_mark=None, timeout=120, filename='system.log'):


### PR DESCRIPTION
`watch_log_for_death` scans node logs looking for a message that says `"<nodeaddress> is now DOWN"`. When this message appears in the logs of other nodes we can be certain that this particular node is now DOWN.

In `Scylla` the messages looks like this:
```bash
127.0.0.1 is now DOWN
127.0.0.1 is now UP
```

But in `Cassandra 4.1.3` the messages are a bit different:
```
127.0.0.1:7000 is now DOWN
127.0.0.1:7000 is now UP
```

In Cassandra the node's address also includes the port. `watch_log_for_death` didn't handle this properly - the regex expected an ip address and then " is now DOWN".
Because of this it wasn't able to detect the message and `node.stop()` kept timing out for Cassandra nodes.

To fix it let's generalize the regex so that it handles both of the messages properly.
The regex is now pretty much the same as that in `watch_log_for_alive`, which looks for `is now UP` messages. It's located a few lines below `watch_for_log_death`.