### PR TITLE
Revert "ccmlib: stop passing auto_bootstrap"

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -104,8 +104,7 @@ class Node(object):
         self.name = name
         self.cluster = cluster
         self.status = Status.UNINITIALIZED
-        # auto_bootstrap is deprecated
-        _ = auto_bootstrap
+        self.auto_bootstrap = auto_bootstrap
         self.network_interfaces = {'thrift': common.normalize_interface(thrift_interface),
                                    'storage': common.normalize_interface(storage_interface),
                                    'binary': common.normalize_interface(binary_interface)}
@@ -151,9 +150,7 @@ class Node(object):
             binary_interface = None
             if 'binary' in itf and itf['binary'] is not None:
                 binary_interface = tuple(itf['binary'])
-            # auto_bootstrap is deprecated
-            auto_bootstrap = True
-            node = cluster.create_node(data['name'], auto_bootstrap, tuple(itf['thrift']), tuple(itf['storage']), data[
+            node = cluster.create_node(data['name'], data['auto_bootstrap'], tuple(itf['thrift']), tuple(itf['storage']), data[
                                        'jmx_port'], remote_debug_port, initial_token, save=False, binary_interface=binary_interface)
             node.status = data['status']
             if 'pid' in data:
@@ -304,6 +301,7 @@ class Node(object):
         if not only_status:
             if show_cluster:
                 print(f"{indent}{'cluster'}={self.cluster.name}")
+            print(f"{indent}{'auto_bootstrap'}={self.auto_bootstrap}")
             print(f"{indent}{'thrift'}={self.network_interfaces['thrift']}")
             if self.network_interfaces['binary'] is not None:
                 print(f"{indent}{'binary'}={self.network_interfaces['binary']}")
@@ -1621,6 +1619,7 @@ class Node(object):
         values = {
             'name': self.name,
             'status': self.status,
+            'auto_bootstrap': self.auto_bootstrap,
             'interfaces': self.network_interfaces,
             'jmx_port': self.jmx_port,
             'config_options': self.__config_options,
@@ -1649,6 +1648,7 @@ class Node(object):
             yaml_text = f.read()
 
         data['cluster_name'] = self.cluster.name
+        data['auto_bootstrap'] = self.auto_bootstrap
         data['initial_token'] = self.initial_token
         if not self.cluster.use_vnodes and self.get_base_cassandra_version() >= 1.2:
             data['num_tokens'] = 1

--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -242,6 +242,7 @@ class ScyllaDockerNode(ScyllaNode):
         if not only_status:
             if show_cluster:
                 print(f"{indent}{'cluster'}={self.cluster.name}")
+            print(f"{indent}{'auto_bootstrap'}={self.auto_bootstrap}")
             print(f"{indent}{'thrift'}={self.network_interfaces['thrift']}")
             if self.network_interfaces['binary'] is not None:
                 print(f"{indent}{'binary'}={self.network_interfaces['binary']}")
@@ -268,6 +269,7 @@ class ScyllaDockerNode(ScyllaNode):
         values = {
             'name': self.name,
             'status': self.status,
+            'auto_bootstrap': self.auto_bootstrap,
             'interfaces': self.network_interfaces,
             'jmx_port': self.jmx_port,
             'docker_id': docker_id,

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1106,6 +1106,7 @@ class ScyllaNode(Node):
             data = yaml.safe_load(f)
 
         data['cluster_name'] = self.cluster.name
+        data['auto_bootstrap'] = self.auto_bootstrap
         data['initial_token'] = self.initial_token
         if (not self.cluster.use_vnodes and
                 self.get_base_cassandra_version() >= 1.2):


### PR DESCRIPTION
Reverts scylladb/scylla-ccm#536

according to Piotr Grabowski

> This change breaks Java Driver 4.x CI with Cassandra 4.x - in one test node bootstrap starts timing out and now requires a very large timeout (120 seconds)

so revert the offending change.