### PR TITLE
ccmlib/scylla_node.py: nodetool(): prepend api-port instead of append

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -763,7 +763,7 @@ class ScyllaNode(Node):
         """
         # pass the api_port to nodetool. if it is the nodetool-wrapper. it should
         # interpret the command line and use it for the -p option
-        cmd = f"{cmd} -Dcom.scylladb.apiPort=10000"
+        cmd = f"-Dcom.scylladb.apiPort=10000 {cmd}"
         try:
             return super().nodetool(cmd, capture_output, wait, timeout, verbose)
         except subprocess.TimeoutExpired:


### PR DESCRIPTION
Nodetool commands can contain a `--` sequence, after which all subsequent command line parameters are considered positional. This means that the option we are trying to add, -Dcom.scylladb.apiPort=10000, will be parsed as a positional args and will likely trigger failure in parsing the command-line arguments.
Instead of appending it to the command string, prepend it. At this point, the `cmd` starts with the nodetool command and `node.py::nodetool()` will prepend host and port args. Do the same and prepend the rest api port.

Tested locally with a test which fails with the previous code.