### PR TITLE
pytest.ini: s/repo_test/repo_tests/

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,4 +14,4 @@ markers =
   docker: Run tests with docker image
   reloc: Run tests with relocatable packages
   cassandra: Run tests with cassandra binaries
-  repo_test: Run test for testing get versions
+  repo_tests: Run test for testing get versions


### PR DESCRIPTION
otherwise pytest complains at seeing the marker of `repo_tests`, like

```
============================================================================================================== warnings summary ==============================================================================================================
tests/test_scylla_download.py:9
  /home/kefu/dev/scylla-ccm/tests/test_scylla_download.py:9: PytestUnknownMarkWarning: Unknown pytest.mark.repo_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.repo_tests

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

this warning is distracting.