### PR TITLE
utils.sni_proxy: fix docker build retry logic

### DIFF
--- a/ccmlib/utils/sni_proxy.py
+++ b/ccmlib/utils/sni_proxy.py
@@ -4,6 +4,7 @@ import subprocess
 import json
 import base64
 import itertools
+import logging
 from contextlib import contextmanager
 import tempfile
 from textwrap import dedent
@@ -14,6 +15,8 @@ import yaml
 
 from ccmlib.utils.ssl_utils import generate_ssl_stores
 from ccmlib.common import wait_for
+
+logger = logging.getLogger(__name__)
 
 @contextmanager
 def file_or_memory(path=None, data=None):
@@ -133,7 +136,13 @@ def start_sni_proxy(conf_dir, nodes_info, listen_port=443):
     sniproxy_conf_path = configure_sni_proxy(conf_dir, nodes_info, listen_port=listen_port)
     sniproxy_dockerfile = os.path.join(os.path.dirname(__file__), '..', 'resources', 'docker', 'sniproxy')
     def build_sniproxy():
-        subprocess.check_output(['/bin/bash', '-c', f'docker build {sniproxy_dockerfile} -t sniproxy'], universal_newlines=True)
+        try:
+            subprocess.check_output(['/bin/bash', '-c', f'docker build {sniproxy_dockerfile} -t sniproxy'], universal_newlines=True)
+            return True
+        except Exception:
+            logger.exception("failed to build sniproxy image")
+            pass
+
     wait_for(func=build_sniproxy, timeout=360, step=1)
 
     docker_id = subprocess.check_output(['/bin/bash', '-c', f'docker run -d --network=host -v {sniproxy_conf_path}:/etc/sniproxy.conf:z -p {listen_port}:{listen_port} -it sniproxy'], universal_newlines=True)


### PR DESCRIPTION
4cdf92333e6a1115dd2b20b292ee955fd5632527 was trying to apply retry of the `docker build` command
but it wasn't complete and would really retrying

Fixes: scylladb/scylladb#15662