### PR TITLE
fix(node decomission): stop a decommissioned node by default

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1428,10 +1428,12 @@ class Node(object):
     def version(self):
         self.nodetool("version")
 
-    def decommission(self):
+    def decommission(self, stop_node: bool = True):
         self.nodetool("decommission")
         self.status = Status.DECOMMISSIONED
         self._update_config()
+        if stop_node:
+            self.stop()
 
     def hostid(self, timeout=60, force_refresh=False):
         if not hasattr(self, 'node_hostid') or force_refresh:


### PR DESCRIPTION
	A decommissioned node currently left is_running() after its
	status changed to "decommissioned". thus it is unexpectedly left
	as part of cluster nodes, like in cluster.nodelist().
	This should not be the default, but rather to stop() the node
	after decommission successfully completed (as it is in SCT).
	This fix requires a corresponding dtest PR to adjust all calls of
	node.decommission() in order to remove 14 un-needed calls to node.stop()
	or to set the new flag of stop_node=False needed for raft testing.
	This fix is a followup of:
	https://github.com/scylladb/scylla-dtest/pull/4767#discussion_r1731340260
refs: https://github.com/scylladb/scylla-dtest/pull/4767#discussion_r1731340260