### PR TITLE
ccmlib/scylla_node.py: use native scylla nodetool when it's available

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -858,8 +858,17 @@ class Node(object):
         if not isinstance(nodetool, list):
             nodetool = [nodetool]
         # see https://www.oracle.com/java/technologies/javase/8u331-relnotes.html#JDK-8278972
-        nodetool.extend(['-h', host, '-p', str(self.jmx_port), '-Dcom.sun.jndi.rmiURLParsing=legacy'])
-        nodetool.extend(cmd.split())
+        args = ['-h', host, '-p', str(self.jmx_port), '-Dcom.sun.jndi.rmiURLParsing=legacy']
+        if len(nodetool) > 1:
+            nodetool.extend(cmd.split())
+            # put args at the end of command line options, as "scylla nodetool"
+            # expects them as options of the subcommand
+            nodetool.extend(args)
+        else:
+            # while java-based tool considers them as options of the nodetool
+            # itself
+            nodetool.extend(args)
+            nodetool.extend(cmd.split())
 
         return self._do_run_nodetool(nodetool, capture_output, wait, timeout, verbose)
 


### PR DESCRIPTION
in b18f85d7, we use the native nodetool if JMX is not available, but when running dtest from the local build, the jmx repo is still around, so the java-based nodetool is picked. but the java-based nodetool does not support tablets, and it would be great to always test the native implementation built locally when testing using dtest without building a relocatable package.

so, in this change, we go a step further by checking if the command line of `scylla nodetool help` works, if it succeeds, we go ahead and use `scylla nodetool`, otherwise, we fall back to the java-based nodetool. we could instead use `scylla nodetool --help` instead of calling a certain command of nodetool, but seastar returns 1 if `--help` is used. a pull request was created to address it . see https://github.com/scylladb/seastar/pull/2213.

also, the native nodetool expect `-h` and `--port` as parameters of the subcommand, not the parameters of `scylla nodetool`, it complains like:

```
E               ccmlib.node.ToolError: Subprocess /jenkins/workspace/scylla-master/gating-dtest-release/scylla/.dtest/dtest-7r2n368l/test/node1/bin/scylla nodetool -h 127.0.17.1 -p 10000 snapshot exited with non-zero status; exit status: 100;
E               stderr: error: unrecognized operation argument: expected one of ({cleanup, compact, disablebackup, disablebinary, disablegossip, enablebackup, enablebinary, enablegossip, flush, gettraceprobability, help, settraceprobability, statusbackup, statusbinary, statusgossip, version}), got --host
```

but the java-based tool looks for these options before the subcommand, so put them conditionally.