### PR TITLE
ccmlib/cluster: fix automatic rack naming

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -283,7 +283,7 @@ class Cluster(object):
                 if isinstance(x, int):
                     topology[dc] = OrderedDict([(None, x)])
                 elif isinstance(x, list):
-                    topology[dc] = OrderedDict([(None, n) for n in x])
+                    topology[dc] = OrderedDict([(f"RAC{i}", n) for i, n in enumerate(x, start=1)])
                 elif isinstance(x, dict):
                     topology[dc] = OrderedDict([(rack, n) for rack, n in x.items()])
                 else:


### PR DESCRIPTION
Make Cluster.populate() work correctly for option 3.b of the nodes argument (e.g., {"dc1": [2, 2]}): as described in the comment it'll be converted to something like {"dc1": {"RAC1": 2, "RAC2": 2}}