### PR TITLE
scylla_node: wait_for_compactions: move override to class ScyllaNode

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1583,6 +1583,12 @@ class ScyllaNode(Node):
         stdout, _ = sstable_stats['']
         return json.loads(stdout)['sstables']
 
+    def wait_for_compactions(self, idle_timeout = None):
+        if idle_timeout is None:
+            idle_timeout = 300 if self.scylla_mode() != 'debug' else 900
+        super(ScyllaNode, self).wait_for_compactions(idle_timeout=idle_timeout)
+
+
 class NodeUpgrader:
 
     """
@@ -1711,8 +1717,3 @@ class NodeUpgrader:
         if self.node.node_scylla_version != expected_version:
             raise NodeUpgradeError("Node hasn't been upgraded. Expected version after upgrade: %s, Got: %s" % (
                                     expected_version, self.node.node_scylla_version))
-
-    def wait_for_compactions(self, idle_timeout=None):
-        if idle_timeout is None:
-            idle_timeout = 300 if self.scylla_mode() != 'debug' else 900
-        super(ScyllaNode, self).wait_for_compactions(idle_timeout=idle_timeout)


### PR DESCRIPTION
Change a1624b5c471c8653e3855e0bfa3ea06422e95f2a added the method to class `NodeUpgrader` instead of `ScyllaNode` by mistake so it is a no-op and `test_lcs_sstable_promotion` still fails in debug mode occasionally, like
https://jenkins.scylladb.com/view/master/job/scylla-master/job/dtest-debug/261/testReport/compaction_additional_test/TestLCSSSTablePromotion/Run_Dtest_Parallel_Cloud_Machines___FullDtest___full_split044___test_lcs_sstable_promotion/
```
ccmlib.node.TimeoutError: Waiting for compactions timed out after 300 seconds with 26 pending tasks remaining.
```