### PR TITLE
github actions: update to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Copy logs/results
       if: contains(github.event.pull_request.labels.*.name, 'PR-upload-log')
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ccm-tests-log
         path: tests/test_results/

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Copy logs/results
       if: contains(github.event.pull_request.labels.*.name, 'PR-upload-log')
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ccm-tests-log
         path: tests/test_results/


### PR DESCRIPTION
actions/upload-artifact@v2 is deprecated and can't be used anymore