### PR TITLE
github/workflows/nix: do not set env var with another env var

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,8 +17,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     continue-on-error: true
-    env:
-      SCYLLA_VERSION: "unstable/master:${{ env.RELOC_VERSION }}"
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
@@ -33,6 +31,10 @@ jobs:
           ~/.ccm/repository
           ~/.ccm/scylla-repository
         key: ${{ runner.os }}-${{ env.RELOC_VERSION }}-binaries
+
+    - name: Set environmental variables
+      run: |
+        echo "SCYLLA_VERSION=unstable/master:$RELOC_VERSION" >> "$GITHUB_ENV"
 
     - name: Download versions
       if: steps.cache-versions.outputs.cache-hit != 'true'


### PR DESCRIPTION
this change addresses a regression introduced by 92494911.

in 92494911, we tried to set `$SCYLLA_VERSION` with `env.RELOC_VERSION`, but github action does not allow this. because the env variables in github's workflow YAML are expanded when the YAML file is parsed. so `SCYLLA_VERSION` is never expanded with the value of `RELOC_VERSION`.

so, in this change, to avoid the repeatings, we use environmental file to store `SCYLLA_VERSION`, so that it can be picked by the steps that consume this env var.

see also https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files