### PR TITLE
node: _parse_pending_tasks: handle tail_pattern mismatch

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -747,7 +747,8 @@ class Node(object):
         else:
             return False
 
-    def _parse_pending_tasks(self, output, keyspace, column_family):
+    @staticmethod
+    def _parse_pending_tasks(output, keyspace, column_family):
         # "nodetool compactionstats" prints the compaction stats like:
         # pending tasks: 42
         # - ks1.cf1: 13

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -773,7 +773,10 @@ class Node(object):
 
         total = 0
         for line in tail:
-            ks, cf, num = tail_pattern.search(line).groups()
+            m = tail_pattern.search(line)
+            if not m:
+                break
+            ks, cf, num = m.groups()
             if matches(keyspace, ks) and matches(column_family, cf):
                 total += int(num)
         return total

--- a/tests/test_internal_functions.py
+++ b/tests/test_internal_functions.py
@@ -1,0 +1,40 @@
+from ccmlib.node import Node
+
+def test_parse_pending_tasks():
+    def verify_result(output, keyspace, column_family, expected):
+        n = Node._parse_pending_tasks(output, keyspace, column_family)
+        assert n == expected
+
+    def verify_cases(output, cases):
+        for ks, cf, expected in cases:
+            verify_result(output, ks, cf, expected)
+
+    for output in [
+        '''
+        pending tasks: 6
+        - system_schema.tables: 1
+        - system_schema.columns: 2
+        - keyspace1.standard1: 3
+        ''',
+        '''
+        pending tasks: 6
+        - system_schema.tables: 1
+        - system_schema.columns: 2
+        - keyspace1.standard1: 3
+
+        id                                   compaction type keyspace      table   completed total unit progress
+        8e1f2d90-a252-11ee-a7f4-1bf9ae4e6ffd COMPACTION      system_schema columns 1         640   
+    keys 0.16%
+        Active compaction remaining time :        n/a
+        '''
+    ]:
+        verify_cases(output, [
+                        ('system_schema', 'tables', 1),
+                        ('system_schema', 'columns', 2),
+                        ('system_schema', None, 3),
+                        ('keyspace1', 'standard1', 3),
+                        ('keyspace1', None, 3),
+                        (None, None, 6),
+                        ('keyspace1x', None, 0),
+                        ('keyspace1x', 'table1x', 0),
+                     ])


### PR DESCRIPTION
`nodetool compactionstats` may contain more lines after the pending tasks section.

For exameple:
```
pending tasks: 2
- system_schema.tables: 1
- system_schema.columns: 1

id                                   compaction type keyspace      table   completed total unit progress
8e1f2d90-a252-11ee-a7f4-1bf9ae4e6ffd COMPACTION      system_schema columns 1         640   keys 0.16%
Active compaction remaining time :        n/a
```

Break from the `_parse_pending_tasks` loop once the tail_pattern regex mismatches the line to prevent the following error, as seen for example in https://jenkins.scylladb.com/job/scylla-master/job/dtest-debug/270/testReport/resharding_test/TestReshardingTombstonesSingleNode/Run_Dtest_Parallel_Cloud_Machines___FullDtest___full_split004___test_disable_tombstone_removal_during_reshard_1_SizeTieredCompactionStrategy_15_/
```
        for line in tail:
>           ks, cf, num = tail_pattern.search(line).groups()
E           AttributeError: 'NoneType' object has no attribute 'groups'
```

This fix is on top of ae645ad1