### PR TITLE
setup.py: do not claim the support for 3.3 and 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,10 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9'
+        'Programming Language :: Python :: 3.11'
+        'Programming Language :: Python :: 3.12'
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
instead of testing on 3.3 or 3.4, we test on 3.8, 3.9, 3.11 and 3.12. so update setup.py to reflect this fact.