### PR TITLE
cluster: add add_seed method

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -447,6 +447,14 @@ class Cluster(object):
         seed_index = self.seeds.index(node)
         return [s.network_interfaces['storage'][0] for s in self.seeds[:seed_index + 1]]
 
+    def add_seed(self, node):
+        if type(node) is Node:
+            address = node.address()
+        else:
+            address = node
+        if not address in self.seeds:
+            self.seeds.append(address)
+
     def show(self, verbose):
         msg = f"Cluster: '{self.name}'"
         print(msg)


### PR DESCRIPTION
To be used after replacing nodes.
We cannot add the replacing nodes to seeds right away since it's considered invalid to add a replacing node as a seed (probably for historical reasons).
So we need to add it only after it's finished
replace bootstrapping.