### PR TITLE
Fixes for handling `SCYLLA_EXT_OPTS` correctly

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -549,7 +549,7 @@ class ScyllaNode(Node):
 
         MB = 1024 * 1024
 
-        def process_opts(opts):
+        def process_opts(opts, args_translation_map = {}):
             ext_args = OrderedDict()
             opts_i = 0
             while opts_i < len(opts):
@@ -570,11 +570,12 @@ class ScyllaNode(Node):
                         opts_i += 1
                     val = ' '.join(vals)
                 if key not in ext_args and not key.startswith("--scylla-manager"):
-                    ext_args[key] = val
+                    ext_args[args_translation_map.get(key, key)] = val
             return ext_args
 
+        scylla_params_translation_map = {"-m" : "--memory", "-c" : "--smp"}
         # Lets search for default overrides in SCYLLA_EXT_OPTS
-        env_args = process_opts(os.getenv('SCYLLA_EXT_OPTS', "").split())
+        env_args = process_opts(os.getenv('SCYLLA_EXT_OPTS', "").split(), scylla_params_translation_map)
 
         # precalculate self._mem_mb_per_cpu if --memory is given in SCYLLA_EXT_OPTS
         # and it wasn't set explicitly by the test


### PR DESCRIPTION
This mini-series implements two fixes for handling `SCYLLA_EXT_OPTS`:
1. It adds support for `-c` and `-m` options which are abbreviations for the `--smp` and `--memory` options and handles them correctly.
2. It adds support for multiple occurrences of  `--experimental-features` with correct handling.

The individual issues:
#539 and #540 describes the specific problems.