### PR TITLE
fix regex deprecation warnings

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -832,7 +832,7 @@ def get_version_from_build(install_dir=None, node_path=None):
         build = os.path.join(install_dir, 'build.xml')
         with open(build) as f:
             for line in f:
-                match = re.search('name="base\.version" value="([0-9.]+)[^"]*"', line)
+                match = re.search(r'name="base\.version" value="([0-9.]+)[^"]*"', line)
                 if match:
                     return match.group(1)
     raise CCMError("Cannot find version")
@@ -853,7 +853,7 @@ def _get_scylla_version(install_dir):
             # return only version strings (loosly) conforming to PEP-440
             # See https://www.python.org/dev/peps/pep-0440/
             # 'i.j(.|-)dev[N]' < 'i.j.rc[N]' < 'i.j.k' < i.j(.|-)post[N]
-            if re.fullmatch('(\d+!)?\d+([.-]\d+)*([a-z]+\d*)?([.-](post|dev|rc)\d*)*', v):
+            if re.fullmatch(r'(\d+!)?\d+([.-]\d+)*([a-z]+\d*)?([.-](post|dev|rc)\d*)*', v):
                 return v
     return '3.0'
 
@@ -885,7 +885,7 @@ def get_scylla_version(install_dir):
 def get_dse_version(install_dir):
     for root, dirs, files in os.walk(install_dir):
         for file in files:
-            match = re.search('^dse(?:-core)?-([0-9.]+)(?:-SNAPSHOT)?\.jar', file)
+            match = re.search(r'^dse(?:-core)?-([0-9.]+)(?:-SNAPSHOT)?\.jar', file)
             if match:
                 return match.group(1)
     return None
@@ -895,7 +895,7 @@ def get_dse_cassandra_version(install_dir):
     clib = os.path.join(install_dir, 'resources', 'cassandra', 'lib')
     for file in os.listdir(clib):
         if fnmatch.fnmatch(file, 'cassandra-all*.jar'):
-            match = re.search('cassandra-all-([0-9.]+)(?:-.*)?\.jar', file)
+            match = re.search(r'cassandra-all-([0-9.]+)(?:-.*)?\.jar', file)
             if match:
                 return match.group(1)
     raise ArgumentError("Unable to determine Cassandra version in: " + install_dir)
@@ -931,7 +931,7 @@ def invalidate_cache():
 
 def get_jdk_version():
     version = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
-    ver_pattern = '\"(\d+\.\d+).*\"'
+    ver_pattern = r'\"(\d+\.\d+).*\"'
     return re.search(ver_pattern, str(version)).groups()[0]
 
 

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -376,10 +376,10 @@ def get_tagged_version_numbers(series='stable'):
     releases = []
     if series == 'testing':
         # Testing releases always have a hyphen after the version number:
-        tag_regex = re.compile('^refs/tags/cassandra-([0-9]+\.[0-9]+\.[0-9]+-.*$)')
+        tag_regex = re.compile(r'^refs/tags/cassandra-([0-9]+\.[0-9]+\.[0-9]+-.*$)')
     else:
         # Stable and oldstable releases are just a number:
-        tag_regex = re.compile('^refs/tags/cassandra-([0-9]+\.[0-9]+\.[0-9]+$)')
+        tag_regex = re.compile(r'^refs/tags/cassandra-([0-9]+\.[0-9]+\.[0-9]+$)')
 
     tag_url = urllib.request.urlopen(GITHUB_TAGS)
     for ref in (i.get('ref', '') for i in json.loads(tag_url.read())):

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -127,7 +127,7 @@ def release_packages(s3_url, version, arch='x86_64', scylla_product='scylla'):
         # If found packages for released version
         if version.count('.') == 1:
             # Choose relocatable packages for latest release version
-            a = re.findall(f'-{version}\.(\d+)(?:-|\.)', ','.join(candidates))
+            a = re.findall(rf'-{version}\.(\d+)(?:-|\.)', ','.join(candidates))
             latest_candidate = f"{version}.{max(set(a))}" if a else ''
         elif version.count('.') == 2:
             # Choose relocatable packages for supplied version
@@ -141,7 +141,7 @@ def release_packages(s3_url, version, arch='x86_64', scylla_product='scylla'):
         if '.rc' in version:
             latest_candidate = version
         else:
-            a = re.findall('\.rc(\d+)(?:-|\.)', ','.join(all_packages))
+            a = re.findall(r'\.rc(\d+)(?:-|\.)', ','.join(all_packages))
             latest_candidate = f"{version}.rc{max(set(a))}" if a else ""
 
         release_packages = [package for package in all_packages if latest_candidate in package]


### PR DESCRIPTION
```
ccmlib/common.py:835
  /home/bhalevy/dev/scylla-ccm/ccmlib/common.py:835: DeprecationWarning: invalid escape sequence '\.'
    match = re.search('name="base\.version" value="([0-9.]+)[^"]*"', line)

ccmlib/common.py:856
  /home/bhalevy/dev/scylla-ccm/ccmlib/common.py:856: DeprecationWarning: invalid escape sequence '\d'
    if re.fullmatch('(\d+!)?\d+([.-]\d+)*([a-z]+\d*)?([.-](post|dev|rc)\d*)*', v):

ccmlib/common.py:888
  /home/bhalevy/dev/scylla-ccm/ccmlib/common.py:888: DeprecationWarning: invalid escape sequence '\.'
    match = re.search('^dse(?:-core)?-([0-9.]+)(?:-SNAPSHOT)?\.jar', file)

ccmlib/common.py:898
  /home/bhalevy/dev/scylla-ccm/ccmlib/common.py:898: DeprecationWarning: invalid escape sequence '\.'
    match = re.search('cassandra-all-([0-9.]+)(?:-.*)?\.jar', file)

ccmlib/common.py:934
  /home/bhalevy/dev/scylla-ccm/ccmlib/common.py:934: DeprecationWarning: invalid escape sequence '\d'
    ver_pattern = '\"(\d+\.\d+).*\"'
```