### PR TITLE
github/workflows/integration-tests: extract RELOC_VERSION as an env variable

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,9 @@ on:
     branches:
      - next*
 
+env:
+  RELOC_VERSION: "2023-04-13T13:31:00Z"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -59,12 +62,15 @@ jobs:
           ~/.ccm/scylla-repository
         key: ${{ runner.os }}-binaries
 
+    - name: Set environmental variables
+      run: |
+        echo "SCYLLA_VERSION=unstable/master:$RELOC_VERSION" >> "$GITHUB_ENV"
+
     - name: Download versions
       if: steps.cache-versions.outputs.cache-hit != 'true'
       run: |
-        if [ ! -f ~/.ccm/scylla-repository/unstable/master/2023-04-13T13_31_00Z ]; then
-          RELOC_VERSION="2023-04-13T13:31:00Z"
-        
+        normalized=$(echo $RELOC_VERSION | tr ':' '_')
+        if [ ! -f ~/.ccm/scylla-repository/unstable/master/$normalized ]; then
           ./ccm create temp -n 1 --scylla --version unstable/master:${RELOC_VERSION}
           ./ccm remove
         fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,7 +60,7 @@ jobs:
         path: |
           ~/.ccm/repository
           ~/.ccm/scylla-repository
-        key: ${{ runner.os }}-binaries
+        key: ${{ runner.os }}-${{ env.RELOC_VERSION }}-binaries
 
     - name: Set environmental variables
       run: |


### PR DESCRIPTION
encode `RELOC_VERSION` in the key of binary, so we can use different binary for testing. there is chance that newer ccm would like to use newer scylla executables for testing.

this series is more a refactory, and it does not change the version of scylla we are using, but in a follow up change, we will use a different `RELOC_VERSION` for testing newer scylla.