### PR TITLE
test_scylla_repository: skip test for splitted packages

### DIFF
--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -127,6 +127,7 @@ class TestReinstallPackages:
         file_text = file_text.replace("hash=", "hash=123")
         source_file.write_text(file_text)
 
+    @pytest.mark.skip("no more version with no unified package, TODO: remove when rest of related code is removed")
     def test_setup_no_unified_packages_reinstall(self):
         """
         Validate that if package hash is changed, new package will be downloaded.


### PR DESCRIPTION
none of the version under master folder has splitted packages only i.e. all of them has unified package, hence this test isn't relevent anymore

recently we fixed the unified package retrival and miss the fact this test, got broken.

next step would be to remove the support of splitted packages completly