### PR TITLE
tests/ccmcluster.py: make parse_cluster_status ignore lines that does not match

### DIFF
--- a/tests/ccmcluster.py
+++ b/tests/ccmcluster.py
@@ -113,7 +113,10 @@ class CCMCluster:
         """
         nodes_status = []
         for line in stdout.split("\n")[2:]:
-            node, status = line.split(":")
+            chunks = line.split(":")
+            if len(chunks) != 2:
+                continue
+            node, status = chunks
             nodes_status.append((node.strip(), status.strip()))
 
         return nodes_status


### PR DESCRIPTION
It could fail with following error:
```
    def parse_cluster_status(self, stdout):
        """
            Output:

            Cluster: 'CCMCluster-reloc'
            ---------------------------
            node1: UP

            return:
            [(node1, UP)]
        """
        nodes_status = []
        for line in stdout.split("\n")[2:]:
>           node, status = line.split(":")
E           ValueError: not enough values to unpack (expected 2, got 1)
```