### PR TITLE
github/workflows/nix: extract RELOC_VERSION as an env variable

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,7 +37,8 @@ jobs:
     - name: Download versions
       if: steps.cache-versions.outputs.cache-hit != 'true'
       run: |
-        if [ ! -f ~/.ccm/scylla-repository/unstable/master/2023-04-13T13_31_00Z ]; then
+        normalized=$(echo $RELOC_VERSION | tr ':' '_')
+        if [ ! -f ~/.ccm/scylla-repository/unstable/master/$normalized ]; then
           nix develop --command ./ccm create temp -n 1 --scylla --version $SCYLLA_VERSION
           nix develop --command ./ccm remove
         fi

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -10,11 +10,15 @@ on:
     branches:
      - next*
 
+env:
+  RELOC_VERSION: "2023-04-13T13:31:00Z"
+
 jobs:
   build:
     runs-on: ubuntu-latest
     continue-on-error: true
-
+    env:
+      SCYLLA_VERSION: "unstable/master:${{ env.RELOC_VERSION }}"
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
@@ -34,9 +38,7 @@ jobs:
       if: steps.cache-versions.outputs.cache-hit != 'true'
       run: |
         if [ ! -f ~/.ccm/scylla-repository/unstable/master/2023-04-13T13_31_00Z ]; then
-          RELOC_VERSION="2023-04-13T13:31:00Z"
-        
-          nix develop --command ./ccm create temp -n 1 --scylla --version unstable/master:${RELOC_VERSION}
+          nix develop --command ./ccm create temp -n 1 --scylla --version $SCYLLA_VERSION
           nix develop --command ./ccm remove
         fi
         nix develop --command ./ccm create temp-cas -n 1 --version 3.11.4 > /dev/null

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -32,7 +32,7 @@ jobs:
         path: |
           ~/.ccm/repository
           ~/.ccm/scylla-repository
-        key: ${{ runner.os }}-binaries
+        key: ${{ runner.os }}-${{ env.RELOC_VERSION }}-binaries
 
     - name: Download versions
       if: steps.cache-versions.outputs.cache-hit != 'true'


### PR DESCRIPTION
encode RELOC_VERSION in the key of binary, so we can use different binary for testing. there is chance that newer ccm would like to use newer scylla executables for testing.

this series is more a refactory, and it does not change the version of scylla we are using, but in a follow up change, we will use a different `RELOC_VERSION` for testing newer scylla.