### PR TITLE
scylla_cluster: load_from_repository: set default timeouts

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -627,9 +627,10 @@ def scylla_extract_mode(path):
     #   /jenkins/data/relocatable/unstable/master/202001192256/scylla-package.tar.gz
     #   url=https://downloads.scylla.com/relocatable/unstable/master/202001192256/scylla-debug-package.tar.gz
     #   url=https://downloads.scylladb.com/unstable/scylla/master/relocatable/latest/scylla-debug-unified-5.4.0~dev-0.20230801.37b548f46365.x86_64.tar.gz
+    #   /jenkins/workspace/scylla-master/dtest-debug/scylla/build/debug/dist/tar/scylla-debug-unified-5.4.0~dev-0.20231013.055f0617064d.x86_64.tar.gz
     #   url=https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla-enterprise/enterprise/relocatable/latest/scylla-enterprise-debug-unstripped-2023.3.0~dev-0.20230806.6dc3aeaf312c.aarch64.tar.gz
     name = os.path.split(path)[-1]
-    m = re.search(r'(^|/)(?P<product>scylla(?:-enterprise)?)(?:-(?P<mode>debug|dev|release))?-.*\.tar\.gz', name)
+    m = re.search(r'(^|/)(?P<product>scylla(?:-enterprise)?)(?:-(?P<mode>debug|dev|release))?-[^/]*\.tar\.gz', name)
     if m:
         mode = m.groupdict().get('mode')
         return mode if mode in ('debug', 'dev') else 'release'

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -42,11 +42,12 @@ class ScyllaCluster(Cluster):
 
         self.started = False
         self.force_wait_for_cluster_start = (force_wait_for_cluster_start != False)
-        self.default_wait_other_notice_timeout = 120 if self.scylla_mode != 'debug' else 600
-        self.default_wait_for_binary_proto = 420 if self.scylla_mode != 'debug' else 900
+        self.__set_default_timeouts()
         self._scylla_manager = None
         self.skip_manager_server = skip_manager_server
         self.scylla_version = cassandra_version
+
+        self.debug(f"ScyllaCluster: cassandra_version={cassandra_version} docker_image={docker_image} install_dir={install_dir} scylla_mode={self.scylla_mode} default_wait_other_notice_timeout={self.default_wait_other_notice_timeout} default_wait_for_binary_proto={self.default_wait_for_binary_proto}")
 
         super(ScyllaCluster, self).__init__(path, name, partitioner,
                                             install_dir, create_directory,
@@ -71,7 +72,14 @@ class ScyllaCluster(Cluster):
     def load_from_repository(self, version, verbose):
         install_dir, version = scylla_repository.setup(version, verbose)
         install_dir, self.scylla_mode = common.scylla_extract_install_dir_and_mode(install_dir)
+        assert self.scylla_mode is not None
+        self.__set_default_timeouts()
+        self.debug(f"ScyllaCluster: load_from_repository: install_dir={install_dir} scylla_mode={self.scylla_mode} default_wait_other_notice_timeout={self.default_wait_other_notice_timeout} default_wait_for_binary_proto={self.default_wait_for_binary_proto}")
         return install_dir, version
+
+    def __set_default_timeouts(self):
+        self.default_wait_other_notice_timeout = 120 if self.scylla_mode != 'debug' else 600
+        self.default_wait_for_binary_proto = 420 if self.scylla_mode != 'debug' else 900
 
     # override get_node_jmx_port for scylla-jmx
     # scylla-jmx listens on the unique node address (127.0.<cluster.id><node.id>)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -33,6 +33,7 @@ def test_scylla_extract_mode():
     assert scylla_extract_mode("url=https://downloads.scylla.com/relocatable/unstable/master/202001192256/scylla-debug-package.tar.gz") == 'debug'
     assert scylla_extract_mode("url=https://downloads.scylladb.com/unstable/scylla/master/relocatable/latest/scylla-debug-unified-5.4.0~dev-0.20230801.37b548f46365.x86_64.tar.gz") == 'debug'
     assert scylla_extract_mode("url=https://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla-enterprise/enterprise/relocatable/latest/scylla-enterprise-debug-unstripped-2023.3.0~dev-0.20230806.6dc3aeaf312c.aarch64.tar.gz") == 'debug'
+    assert scylla_extract_mode("/jenkins/workspace/scylla-master/dtest-debug/scylla/build/debug/dist/tar/scylla-debug-unified-5.4.0~dev-0.20231013.055f0617064d.x86_64.tar.gz") == 'debug'
 
 # Those tests assume that LockFile uses fcntl.flock
 # If it switches to anything else, the tests need to be adjusted.


### PR DESCRIPTION
Commit 4f619b75ab048366f3a0f7971450d00485e910bc (scylladb/scylla-ccm#492)
Improved the regular expression used in `scylla_extract_mode` to better
detect the scylla_mode given the package url.

However, when we install from a local path, like
`/jenkins/workspace/scylla-master/dtest-debug/scylla/build/debug/dist/tar/scylla-debug-unified-5.4.0~dev-0.20231013.055f0617064d.x86_64.tar.gz`,
The regular expression fails to detect the mode since it falsely start the match at `/scylla-master`.

This change restricts the match to the last path component.

As seen in https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-debug/258/artifact/logs-full.debug.041/dtest-gw0.log
```
07:20:43,371 790     errors                         ERROR    conftest.py         :225  | test_cluster_expansion_with_cdc[Single_cluster]: test failed:
...
>               self.wait_for_binary_interface(from_mark=from_mark, process=self._process_scylla, timeout=t)
...
self = <ccmlib.scylla_node.ScyllaNode object at 0x7fbd89790f10>
exprs = 'Starting listening for CQL clients', from_mark = 0, timeout = 420
```

When `cassandra_version` is passed to `ScyllaCluster.__init__`
we set `self.scylla_mode = None` and the default timeouts are not
adjusted.

`scylla_mode` is set correctly later on in `load_from_repository`.
Call `__set_default_timeouts` again to adjust the timeout based
on the valid `scylla_mode`.
