### PR TITLE
cluster: prepare: support multi rack

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -114,6 +114,7 @@ class Node(object):
         self.pid = None
         self.all_pids = []
         self.data_center = None
+        self.rack = None
         self.workload = None
         self.__config_options = {}
         self.__install_dir = None
@@ -162,6 +163,8 @@ class Node(object):
                 node.__config_options = data['config_options']
             if 'data_center' in data:
                 node.data_center = data['data_center']
+            if 'rack' in data:
+                node.rack = data['rack']
             if 'workload' in data:
                 node.workload = data['workload']
             return node


### PR DESCRIPTION
Support a `rack` member in `Node`
and allow specifying datacenter racks by extending the `nodes` parameter to `prepare` supported notations as follows:

    # nodes can be provided in multiple notations, determining the cluster topology:
    # 1. int - specifying the number of nodes in a single DC, single RACK cluster
    # 2. list[int] - specifying the number of nodes in a multi DC, single RACK per DC cluster
    #    The datacenters are automatically named as dc{i}, starting from 1, the rack is named RAC1
    # 3 dict[str, int|list|dict] - specifying the number of nodes in a multi DC, single or multi RACK per DC cluster
    #   The dictionary keys explicitly identify each datacenter name, and the value is either:
    #   a. int - the number of nodes in the DC.
    #   b. list[int] - the number of nodes in each rack in the datacenter.
    #   c. dict[str, int] - the number of nodes in each named rack in the datacenter.

The motivation for doing so is for adding dtests testing mult-rack topologies.

Refs https://github.com/scylladb/scylla-dtest/issues/3681
Fixes scylladb/scylla-ccm#518