### PR TITLE
node: stress_object: strip off commas from value strings

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1381,24 +1381,25 @@ class Node(object):
 
     @staticmethod
     def _set_stress_val(key, val, res):
-        # Set locale to the user's default value (usually specified in the LANG)
-        locale.setlocale(locale.LC_NUMERIC, '')
+        def parse_num(s):
+            return locale.atof(s.replace(',', ''))
+
         if "[" in val:
             p = re.compile(r'^\s*([\d\.\,]+\d?)\s*\[.*')
             m = p.match(val)
             if m:
-                res[key] = locale.atof(m.group(1))
+                res[key] = parse_num(m.group(1))
             p = re.compile(r'^.*READ:\s*([\d\.\,]+\d?)[^\d].*')
             m = p.match(val)
             if m:
-                res[key + ":read"] = locale.atof(m.group(1))
+                res[key + ":read"] = parse_num(m.group(1))
             p = re.compile(r'.*WRITE:\s*([\d\.\,]+\d?)[^\d].*')
             m = p.match(val)
             if m:
-                res[key + ":write"] = locale.atof(m.group(1))
+                res[key + ":write"] = parse_num(m.group(1))
         else:
             try:
-                res[key] = locale.atof(val)
+                res[key] = parse_num(val)
             except ValueError:
                 res[key] = val
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1382,7 +1382,7 @@ class Node(object):
     @staticmethod
     def _set_stress_val(key, val, res):
         def parse_num(s):
-            return locale.atof(s.replace(',', ''))
+            return float(s.replace(',', ''))
 
         if "[" in val:
             p = re.compile(r'^\s*([\d\.\,]+\d?)\s*\[.*')


### PR DESCRIPTION
Some resharding_test dtest, e.g. `test_resharding_counter` fails locally for me:
```
    def _run_stress(self, op_cnt, stress_cmd):
        res = self.node.stress_object(stress_cmd)
        if not isinstance(res, dict):
            raise Exception('Error running cassandra-stress: {}'.format(res))
        assert res['total errors'] == 0
>       assert res['total partitions'] >= op_cnt
E       assert 10.0 >= 10000
```

When printing the cassandra-stress stdout I saw that it uses a comma as a 1000s separator:
```
Total partitions          :     10,000 [COUNTER_READ: 10,000]
```

This is probably related to the LOCALE on my machine.

This change explicitly sets the locale to en_US
tha defines comma as the thousands separator
and dot as the decimal point.

The origin local is reset when the function is done.