### PR TITLE
ccmlib/scylla_node: add ks, cf params to wait_for_compactions()

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1669,10 +1669,15 @@ class ScyllaNode(Node):
         stdout, _ = outputs['']
         return json.loads(stdout)['sstables']
 
-    def wait_for_compactions(self, idle_timeout = None):
+    def wait_for_compactions(self,
+                             keyspace=None,
+                             column_family=None,
+                             idle_timeout=None):
         if idle_timeout is None:
             idle_timeout = 300 if self.scylla_mode() != 'debug' else 900
-        super().wait_for_compactions(idle_timeout=idle_timeout)
+        super().wait_for_compactions(keyspace=keyspace,
+                                     column_family=column_family,
+                                     idle_timeout=idle_timeout)
 
 
 class NodeUpgrader:


### PR DESCRIPTION
before this change, wait_for_compactions() waits until all pending compactions are finished. but sometimes, we just want to

1. disable a certain $ks.$cf with column_family/autocompaction RESTful API, and
2. wait until all pending compaction tasks of the specified $ks.$cf is done, then
3. check the sstables of that table

column_family/autocompaction does not stop all compaction jobs a scylla instance, it just stops the specified table. so there are chances that we are still observing compaction tasks even if all the compactions of the specified table are stopped.

so, in this change, to cater the needs of the use case above, we add optional parameters to Node and ScyllaNode, so that we can specify the table we are interested in, instead of waiting for all tables.

also, instead of assigning `n` to `pending_task` before comparing them to detect the unexpected increasing number of pending tasks, we compare them before the assignment. otherwise, the branch is unreachable even if the `pending_tasks` is increasing.

Refs https://github.com/scylladb/scylladb/issues/16170