### PR TITLE
scylla_node: pass -Dcom.scylladb.apiPort=10000 when running nodetool

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -757,12 +757,15 @@ class ScyllaNode(Node):
         else:
             self.jmx_pid = None
 
-    def nodetool(self, *args, **kwargs):
+    def nodetool(self, cmd, capture_output=True, wait=True, timeout=None, verbose=True):
         """
         Kill scylla-jmx in case of timeout, to supply enough debugging information
         """
+        # pass the api_port to nodetool. if it is the nodetool-wrapper. it should
+        # interpret the command line and use it for the -p option
+        cmd = f"{cmd} -Dcom.scylladb.apiPort=10000"
         try:
-            return super().nodetool(*args, **kwargs)
+            return super().nodetool(cmd, capture_output, wait, timeout, verbose)
         except subprocess.TimeoutExpired:
             self.error("nodetool timeout, going to kill scylla-jmx with SIGQUIT")
             self.kill_jmx(signal.SIGQUIT)


### PR DESCRIPTION
this pass the setting of "api_port" to nodetool-wrapper, so that it can override the "-p" option with the port number. otherwise "scylla nodetool" would not be able to access the API service by connecting to the JMX server.