### PR TITLE
get_relocatable_s3_url: support :debug suffix in s3_version

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -178,6 +178,9 @@ def release_packages(s3_url, version, arch='x86_64', scylla_product='scylla'):
 
 
 def get_relocatable_s3_url(branch, s3_version, links):
+    debug_tag = ':debug'
+    if s3_version.endswith(debug_tag):
+        s3_version = s3_version[:-len(debug_tag)]
     for reloc_url in links:
         s3_url = reloc_url.format(branch, s3_version)
         resp = aws_bucket_ls(s3_url)


### PR DESCRIPTION
Following up on 7721ac7a8d0b844568006af7a6b508cb84042a16 the :debug suffix may end up in s3_version
when passed to get_relocatable_s3_url.