### PR TITLE
ccmlib/common: check for scylla built with CMake as well 

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -591,11 +591,15 @@ def isScylla(install_dir):
 
         raise ArgumentError('Undefined installation directory')
 
-    return (os.path.exists(os.path.join(install_dir, 'scylla')) or
-            os.path.exists(os.path.join(install_dir, 'build', 'debug', 'scylla')) or
-            os.path.exists(os.path.join(install_dir, 'build', 'dev', 'scylla')) or
-            os.path.exists(os.path.join(install_dir, 'build', 'release', 'scylla')) or
-            os.path.exists(os.path.join(install_dir, 'bin', 'scylla')))
+    if os.path.exists(os.path.join(install_dir, 'scylla')):
+        return True
+
+    scylla_build_modes = ['debug', 'dev', 'release']
+    for mode in scylla_build_modes:
+        if os.path.exists(os.path.join(install_dir, 'build', mode, 'scylla')):
+            return True
+
+    return os.path.exists(os.path.join(install_dir, 'bin', 'scylla'))
 
 
 def isOpscenter(install_dir):

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -595,7 +595,8 @@ def isScylla(install_dir):
         return True
 
     scylla_build_modes = ['debug', 'dev', 'release']
-    for mode in scylla_build_modes:
+    cmake_build_types = ['Debug', 'Dev', 'RelWithDebInfo']
+    for mode in scylla_build_modes + cmake_build_types:
         if os.path.exists(os.path.join(install_dir, 'build', mode, 'scylla')):
             return True
 


### PR DESCRIPTION
cmake generates scylla at paths like `build/Debug/scylla` instead of
`build/debug/scylla`, so check for them as well.