### PR TITLE
scylla_repository: setup: allow debug in version string

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -238,12 +238,21 @@ def setup(version, verbose=True, skip_downloads=False):
               - release:4.2.1
               - release:2020.1
               - release:2020.1.5
+            3. Debug versions of the above
+              - unstable/master:latest:debug
+              - unstable/enterprise:2020-08-18T14:49:18Z:debug
+              - release:4.3:debug
+              - release:4.2.1:debug
 
     :param verbose: if True, print progress during download
     :param skip_downloads: if True, skips the actual download of files for testing purposes
 
     """
     s3_url = ''
+    scylla_debug = version.endswith(":debug")
+    if scylla_debug:
+        version = version[:-6]
+    scylla_mode_suffix = '-debug' if scylla_debug else ''
     type_n_version = version.split(':', 1)
     scylla_product = os.environ.get('SCYLLA_PRODUCT', 'scylla')
     scylla_arch = os.environ.get('SCYLLA_ARCH', 'x86_64')
@@ -255,7 +264,7 @@ def setup(version, verbose=True, skip_downloads=False):
     if type_n_version[0] == 'release':
         version = normalize_scylla_version(version)
         type_n_version = version.split(os.path.sep, 1)
-    version_dir = version_directory(version) if not skip_downloads else None
+    version_dir = version_directory(version + scylla_mode_suffix) if not skip_downloads else None
 
     # If the test version is unstable (not release, maybe private branch) and installation folder exists,
     # we want to check if this version was downloaded nd installed already in the past and was changed.
@@ -273,21 +282,23 @@ def setup(version, verbose=True, skip_downloads=False):
 
             s3_url = get_relocatable_s3_url('', major_version, RELEASE_RELOCATABLE_URLS_BASE)
 
-            packages, type_n_version[1] = release_packages(s3_url=s3_url, version=s3_version, arch=scylla_arch, scylla_product=scylla_product)
+            packages, type_n_version[1] = release_packages(s3_url=s3_url, version=s3_version, arch=scylla_arch, scylla_product=scylla_product + scylla_mode_suffix)
         else:
             _, branch = type_n_version[0].split("/")
             s3_url = get_relocatable_s3_url(branch, s3_version, RELOCATABLE_URLS_BASE)
 
             try:
                 build_manifest = read_build_manifest(s3_url)
-                url = build_manifest.get(f'unified-pack-url-{scylla_arch}')
-                assert url, "didn't found the url for unified package"
+                url = build_manifest.get(f'unified-pack-url-{scylla_arch}') or build_manifest.get('unified-pack-url')
+                assert url, f"didn't find the url for unified package, {build_manifest=}"
+                if scylla_debug:
+                    url = re.sub("-unified", "-debug-unified", url)
                 if not url.startswith('s3'):
                     url = f's3.amazonaws.com/{url}'
                 url = f'http://{url}'
                 packages = RelocatablePackages(scylla_unified_package=url)
             except Exception as ex:
-                logging.exception("could download relocatable")
+                logging.exception(f"could not download relocatable, {ex=}")
 
                 scylla_package_path = f'{scylla_product}-package.tar.gz'
                 scylla_arch_package_path = f'{scylla_product}-{scylla_arch}-package.tar.gz'
@@ -318,7 +329,7 @@ def setup(version, verbose=True, skip_downloads=False):
                     scylla_package=os.path.join(s3_url, scylla_package_path)
                 )
 
-        version = os.path.join(*type_n_version)
+        version = os.path.join(*type_n_version) + scylla_mode_suffix
 
     if skip_downloads:
         return directory_name(version), packages


### PR DESCRIPTION
Add support for optional [:debug] flag following the version string to specify debug mode.

Closes: #590
Follow-up on: #591, simple version of that. Just check for the debug flag, and if it exists, add "-debug" where appropiate.

Tested locally
```
➜ pytest -s --scylla-version='unstable/master:latest:debug' --tablets  materialized_views_test.py::TestMaterializedViews::test_do_not_finish_view_building_with_hints
S3 download: scylla-debug-unified-6.2.0~dev-0.20240816.afee3924b3dc.x86_64.tar.gz100%|██████████| 245M/245M [00:11<00:00, 21.7MB/s]
Extracting /tmp/ccm-nfwvr5ro.tar.gz (http://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla/master/relocatable/2024-08-16T01:33:28Z/scylla-debug-unified-6.2.0~dev-0.20240816.afee3924b3dc.x86_64.tar.gz, /tmp/tmprl4krzl2) as version unstable/master/latest-debug ...
Relocatable package format version 3.0 detected.
Completed to install Scylla in the folder '/home/cezar/.ccm/scylla-repository/unstable/master/latest-debug'
```