### PR TITLE
ccmlib: drop cassandra-cli and thrift support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ After that execute:
 
     ccm start
 
-That will start 3 nodes on IP 127.0.0.[1, 2, 3] on port 9160 for thrift, port
+That will start 3 nodes on IP 127.0.0.[1, 2, 3] on port 9042 for native transport, port
 7000 for the internal cluster communication and ports 7100, 7200 and 7300 for JMX.
 You can check that the cluster is correctly set up with
 
@@ -297,9 +297,9 @@ how to use ccmlib follows:
     cluster.populate(3).start()
     [node1, node2, node3] = cluster.nodelist()
 
-    # do some tests on the cluster/nodes. To connect to a node through thrift,
+    # do some tests on the cluster/nodes. To connect to a node through native protocol,
     # the host and port to a node is available through
-    #   node.network_interfaces['thrift']
+    #   node.network_interfaces['binary]
 
     cluster.flush()
     node2.compact()

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -578,13 +578,6 @@ class Cluster(object):
         self.nodelist()[0].stress(stress_options=stress_options + ['-node', ','.join(livenodes)] )
         return self
 
-    def run_cli(self, cmds=None, show_output=False, cli_options=None):
-        cli_options = cli_options or []
-        livenodes = [node for node in list(self.nodes.values()) if node.is_live()]
-        if len(livenodes) == 0:
-            raise common.ArgumentError("No live node")
-        livenodes[0].run_cli(cmds, show_output, cli_options)
-
     def set_configuration_options(self, values=None, batch_commitlog=None):
         if values is not None:
             for k, v in values.items():

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -931,28 +931,6 @@ class ClusterUpdatelog4jCmd(Cmd):
             sys.exit(1)
 
 
-class ClusterCliCmd(Cmd):
-
-    def description(self):
-        return "Launch cassandra cli connected to some live node (if any)"
-
-    def get_parser(self):
-        usage = "usage: ccm cli [options] [cli_options]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        parser.add_option('-x', '--exec', type="string", dest="cmds", default=None,
-                          help="Execute the specified commands and exit")
-        parser.add_option('-v', '--verbose', action="store_true", dest="verbose",
-                          help="With --exec, show cli output after completion", default=False)
-        return parser
-
-    def validate(self, parser, options, args):
-        Cmd.validate(self, parser, options, args, load_cluster=True)
-        self.cli_options = parser.get_ignored() + args[1:]
-
-    def run(self):
-        self.cluster.run_cli(self.options.cmds, self.options.verbose, self.cli_options)
-
-
 class ClusterBulkloadCmd(Cmd):
 
     def description(self):

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -365,28 +365,6 @@ class NodeDsetoolCmd(_DseToolCmd):
         self.node.dsetool(" ".join(self.args[1:]))
 
 
-class NodeCliCmd(Cmd):
-
-    def description(self):
-        return "Launch a cassandra cli connected to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name cli [options] [cli_options]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        parser.add_option('-x', '--exec', type="string", dest="cmds", default=None,
-                          help="Execute the specified commands and exit")
-        parser.add_option('-v', '--verbose', action="store_true", dest="verbose",
-                          help="With --exec, show cli output after completion", default=False)
-        return parser
-
-    def validate(self, parser, options, args):
-        Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
-        self.cli_options = parser.get_ignored() + args[1:]
-
-    def run(self):
-        self.node.run_cli(self.options.cmds, self.options.verbose, self.cli_options)
-
-
 class NodeCqlshCmd(Cmd):
 
     def description(self):

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -29,7 +29,7 @@ class DseCluster(Cluster):
         return os.path.exists(os.path.join(self.get_path(), 'opscenter'))
 
     def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None):
-        return DseNode(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface)
+        return DseNode(name, self, auto_bootstrap, None, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface)
 
     def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=None, profile_options=None, quiet_start=False):
         if jvm_args is None:
@@ -80,7 +80,9 @@ class DseCluster(Cluster):
             os.makedirs(cluster_conf)
             if len(self.seeds) > 0:
                 seed = self.seeds[0]
-                (seed_ip, seed_port) = seed.network_interfaces['thrift']
+                # NOTE: should be use api_port, not storage_port. but we don't
+                #       test DSE.
+                (seed_ip, seed_port) = seed.network_interfaces['storage']
                 seed_jmx = seed.jmx_port
                 with open(os.path.join(cluster_conf, self.name + '.conf'), 'w+') as f:
                     f.write('[jmx]\n')

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -21,8 +21,8 @@ class DseNode(Node):
     Provides interactions to a DSE node.
     """
 
-    def __init__(self, name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None):
-        super(DseNode, self).__init__(name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface)
+    def __init__(self, name, cluster, auto_bootstrap, _, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None):
+        super(DseNode, self).__init__(name, cluster, auto_bootstrap, None, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface)
         self.get_cassandra_version()
         if self.cluster.hasOpscenter():
             self._copy_agent()
@@ -341,7 +341,7 @@ class DseNode(Node):
         with open(server_xml, 'w+') as f:
             f.write('<Server port="8005" shutdown="SHUTDOWN">\n')
             f.write('  <Service name="Solr">\n')
-            f.write(f"    <Connector port=\"8983\" address=\"{self.network_interfaces['thrift'][0]}\" protocol=\"HTTP/1.1\" connectionTimeout=\"20000\" maxThreads = \"200\" URIEncoding=\"UTF-8\"/>\n")
+            f.write(f"    <Connector port=\"8983\" address=\"{self.network_interfaces['binary'][0]}\" protocol=\"HTTP/1.1\" connectionTimeout=\"20000\" maxThreads = \"200\" URIEncoding=\"UTF-8\"/>\n")
             f.write('    <Engine name="Solr" defaultHost="localhost">\n')
             f.write('      <Host name="localhost"  appBase="../solr/web"\n')
             f.write('            unpackWARs="true" autoDeploy="true"\n')
@@ -391,7 +391,7 @@ class DseNode(Node):
         address_yaml = os.path.join(agent_dir, 'conf', 'address.yaml')
         if not os.path.exists(address_yaml):
             with open(address_yaml, 'w+') as f:
-                (ip, port) = self.network_interfaces['thrift']
+                (ip, port) = self.network_interfaces['binary']
                 jmx = self.jmx_port
                 f.write('stomp_interface: 127.0.0.1\n')
                 f.write(f'local_interface: {ip}\n')

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -900,31 +900,6 @@ class Node(object):
         env = self.get_env()
         os.execve(verify_bin, [common.platform_binary('sstableverify')] + options, env)
 
-    def run_cli(self, cmds=None, show_output=False, cli_options=[]):
-        cli = self.get_tool('cassandra-cli')
-        env = self.get_env()
-        host = self.network_interfaces['thrift'][0]
-        port = self.network_interfaces['thrift'][1]
-        args = ['-h', host, '-p', str(port), '--jmxport', str(self.jmx_port)] + cli_options
-        sys.stdout.flush()
-        if cmds is None:
-            os.execve(cli, [common.platform_binary('cassandra-cli')] + args, env)
-        else:
-            p = subprocess.Popen([cli] + args, env=env, stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
-            for cmd in cmds.split(';'):
-                p.stdin.write(cmd + ';\n')
-            p.stdin.write("quit;\n")
-            p.wait()
-            for err in p.stderr.readlines():
-                print("(EE) ", err, end='')
-            if show_output:
-                i = 0
-                for log in p.stdout.readlines():
-                    # first four lines are not interesting
-                    if i >= 4:
-                        print(log, end='')
-                    i = i + 1
-
     def run_cqlsh(self, cmds=None, show_output=False, cqlsh_options=None, return_output=False, timeout=600, extra_env=None):
         cqlsh_options = cqlsh_options or []
         cqlsh = self.get_tool('cqlsh')
@@ -977,15 +952,6 @@ class Node(object):
 
             if return_output:
                 return output
-
-    def cli(self):
-        cdir = self.get_install_dir()
-        cli = common.join_bin(cdir, 'bin', 'cassandra-cli')
-        env = self.get_env()
-        host = self.network_interfaces['thrift'][0]
-        port = self.network_interfaces['thrift'][1]
-        args = ['-h', host, '-p', str(port), '--jmxport', str(self.jmx_port)]
-        return CliSession(subprocess.Popen([cli] + args, env=env, stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True))
 
     def set_log_level(self, new_level, class_name=None):
         known_level = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'OFF']

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -90,7 +90,7 @@ class ScyllaCluster(Cluster):
     def create_node(self, name, auto_bootstrap, thrift_interface,
                     storage_interface, jmx_port, remote_debug_port,
                     initial_token, save=True, binary_interface=None):
-        return ScyllaNode(name, self, auto_bootstrap, thrift_interface,
+        return ScyllaNode(name, self, auto_bootstrap, None,
                           storage_interface, jmx_port, remote_debug_port,
                           initial_token, save, binary_interface, scylla_manager=self._scylla_manager)
 

--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -39,7 +39,7 @@ class ScyllaDockerCluster(ScyllaCluster):
                     storage_interface, jmx_port, remote_debug_port,
                     initial_token, save=True, binary_interface=None):
 
-        return ScyllaDockerNode(name, self, auto_bootstrap, thrift_interface,
+        return ScyllaDockerNode(name, self, auto_bootstrap, None,
                                 storage_interface, jmx_port, remote_debug_port,
                                 initial_token, save=save, binary_interface=binary_interface,
                                 scylla_manager=self._scylla_manager)
@@ -150,7 +150,7 @@ class ScyllaDockerNode(ScyllaNode):
         if not self.pid:
             node1 = self.cluster.nodelist()[0]
             if not self.name == node1.name:
-                seeds = f"--seeds {node1.network_interfaces['thrift'][0]}"
+                seeds = f"--seeds {node1.network_interfaces['storage'][0]}"
             else:
                 seeds = ''
             scylla_yaml = self.read_scylla_yaml()
@@ -243,7 +243,6 @@ class ScyllaDockerNode(ScyllaNode):
             if show_cluster:
                 print(f"{indent}{'cluster'}={self.cluster.name}")
             print(f"{indent}{'auto_bootstrap'}={self.auto_bootstrap}")
-            print(f"{indent}{'thrift'}={self.network_interfaces['thrift']}")
             if self.network_interfaces['binary'] is not None:
                 print(f"{indent}{'binary'}={self.network_interfaces['binary']}")
             print(f"{indent}{'storage'}={self.network_interfaces['storage']}")

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -49,7 +49,7 @@ class ScyllaNode(Node):
         self._relative_repos_root = None
         self._has_jmx = None
         super().__init__(name, cluster, auto_bootstrap,
-                         thrift_interface, storage_interface,
+                         None, storage_interface,
                          jmx_port, remote_debug_port,
                          initial_token, save, binary_interface)
         self.__global_log_level = 'info'
@@ -1151,11 +1151,8 @@ class ScyllaNode(Node):
                 ','.join(self.cluster.get_seeds(node=self)))
         data['listen_address'], data['storage_port'] = (
             self.network_interfaces['storage'])
-        data['rpc_address'], data['rpc_port'] = (
-            self.network_interfaces['thrift'])
-        if (self.network_interfaces['binary'] is not None and
-                self.get_base_cassandra_version() >= 1.2):
-            _, data['native_transport_port'] = self.network_interfaces['binary']
+        assert self.network_interfaces['binary'] is not None
+        data['rpc_address'], data['native_transport_port'] = self.network_interfaces['binary']
 
         # Use "workdir,W" instead of "workdir", because scylla defines this option this way
         # and dtests compares names of used options with the names defined in scylla.
@@ -1286,12 +1283,6 @@ class ScyllaNode(Node):
                                 'rpc_interface': 0,
                                 'rpc_interface_prefer_ipv6': 0,
                                 'rpc_keepalive': 0,
-                                'rpc_max_threads': 0,
-                                'rpc_min_threads': 0,
-                                'rpc_port': 0,
-                                'rpc_recv_buff_size_in_bytes': 0,
-                                'rpc_send_buff_size_in_bytes': 0,
-                                'rpc_server_type': 0,
                                 'seed_provider': 0,
                                 'server_encryption_options': 0,
                                 'snapshot_before_compaction': 0,
@@ -1302,7 +1293,6 @@ class ScyllaNode(Node):
                                 'storage_port': 0,
                                 'stream_throughput_outbound_megabits_per_sec': 0,
                                 'streaming_socket_timeout_in_ms': 0,
-                                'thrift_framed_transport_size_in_mb': 0,
                                 'tombstone_failure_threshold': 0,
                                 'tombstone_warn_threshold': 0,
                                 'trickle_fsync': 0,


### PR DESCRIPTION
cassandra-cli was removed in Cassandra 2.2.0. and it was replaced by
cqlsh in newer releases. actually, scylla-tools does not build or
package this command line tool at all. so let's drop the related helpers
for accessing this tool. 

thrift was deprecated in both ScyllaDB and Cassandra. so there is
no need to pass it around. to be compatible with existing users of
the ccmlib, the thrift related parameters are preserved in public
intefaces, but they are not passed down anymore. in some places,
we enforce that the host on which thrift protocol is served should
be identical to that of binary. and actually, scylla always use
the same host address for both thrift and binary protocols. so we
replace the address like `self.network_interfaces['thrift'][0]`
with `self.network_interfaces['binary'][0]`.

Refs https://github.com/scylladb/scylladb/issues/3811
Refs https://github.com/scylladb/scylladb/issues/18416