### PR TITLE
scylla_node: pass -Dcom.scylladb.apiPort=10000 when running nodetool

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -761,6 +761,10 @@ class ScyllaNode(Node):
         """
         Kill scylla-jmx in case of timeout, to supply enough debugging information
         """
+        # pass the api_port to nodetool. if it is the nodetool-wrapper. it should
+        # interpret the command line and use it for the -p option
+        cmd, *other_args = args
+        args = (f"{cmd} -Dcom.scylladb.apiPort=10000", *other_args)
         try:
             return super().nodetool(*args, **kwargs)
         except subprocess.TimeoutExpired:


### PR DESCRIPTION
this pass the setting of "api_port" to nodetool-wrapper, so that it can override the "-p" option with the port number. otherwise "scylla nodetool" would not be able to access the API service by connecting to the JMX server.