### PR TITLE
Remove --collectd-hostname from node command line invocation

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -544,8 +544,6 @@ class ScyllaNode(Node):
         with open(conf_file, 'r') as f:
             data = yaml.safe_load(f)
         jvm_args = jvm_args + ['--api-address', data['api_address']]
-        jvm_args = jvm_args + ['--collectd-hostname',
-                               f'{socket.gethostname()}.{self.name}']
 
         args = [launch_bin, '--options-file', options_file, '--log-to-stdout', '1']
 


### PR DESCRIPTION
We'd like to deprecate collectd, we use Prometheus these days. 

Refs: https://github.com/scylladb/scylla-enterprise/issues/3628