### PR TITLE
common: treat code compiled with coverage as debug

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -661,6 +661,12 @@ def scylla_extract_install_dir_and_mode(install_dir):
                 f.close()
             except:
                 pass
+
+    is_gcov = subprocess.run(['bash', '-c', f'strings {install_dir}/libexec/scylla | grep -i GCOV_'], stderr=subprocess.DEVNULL,
+                  stdout=subprocess.DEVNULL, check=False)
+    if is_gcov.returncode == 0:
+        scylla_mode = "debug"
+
     return install_dir, scylla_mode
 
 


### PR DESCRIPTION
since there are some slowdowns with coverage enabled binary we temporary treat it as debug, so all test that were tuned down for debug in dtest, would be have the same as they do for debug.