### PR TITLE
ccmlib/common: print out process if it's listen given address

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -702,6 +702,8 @@ class ScyllaNode(Node):
                                             wait_normal_token_owner=wait_normal_token_owner,
                                             wait_for_binary_proto=wait_for_binary_proto,
                                             ext_env=ext_env)
+        self.info(f"Started scylla: pid: {scylla_process.pid}")
+
         if self.has_jmx:
             self._start_jmx(data)
 


### PR DESCRIPTION
when we start, for instance, a scylla node, we use `check_socket_available()` to see if the given address can be bound, if not an exception is raised. but we still have no idea who is listening on this address.

in this change, we print out the process in this case, so that we can understand the problem better. in general, it's either an infra issue, or, it could be caused by a buggy test.