### PR TITLE
scylla_node: correct the docstring of ScyllaNode.dump_sstable_stats()

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1496,7 +1496,7 @@ class ScyllaNode(Node):
                            keyspace: str,
                            column_family: str,
                            datafiles: Optional[List[str]] = None) -> List[Dict[str, Any]]:
-        """dump the partitions in the specified table using `scylla sstable dump-data`
+        """dump the partitions in the specified table using `scylla sstable dump-statistics`
 
         :param keyspace: restrict the operation to sstables of this keyspace
         :param column_family: restrict the operation to sstables of this column_family


### PR DESCRIPTION
it was a copy-n-pasta error. and should be dump-statistics not dump-data.