### PR TITLE
node: watch_log_for: reduce polling sleep time

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -434,7 +434,7 @@ class Node(object):
         timeouts (a TimeoutError is then raised). On successful completion,
         a list of pair (line matched, match object) is returned.
         """
-        elapsed = 0
+        deadline = time.time() + timeout
         tofind = [exprs] if isinstance(exprs, str) else exprs
         tofind = [re.compile(e) for e in tofind]
         matchings = []
@@ -485,9 +485,9 @@ class Node(object):
                             break
                 else:
                     # yep, it's ugly
-                    time.sleep(0.01)
-                    elapsed = elapsed + 1
-                    if elapsed > 100 * timeout:
+                    # FIXME: consider using inotify with IN_MODIFY to monitor the file
+                    time.sleep(0.001)
+                    if time.time() > deadline:
                         raise TimeoutError(time.strftime("%d %b %Y %H:%M:%S", time.gmtime()) + " [" + self.name + "] Missing: " + str(
                             [e.pattern for e in tofind]) + ":\n" + reads[:50] + f".....\nSee {filename} for remainder")
 


### PR DESCRIPTION
Currently, when watch_log_for reaches end-of-file
it sleeps for 10 milliseconds (0.01 seconds).
This proved to be too much as the caller sometimes needs to quickly react to certain log messages, and missing the event in 10 milliseconds will be too late, as seen in https://github.com/scylladb/scylla-dtest/pull/4393#issuecomment-2148934115

This change reduces the sleep time to a single millisecond and also changes the timeout detection to using a proper time-based deadline, rather than counting the number of times we sleep (I'm really not sure why it was originally done that way).