### PR TITLE
scylla_node: encode stdout and stderr if not text

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1465,7 +1465,10 @@ class ScyllaNode(Node):
             if not sstables:
                 empty_dump = {'sstables': {'anonymous': []}}
                 stdout, stderr = json.dumps(empty_dump), ''
-                return (stdout, stderr)
+                if text:
+                    return stdout, stderr
+                else:
+                    return stdout.encode('utf-8'), stderr.encode('utf-8')
             common_args = [scylla_path, "sstable", command] + additional_args
             env = self._get_environ()
             res = subprocess.run(common_args + sstables, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=text, check=False, env=env)


### PR DESCRIPTION
if there are no sstables, and we expect bytes as the output, we should encode the encoded json into bytes before returning it. otherwise we'd have exception like:

```
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```

when trying to decode the returned stdout.