### PR TITLE
ccmlib/scylla_node: dump_sstable_stats to handle broken utf-8

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1659,10 +1659,12 @@ class ScyllaNode(Node):
                                                 keyspace=keyspace,
                                                 column_families=[column_family],
                                                 datafiles=datafiles,
-                                                batch=True)
+                                                batch=True,
+                                                text=False,
+                                                )
         assert '' in sstable_stats
         stdout, _ = sstable_stats['']
-        return json.loads(stdout)['sstables']
+        return json.loads(stdout.decode('utf-8', 'ignore'))['sstables']
 
     def dump_sstable_scylla_metadata(self,
                            keyspace: str,


### PR DESCRIPTION
in some cases the output of `scylla sstable` can be with illegal utf-8, we should just skip them, and it would work as expected.