### PR TITLE
github/workflows: extract RELOC_VERSION into a workflow

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,23 @@
+name: ci
+
+on:
+  push:
+    branches:
+     - master
+     - next*
+
+  pull_request:
+    branches:
+     - next*
+
+jobs:
+  ci-without-nix:
+    name: CCM Integration tests
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      reloc_version: "2023-04-13T13:31:00Z"
+  ci-with-nix:
+    name: CCM Integration tests (using Nix)
+    uses: ./.github/workflows/nix.yml
+    with:
+      reloc_version: "2023-04-13T13:31:00Z"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,17 +1,11 @@
 name: CCM Integration tests
 
 on:
-  push:
-    branches:
-     - master
-     - next*
-
-  pull_request:
-    branches:
-     - next*
-
-env:
-  RELOC_VERSION: "2023-04-13T13:31:00Z"
+  workflow_call:
+    inputs:
+      reloc_version:
+        required: true
+        type: string
 
 jobs:
   build:
@@ -60,18 +54,18 @@ jobs:
         path: |
           ~/.ccm/repository
           ~/.ccm/scylla-repository
-        key: ${{ runner.os }}-${{ env.RELOC_VERSION }}-binaries
+        key: ${{ runner.os }}-${{ inputs.reloc_version }}-binaries
 
     - name: Set environmental variables
       run: |
-        echo "SCYLLA_VERSION=unstable/master:$RELOC_VERSION" >> "$GITHUB_ENV"
+        echo "SCYLLA_VERSION=unstable/master:${{ inputs.reloc_version }}" >> "$GITHUB_ENV"
 
     - name: Download versions
       if: steps.cache-versions.outputs.cache-hit != 'true'
       run: |
-        normalized=$(echo $RELOC_VERSION | tr ':' '_')
+        normalized=$(echo ${{ inputs.reloc_version }} | tr ':' '_')
         if [ ! -f ~/.ccm/scylla-repository/unstable/master/$normalized ]; then
-          ./ccm create temp -n 1 --scylla --version unstable/master:${RELOC_VERSION}
+          ./ccm create temp -n 1 --scylla --version unstable/master:${{ inputs.reloc_version }}
           ./ccm remove
         fi
         ./ccm create temp-cas -n 1 --version 3.11.4 > /dev/null

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,17 +1,11 @@
 name: CCM Integration tests (using Nix)
 
 on:
-  push:
-    branches:
-     - master
-     - next*
-
-  pull_request:
-    branches:
-     - next*
-
-env:
-  RELOC_VERSION: "2023-04-13T13:31:00Z"
+  workflow_call:
+    inputs:
+      reloc_version:
+        required: true
+        type: string
 
 jobs:
   build:
@@ -30,16 +24,16 @@ jobs:
         path: |
           ~/.ccm/repository
           ~/.ccm/scylla-repository
-        key: ${{ runner.os }}-${{ env.RELOC_VERSION }}-binaries
+        key: ${{ runner.os }}-${{ inputs.reloc_version }}-binaries
 
     - name: Set environmental variables
       run: |
-        echo "SCYLLA_VERSION=unstable/master:$RELOC_VERSION" >> "$GITHUB_ENV"
+        echo "SCYLLA_VERSION=unstable/master:${{ inputs.reloc_version }}" >> "$GITHUB_ENV"
 
     - name: Download versions
       if: steps.cache-versions.outputs.cache-hit != 'true'
       run: |
-        normalized=$(echo $RELOC_VERSION | tr ':' '_')
+        normalized=$(echo ${{ inputs.reloc_version }} | tr ':' '_')
         if [ ! -f ~/.ccm/scylla-repository/unstable/master/$normalized ]; then
           nix develop --command ./ccm create temp -n 1 --scylla --version $SCYLLA_VERSION
           nix develop --command ./ccm remove


### PR DESCRIPTION
instead of repeating the RELOC_VERSION in two different workflows, let's extract it into a workflow which will drive the existing two workflow and feed them with the RELOC_VERSION.