### PR TITLE
ComparableScyllaVersion: improve matching 

### DIFF
--- a/ccmlib/utils/version.py
+++ b/ccmlib/utils/version.py
@@ -28,16 +28,16 @@ SEMVER_REGEX = re.compile(
 class ComparableScyllaVersion:
     """Accepts and compares known 'non-semver' and 'semver'-like Scylla versions."""
 
-    def __init__(self, version_string: str):
+    def __init__(self, version_string: str) -> None:
         parsed_version = self.parse(version_string)
-        self.v_major = int(parsed_version[0])
-        self.v_minor = int(parsed_version[1])
-        self.v_patch = int(parsed_version[2])
-        self.v_pre_release = parsed_version[3] or ''
-        self.v_build = parsed_version[4] or ''
+        self.v_major = int(parsed_version["major"])
+        self.v_minor = int(parsed_version["minor"])
+        self.v_patch = int(parsed_version["patch"])
+        self.v_pre_release = parsed_version["prerelease"] or ''
+        self.v_build = parsed_version["build"] or ''
 
     @staticmethod
-    def parse(version_string: str):
+    def parse(version_string: str) -> re.Match:
         """Parse scylla-binary and scylla-docker-tag versions into a proper semver structure."""
         # NOTE: remove 'with build-id' part if exists and other possible non-semver parts
         _scylla_version = (version_string or '').split(" ")[0]
@@ -74,7 +74,7 @@ class ComparableScyllaVersion:
             _scylla_version = f"{dotted_build_id_match[1]}+{dotted_build_id_match[3]}"
 
         if match := SEMVER_REGEX.match(_scylla_version):
-            return match.groups()
+            return match
         raise ValueError(
             f"Cannot parse provided '{version_string}' scylla_version for the comparison. "
             f"Transformed scylla_version: {_scylla_version}")

--- a/ccmlib/utils/version.py
+++ b/ccmlib/utils/version.py
@@ -81,6 +81,15 @@ class ComparableScyllaVersion:
             f"Cannot parse provided '{version_string}' scylla_version for the comparison. "
             f"Transformed scylla_version: {_scylla_version}")
 
+    def major(self) -> 'ComparableScyllaVersion':
+        return ComparableScyllaVersion(f"{self.v_major}")
+
+    def minor(self) -> 'ComparableScyllaVersion':
+        return ComparableScyllaVersion(f"{self.v_major}.{self.v_minor}")
+
+    def patch(self) -> 'ComparableScyllaVersion':
+        return ComparableScyllaVersion(f"{self.v_major}.{self.v_minor}.{self.v_patch}")
+
     def __str__(self):
         result = f"{self.v_major}.{self.v_minor}.{self.v_patch}"
         if self.v_pre_release:

--- a/ccmlib/utils/version.py
+++ b/ccmlib/utils/version.py
@@ -55,7 +55,9 @@ class ComparableScyllaVersion:
 
         # NOTE: make short scylla version like '5.2' be correct semver string
         _scylla_version_parts = re.split(r'\.|-', _scylla_version)
-        if len(_scylla_version_parts) == 2:
+        if len(_scylla_version_parts) == 1:
+            _scylla_version = f"{_scylla_version}.0.0"
+        elif len(_scylla_version_parts) == 2:
             _scylla_version = f"{_scylla_version}.0"
         elif len(_scylla_version_parts) > 2 and re.search(
                 r"\D+", _scylla_version_parts[2].split("-")[0]):

--- a/tests/test_utils_version.py
+++ b/tests/test_utils_version.py
@@ -30,7 +30,7 @@ def test_comparable_scylla_version_init_positive(version_string, expected):
     assert comparable_scylla_version.v_build == expected[4]
 
 
-@pytest.mark.parametrize("version_string", (None, "", "5", "2023", "2023.dev"))
+@pytest.mark.parametrize("version_string", (None, "", "2023.dev"))
 def test_comparable_scylla_versions_init_negative(version_string):
     try:
         ComparableScyllaVersion(version_string)
@@ -89,6 +89,7 @@ def test_comparable_scylla_versions_compare(version_string_left, version_string_
 
 
 @pytest.mark.parametrize("version_string_input, version_string_output", (
+    ("5", "5.0.0"),
     ("5.2.2", "5.2.2"),
     ("2023.1.13", "2023.1.13"),
     ("5.2.0~rc0-0.20230207", "5.2.0-rc0-0.20230207"),

--- a/tests/test_utils_version.py
+++ b/tests/test_utils_version.py
@@ -98,3 +98,10 @@ def test_comparable_scylla_versions_compare(version_string_left, version_string_
 ))
 def test_comparable_scylla_versions_to_str(version_string_input, version_string_output):
     assert str(ComparableScyllaVersion(version_string_input)) == version_string_output
+
+
+def test_major_minor_patch():
+    v = ComparableScyllaVersion('1.2.3~dev')
+    assert v.major() == '1'
+    assert v.minor() == '1.2'
+    assert v.patch() == '1.2.3'


### PR DESCRIPTION
so that we can compare a given ComparableScyllaVersion by its major version, minor version or patch version, when we are interested in features introduced at different major version, minor version, or a certain patch version.