### PR TITLE
Remove cli cluster command

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -39,7 +39,6 @@ def cluster_cmds():
         "updateconf",
         "updatedseconf",
         "updatelog4j",
-        "cli",
         "setdir",
         "bulkload",
         "setlog",


### PR DESCRIPTION
It's implementation was already removed in https://github.com/scylladb/scylla-ccm/commit/06a2adf303c292239b9a84b6a674824e0204797c , but the command was still present in the list, causing an error when printing ccm's help.