### PR TITLE
ccmlib/common: add function to get the default scylla.yaml

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -843,6 +843,10 @@ def get_version_from_build(install_dir=None, node_path=None):
                     return match.group(1)
     raise CCMError("Cannot find version")
 
+def get_default_scylla_yaml(install_dir):
+    scylla_yaml_path = Path(install_dir) / SCYLLA_CONF_DIR / SCYLLA_CONF
+    with scylla_yaml_path.open() as f:
+        return yaml.safe_load(f)
 
 def _get_scylla_version(install_dir):
     scylla_version_files = [

--- a/tests/test_scylla_relocatable_cluster.py
+++ b/tests/test_scylla_relocatable_cluster.py
@@ -3,7 +3,7 @@ import subprocess
 
 import pytest
 
-from ccmlib.common import get_scylla_full_version, get_scylla_version
+from ccmlib.common import get_scylla_full_version, get_scylla_version, get_default_scylla_yaml
 from ccmlib.node import Node, ToolError
 
 
@@ -65,3 +65,12 @@ class TestScyllaRelocatableCluster:
         for s in ['(1 rows)', 'key', '1']:
             assert s in rv[0]
         assert rv[1] == ''
+
+
+    def test_get_default_scylla_yaml(self, relocatable_cluster):
+        install_dir = relocatable_cluster.get_install_dir()
+        scylla_yaml = get_default_scylla_yaml(install_dir)
+        assert scylla_yaml.get('native_transport_port') == 9042
+        assert scylla_yaml.get('consistent_cluster_management') == True
+        assert scylla_yaml.get('listen_address') == 'localhost'
+


### PR DESCRIPTION
this function need to get the install_dir, and out of it it can extract the default scylla.yaml (i.e. before any modification that ccm would be doing to it)

Closes: #582