### PR TITLE
[Backport 6.1] ccmlib/node: check both pending and active tasks when waiting for compactions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Copy logs/results
       if: contains(github.event.pull_request.labels.*.name, 'PR-upload-log')
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ccm-tests-log
         path: tests/test_results/

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Copy logs/results
       if: contains(github.event.pull_request.labels.*.name, 'PR-upload-log')
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ccm-tests-log
         path: tests/test_results/

--- a/README.md
+++ b/README.md
@@ -55,12 +55,11 @@ ccm create my_cluster -n 3 --scylla --vnodes \
 Requirements
 ------------
 
-- A working python installation (tested to work with python 3.11).
-- pyYAML (http://pyyaml.org/ -- `sudo easy_install pyYaml`)
-- ant (http://ant.apache.org/, on Mac OS X, `brew install ant`)
-- psutil (https://pypi.python.org/pypi/psutil)
-- Java (which version depends on the version of Cassandra you plan to use. If
-  unsure, use Java 7 as it is known to work with current versions of Cassandra).
+- A working python installation (tested to work with python 3.12).
+- `pip install -e .` to install the required dependencies.
+- Java if cassandra is used or older scylla < 6.0 (which version depends on the version 
+  of Cassandra you plan to use. If unsure, use Java 8 as it is known to 
+  work with current versions of Cassandra).
 - ccm only works on localhost for now. If you want to create multiple
   node clusters, the simplest way is to use multiple loopback aliases. On
   modern linux distributions you probably don't need to do anything, but
@@ -75,17 +74,8 @@ Requirements
 
 Known issues
 ------------
-Windows only:
-  - `node start` pops up a window, stealing focus.
-  - cli and cqlsh started from ccm show incorrect prompts on command-prompt
-  - non nodetool-based command-line options fail (sstablesplit, scrub, etc)
-  - cli_session does not accept commands.
-  - To install psutil, you must use the .msi from pypi. pip install psutil will not work
-  - You will need ant.bat in your PATH in order to build C* from source
-  - You must run with an Unrestricted Powershell Execution-Policy if using Cassandra 2.1.0+
-  - Ant installed via [chocolatey](https://chocolatey.org/) will not be found by ccm, so you must create a symbolic
-    link in order to fix the issue (as administrator):
-    - cmd /c mklink C:\ProgramData\chocolatey\bin\ant.bat C:\ProgramData\chocolatey\bin\ant.exe
+
+- this fork of ccm doesn't support Windows
 
 Installation
 ------------

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -15,8 +15,6 @@ from ccmlib.node import Node, NodeError
 from ccmlib.common import logger
 from ccmlib.utils.version import parse_version
 
-yaml = YAML()
-yaml.default_flow_style = False
 
 class Cluster(object):
 
@@ -677,7 +675,7 @@ class Cluster(object):
             cluster_config['sni_proxy_listen_port'] = self.sni_proxy_listen_port
 
         with open(filename, 'w') as f:
-            yaml.dump(cluster_config, f)
+            YAML().dump(cluster_config, f)
 
     def __update_pids(self, started):
         for node, p, _ in started:

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -8,13 +8,15 @@ import time
 from collections import OrderedDict, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 
-import yaml
+from ruamel.yaml import YAML
 
 from ccmlib import common, repository
 from ccmlib.node import Node, NodeError
 from ccmlib.common import logger
 from ccmlib.utils.version import parse_version
 
+yaml = YAML()
+yaml.default_flow_style = False
 
 class Cluster(object):
 
@@ -675,7 +677,7 @@ class Cluster(object):
             cluster_config['sni_proxy_listen_port'] = self.sni_proxy_listen_port
 
         with open(filename, 'w') as f:
-            yaml.safe_dump(cluster_config, f)
+            yaml.dump(cluster_config, f)
 
     def __update_pids(self, started):
         for node, p, _ in started:

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -10,8 +10,6 @@ from ccmlib.scylla_docker_cluster import ScyllaDockerCluster
 from ccmlib import repository
 from ccmlib.node import Node
 
-yaml = YAML()
-yaml.default_flow_style = False
 
 class ClusterFactory():
 
@@ -20,7 +18,7 @@ class ClusterFactory():
         cluster_path = os.path.join(path, name)
         filename = os.path.join(cluster_path, 'cluster.conf')
         with open(filename, 'r') as f:
-            data = yaml.load(f)
+            data = YAML().load(f)
         try:
             install_dir = None
             scylla_manager_install_path = data.get('scylla_manager_install_path')

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -1,6 +1,6 @@
 import os
 
-import yaml
+from ruamel.yaml import YAML
 
 from ccmlib import common, repository
 from ccmlib.cluster import Cluster
@@ -10,6 +10,8 @@ from ccmlib.scylla_docker_cluster import ScyllaDockerCluster
 from ccmlib import repository
 from ccmlib.node import Node
 
+yaml = YAML()
+yaml.default_flow_style = False
 
 class ClusterFactory():
 
@@ -18,7 +20,7 @@ class ClusterFactory():
         cluster_path = os.path.join(path, name)
         filename = os.path.join(cluster_path, 'cluster.conf')
         with open(filename, 'r') as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f)
         try:
             install_dir = None
             scylla_manager_install_path = data.get('scylla_manager_install_path')

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -21,12 +21,14 @@ from itertools import zip_longest
 from typing import Callable, Optional, TextIO, Union, List
 from pathlib import Path
 
-import yaml
 import psutil
+from ruamel.yaml import YAML
 from boto3.session import Session
 from botocore import UNSIGNED
 from botocore.client import Config
 
+yaml = YAML()
+yaml.default_flow_style = False
 
 BIN_DIR = "bin"
 CASSANDRA_CONF_DIR = "conf"
@@ -248,7 +250,7 @@ def get_config():
         return {}
 
     with open(config_path, 'r') as f:
-        return yaml.safe_load(f)
+        return yaml.load(f)
 
 
 def now_ms():
@@ -827,7 +829,7 @@ def parse_settings(args):
         elif val.lower() == "false":
             val = False
         else:
-            val = yaml.safe_load(val)
+            val = yaml.load(val)
         splitted = key.split('.')
         if len(splitted) == 2:
             try:
@@ -886,7 +888,7 @@ def get_version_from_build(install_dir=None, node_path=None):
 def get_default_scylla_yaml(install_dir):
     scylla_yaml_path = Path(install_dir) / SCYLLA_CONF_DIR / SCYLLA_CONF
     with scylla_yaml_path.open() as f:
-        return yaml.safe_load(f)
+        return yaml.load(f)
 
 def _get_scylla_version(install_dir):
     scylla_version_files = [
@@ -968,7 +970,7 @@ def is_dse_cluster(path):
             cluster_path = os.path.join(path, name)
             filename = os.path.join(cluster_path, 'cluster.conf')
             with open(filename, 'r') as f:
-                data = yaml.safe_load(f)
+                data = yaml.load(f)
             if 'dse_dir' in data:
                 return True
     except IOError:

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -27,8 +27,6 @@ from boto3.session import Session
 from botocore import UNSIGNED
 from botocore.client import Config
 
-yaml = YAML()
-yaml.default_flow_style = False
 
 BIN_DIR = "bin"
 CASSANDRA_CONF_DIR = "conf"
@@ -817,6 +815,7 @@ def normalize_interface(itf):
 
 def parse_settings(args):
     settings = {}
+    yaml = YAML()
     for s in args:
         splitted = s.split(':', 1)
         if len(splitted) != 2:
@@ -888,7 +887,7 @@ def get_version_from_build(install_dir=None, node_path=None):
 def get_default_scylla_yaml(install_dir):
     scylla_yaml_path = Path(install_dir) / SCYLLA_CONF_DIR / SCYLLA_CONF
     with scylla_yaml_path.open() as f:
-        return yaml.load(f)
+        return YAML().load(f)
 
 def _get_scylla_version(install_dir):
     scylla_version_files = [
@@ -970,7 +969,7 @@ def is_dse_cluster(path):
             cluster_path = os.path.join(path, name)
             filename = os.path.join(cluster_path, 'cluster.conf')
             with open(filename, 'r') as f:
-                data = yaml.load(f)
+                data = YAML().load(f)
             if 'dse_dir' in data:
                 return True
     except IOError:

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -9,10 +9,13 @@ import stat
 import subprocess
 import time
 
-import yaml
+from ruamel.yaml import YAML
 
 from ccmlib import common
 from ccmlib.node import Node, NodeError
+
+yaml = YAML()
+yaml.default_flow_style = False
 
 
 class DseNode(Node):
@@ -293,7 +296,7 @@ class DseNode(Node):
     def __update_yaml(self):
         conf_file = os.path.join(self.get_path(), 'resources', 'dse', 'conf', 'dse.yaml')
         with open(conf_file, 'r') as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f)
 
         data['system_key_directory'] = os.path.join(self.get_path(), 'keys')
 
@@ -310,7 +313,7 @@ class DseNode(Node):
                 data[name] = full_options[name]
 
         with open(conf_file, 'w') as f:
-            yaml.safe_dump(data, f, default_flow_style=False)
+            yaml.dump(data, f)
 
     def _update_log4j(self):
         super(DseNode, self)._update_log4j()

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -14,9 +14,6 @@ from ruamel.yaml import YAML
 from ccmlib import common
 from ccmlib.node import Node, NodeError
 
-yaml = YAML()
-yaml.default_flow_style = False
-
 
 class DseNode(Node):
 
@@ -296,7 +293,7 @@ class DseNode(Node):
     def __update_yaml(self):
         conf_file = os.path.join(self.get_path(), 'resources', 'dse', 'conf', 'dse.yaml')
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = YAML().load(f)
 
         data['system_key_directory'] = os.path.join(self.get_path(), 'keys')
 
@@ -313,7 +310,7 @@ class DseNode(Node):
                 data[name] = full_options[name]
 
         with open(conf_file, 'w') as f:
-            yaml.dump(data, f)
+            YAML().dump(data, f)
 
     def _update_log4j(self):
         super(DseNode, self)._update_log4j()

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -17,12 +17,15 @@ from datetime import datetime
 import locale
 from collections import namedtuple
 
-import yaml
+from ruamel.yaml import YAML
 
 from ccmlib import common
 from ccmlib.cli_session import CliSession
 from ccmlib.repository import setup
 from ccmlib.utils.version import parse_version
+
+yaml = YAML()
+yaml.default_flow_style = False
 
 class Status():
     UNINITIALIZED = "UNINITIALIZED"
@@ -135,7 +138,7 @@ class Node(object):
         node_path = os.path.join(path, name)
         filename = os.path.join(node_path, 'node.conf')
         with open(filename, 'r') as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f)
         try:
             itf = data['interfaces']
             initial_token = None
@@ -1583,12 +1586,12 @@ class Node(object):
         if self.workload is not None:
             values['workload'] = self.workload
         with open(filename, 'w') as f:
-            yaml.safe_dump(values, f)
+            yaml.dump(values, f)
 
     def __update_yaml(self):
         conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f)
 
         with open(conf_file, 'r') as f:
             yaml_text = f.read()
@@ -1638,7 +1641,7 @@ class Node(object):
                     data[name] = full_options[name]
 
         with open(conf_file, 'w') as f:
-            yaml.safe_dump(data, f, default_flow_style=False)
+            yaml.dump(data, f)
 
     def _update_log4j(self):
         append_pattern = 'log4j.appender.R.File='
@@ -1960,7 +1963,7 @@ class Node(object):
     def get_conf_option(self, option):
         conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f)
 
         if option in data:
             return data[option]

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -24,8 +24,6 @@ from ccmlib.cli_session import CliSession
 from ccmlib.repository import setup
 from ccmlib.utils.version import parse_version
 
-yaml = YAML()
-yaml.default_flow_style = False
 
 class Status():
     UNINITIALIZED = "UNINITIALIZED"
@@ -138,7 +136,7 @@ class Node(object):
         node_path = os.path.join(path, name)
         filename = os.path.join(node_path, 'node.conf')
         with open(filename, 'r') as f:
-            data = yaml.load(f)
+            data = YAML().load(f)
         try:
             itf = data['interfaces']
             initial_token = None
@@ -1586,12 +1584,12 @@ class Node(object):
         if self.workload is not None:
             values['workload'] = self.workload
         with open(filename, 'w') as f:
-            yaml.dump(values, f)
+            YAML().dump(values, f)
 
     def __update_yaml(self):
         conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = YAML().load(f)
 
         with open(conf_file, 'r') as f:
             yaml_text = f.read()
@@ -1641,7 +1639,7 @@ class Node(object):
                     data[name] = full_options[name]
 
         with open(conf_file, 'w') as f:
-            yaml.dump(data, f)
+            YAML().dump(data, f)
 
     def _update_log4j(self):
         append_pattern = 'log4j.appender.R.File='
@@ -1963,7 +1961,7 @@ class Node(object):
     def get_conf_option(self, option):
         conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = YAML().load(f)
 
         if option in data:
             return data[option]

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -78,6 +78,9 @@ NodetoolError = ToolError
 
 # Groups: 0 = ks, 1 = cf, 2 = tmp or none, 3 = version, 4 = identifier (generation), 4 = "big-" or none, 5 = suffix (Compacted or Data.db)
 _sstable_regexp = re.compile(r'((?P<keyspace>[^\s-]+)-(?P<cf>[^\s-]+)-)?(?P<tmp>tmp(link)?-)?(?P<version>[^\s-]+)-(?P<identifier>[^-]+)-(?P<big>big-)?(?P<suffix>[a-zA-Z]+)\.[a-zA-Z0-9]+$')
+# Regexes for parsing nodetool compactionstats
+_pending_tasks_pattern = re.compile(r'- (?P<ks>\w+)\.(?P<cf>\w+): (?P<tasks>\d+)')
+_active_tasks_pattern = re.compile(r'\s*([\w-]+)\s+\w+\s+(?P<ks>\w+)\s+(?P<cf>\w+)\s+\d+\s+\d+\s+\w+\s+\d+\.\d+%')
 
 
 class Node(object):
@@ -763,14 +766,12 @@ class Node(object):
         """
         lines = output.strip().splitlines()
         tasks = defaultdict(int)
-        pending_tasks_pattern = re.compile(r'- (?P<ks>\w+)\.(?P<cf>\w+): (?P<tasks>\d+)')
-        active_tasks_pattern = re.compile(r'\s*([\w-]+)\s+\w+\s+(?P<ks>\w+)\s+(?P<cf>\w+)\s+\d+\s+\d+\s+\w+\s+\d+\.\d+%')
 
         for line in lines:
             line = line.strip()
-            if match := pending_tasks_pattern.match(line):
+            if match := _pending_tasks_pattern.match(line):
                 tasks[(match.group("ks"), match.group("cf"))] += int(match.group("tasks"))
-            elif match := active_tasks_pattern.match(line):
+            elif match := _active_tasks_pattern.match(line):
                 tasks[(match.group("ks"), match.group("cf"))] += 1
 
         if keyspace is None and column_family is None:
@@ -786,8 +787,8 @@ class Node(object):
         :param keyspace: only wait for the compactions performed for specified keyspace.
             If not specified, all keyspaces are waited.
             Must be provided if collumn_family is provided.
-        :param column_family: only wait for the compactions performed for specified column_family.
-            If not specified, all keyspaces are waited.
+        :param column_family: only wait for the compactions performed for specified column family.
+            If not specified, all column families are waited.
         :param idle_timeout: the time in seconds to wait for progress.
             Total time to wait is undeteremined, as long as we observe forward progress.
         """

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -15,7 +15,7 @@ import time
 import warnings
 from datetime import datetime
 import locale
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 
 from ruamel.yaml import YAML
 
@@ -745,58 +745,59 @@ class Node(object):
             return False
 
     @staticmethod
-    def _parse_pending_tasks(output, keyspace, column_family):
-        # "nodetool compactionstats" prints the compaction stats like:
-        # pending tasks: 42
-        # - ks1.cf1: 13
-        # - ks1.cf2: 19
-        # - ks2.cf1: 10
-        head_pattern = r"pending tasks:\s*(?P<tasks>\d+)"
-        tail_pattern = re.compile(r'\-\s+(\w+)\.(\w+):\s*(\d+)')
-        head, *tail = output.strip().split('\n')
+    def _parse_tasks(output: str, keyspace: str, column_family: str):
+        """
+        Returns the total number of tasks
+
+        `nodetool compactionstats` prints the compaction stats like:
+        ```
+        pending tasks: 42
+        - ks1.cf1: 13
+        - ks2.cf2: 19
+        - ks3.cf3: 10
+
+        id                                   compaction type keyspace table completed total unit progress
+        55eaee80-7445-11ef-9197-2931a44dadc4 COMPACTION      ks3      cf3   32116     55680 keys 57.68%  
+        55e8f2b0-7445-11ef-b438-2930a44dadc4 COMPACTION      ks4      cf4   46789     55936 keys 83.65%  
+        ```
+        """
+        lines = output.strip().splitlines()
+        tasks = defaultdict(int)
+        pending_tasks_pattern = re.compile(r'- (?P<ks>\w+)\.(?P<cf>\w+): (?P<tasks>\d+)')
+        active_tasks_pattern = re.compile(r'\s*([\w-]+)\s+\w+\s+(?P<ks>\w+)\s+(?P<cf>\w+)\s+\d+\s+\d+\s+\w+\s+\d+\.\d+%')
+
+        for line in lines:
+            line = line.strip()
+            if match := pending_tasks_pattern.match(line):
+                tasks[(match.group("ks"), match.group("cf"))] += int(match.group("tasks"))
+            elif match := active_tasks_pattern.match(line):
+                tasks[(match.group("ks"), match.group("cf"))] += 1
 
         if keyspace is None and column_family is None:
-            matched = re.search(head_pattern, head)
-            if not matched:
-                raise RuntimeError(f"Cannot find 'pending tasks' in nodetool output.\nOutput: {output}")
-            return int(matched.group('tasks'))
+            return sum(tasks.values())
+        elif keyspace is not None and column_family is None:
+            return sum(num_tasks for (ks, _), num_tasks in tasks.items() if ks == keyspace)
+        elif keyspace is not None and column_family is not None:
+            return tasks.get((keyspace, column_family), 0)
 
-        # if keyspace or column_family is specified, check active tasks
-        # of the specified ks.cf instead
-        def matches(expected, actual):
-            if expected is None:
-                return True
-            return expected == actual
-
-        total = 0
-        for line in tail:
-            m = tail_pattern.search(line)
-            if not m:
-                break
-            ks, cf, num = m.groups()
-            if matches(keyspace, ks) and matches(column_family, cf):
-                total += int(num)
-        return total
-
-    def wait_for_compactions(self,
-                             keyspace=None,
-                             column_family=None,
-                             idle_timeout=300):
+    def wait_for_compactions(self, keyspace: str=None, column_family: str=None, idle_timeout=300):
         """Wait for all compactions to finish on this node.
 
-        :param keyspace: only wait for the compactions performed for specified
-            keyspace. if not specified, all keyspaces are waited
-        :param column_family: only wait for the compactions performed for
-            specified column_family. if not specified, all keyspaces are waited
+        :param keyspace: only wait for the compactions performed for specified keyspace.
+            If not specified, all keyspaces are waited.
+            Must be provided if collumn_family is provided.
+        :param column_family: only wait for the compactions performed for specified column_family.
+            If not specified, all keyspaces are waited.
         :param idle_timeout: the time in seconds to wait for progress.
-            Total time to wait is undeteremined, as long as we observe forward
-            progress.
+            Total time to wait is undeteremined, as long as we observe forward progress.
         """
+        if column_family is not None and keyspace is None:
+            raise ValueError("Cannot search only by column family, need also keyspace")
         pending_tasks = -1
         last_change = None
         while not last_change or time.time() - last_change < idle_timeout:
             output, err = self.nodetool("compactionstats", capture_output=True)
-            n = self._parse_pending_tasks(output, keyspace, column_family)
+            n = self._parse_tasks(output, keyspace, column_family)
             # no active tasks, good!
             if n == 0:
                 return

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -19,8 +19,6 @@ from ccmlib.utils.version import ComparableScyllaVersion
 
 SNITCH = 'org.apache.cassandra.locator.GossipingPropertyFileSnitch'
 
-yaml = YAML()
-yaml.default_flow_style = False
 
 class ScyllaCluster(Cluster):
 
@@ -246,7 +244,7 @@ class ScyllaCluster(Cluster):
         filename = os.path.join(self.get_path(), 'cluster.conf')
 
         with open(filename, 'r') as f:
-            data = yaml.load(f)
+            data = YAML().load(f)
 
         if self.is_scylla_reloc():
             data['scylla_version'] = self.scylla_version
@@ -255,7 +253,7 @@ class ScyllaCluster(Cluster):
             data['scylla_manager_install_path'] = self._scylla_manager.install_dir
 
         with open(filename, 'w') as f:
-            yaml.dump(data, f)
+            YAML().dump(data, f)
 
     def sctool(self, cmd):
         if self._scylla_manager == None:
@@ -315,7 +313,7 @@ class ScyllaManager:
     def _update_config(self, install_dir=None):
         conf_file = os.path.join(self._get_path(), common.SCYLLAMANAGER_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = YAML().load(f)
         data['http'] = self._get_api_address()
         if not 'database' in data:
             data['database'] = {}
@@ -351,7 +349,7 @@ class ScyllaManager:
         for key in keys_to_delete:
             del data[key]
         with open(conf_file, 'w') as f:
-            yaml.dump(data, f)
+            YAML().dump(data, f)
 
     def _copy_config_files(self, install_dir):
         conf_dir = os.path.join(install_dir, 'etc')

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -4,10 +4,10 @@ import shutil
 import time
 import subprocess
 import signal
-import yaml
 import uuid
 import datetime
 
+from ruamel.yaml import YAML
 
 from ccmlib import common
 from ccmlib.cluster import Cluster
@@ -19,6 +19,8 @@ from ccmlib.utils.version import ComparableScyllaVersion
 
 SNITCH = 'org.apache.cassandra.locator.GossipingPropertyFileSnitch'
 
+yaml = YAML()
+yaml.default_flow_style = False
 
 class ScyllaCluster(Cluster):
 
@@ -244,7 +246,7 @@ class ScyllaCluster(Cluster):
         filename = os.path.join(self.get_path(), 'cluster.conf')
 
         with open(filename, 'r') as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f)
 
         if self.is_scylla_reloc():
             data['scylla_version'] = self.scylla_version
@@ -253,7 +255,7 @@ class ScyllaCluster(Cluster):
             data['scylla_manager_install_path'] = self._scylla_manager.install_dir
 
         with open(filename, 'w') as f:
-            yaml.safe_dump(data, f)
+            yaml.dump(data, f)
 
     def sctool(self, cmd):
         if self._scylla_manager == None:
@@ -313,7 +315,7 @@ class ScyllaManager:
     def _update_config(self, install_dir=None):
         conf_file = os.path.join(self._get_path(), common.SCYLLAMANAGER_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f)
         data['http'] = self._get_api_address()
         if not 'database' in data:
             data['database'] = {}
@@ -349,7 +351,7 @@ class ScyllaManager:
         for key in keys_to_delete:
             del data[key]
         with open(conf_file, 'w') as f:
-            yaml.safe_dump(data, f, default_flow_style=False)
+            yaml.dump(data, f)
 
     def _copy_config_files(self, install_dir):
         conf_dir = os.path.join(install_dir, 'etc')

--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -12,8 +12,6 @@ from ccmlib import common
 
 LOGGER = logging.getLogger("ccm")
 
-yaml = YAML()
-yaml.default_flow_style = False
 
 class ScyllaDockerCluster(ScyllaCluster):
     def __init__(self, *args, **kwargs):
@@ -139,7 +137,7 @@ class ScyllaDockerNode(ScyllaNode):
                     copyfile(src=file_path, dst=os.path.join(keys_dir_path, file_name))
                     server_encryption_options[key] = os.path.join(self.base_data_path, "keys", file_name)
         with open(conf_file, 'w') as f:
-            yaml.safe_dump(data, f, default_flow_style=False)
+            YAML().dump(data, f)
 
     def create_docker(self, args):
         # TODO: handle smp correctly via the correct param/api (or only via commandline params)

--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -3,7 +3,7 @@ from shutil import copyfile
 from subprocess import check_call, run, PIPE
 import logging
 
-import yaml
+from ruamel.yaml import YAML
 
 from ccmlib.scylla_cluster import ScyllaCluster
 from ccmlib.scylla_node import ScyllaNode
@@ -12,6 +12,8 @@ from ccmlib import common
 
 LOGGER = logging.getLogger("ccm")
 
+yaml = YAML()
+yaml.default_flow_style = False
 
 class ScyllaDockerCluster(ScyllaCluster):
     def __init__(self, *args, **kwargs):

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional
 import logging
 
 import psutil
-import yaml
+from ruamel.yaml import YAML
 import glob
 import re
 import requests
@@ -34,6 +34,9 @@ from ccmlib.node import TimeoutError
 from ccmlib.scylla_repository import setup, get_scylla_version
 from ccmlib.utils.version import parse_version
 
+
+yaml = YAML()
+yaml.default_flow_style = False
 
 class ScyllaNode(Node):
 
@@ -372,18 +375,18 @@ class ScyllaNode(Node):
         data['s3'] = {"endpoint": os.getenv("AWS_S3_ENDPOINT"), "provider": "Minio"}
 
         with open(conf_file, 'w') as f:
-            yaml.safe_dump(data, f, default_flow_style=False)
+            yaml.dump(data, f)
         return conf_file
 
     def update_agent_config(self, new_settings, restart_agent_after_change=True):
         conf_file = os.path.join(self.get_conf_dir(), 'scylla-manager-agent.yaml')
         with open(conf_file, 'r') as f:
-            current_config = yaml.safe_load(f)
+            current_config = yaml.load(f)
 
         current_config.update(new_settings)
 
         with open(conf_file, 'w') as f:
-            yaml.safe_dump(current_config, f, default_flow_style=False)
+            yaml.dump(current_config, f)
 
         if restart_agent_after_change:
             self.restart_scylla_manager_agent(gently=True, recreate_config=False)
@@ -416,7 +419,7 @@ class ScyllaNode(Node):
             pid_file.write(str(self._process_agent.pid))
 
         with open(config_file, 'r') as f:
-            current_config = yaml.safe_load(f)
+            current_config = yaml.load(f)
             # Extracting currently configured port
             current_listening_port = int(current_config['https'].split(":")[1])
 
@@ -569,7 +572,7 @@ class ScyllaNode(Node):
         # from config file scylla#59
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f)
         jvm_args = jvm_args + ['--api-address', data['api_address']]
 
         args = [launch_bin, '--options-file', options_file, '--log-to-stdout', '1']
@@ -1144,7 +1147,7 @@ class ScyllaNode(Node):
         # TODO: copied from node.py
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f)
 
         data['cluster_name'] = self.cluster.name
         data['auto_bootstrap'] = self.auto_bootstrap
@@ -1205,7 +1208,7 @@ class ScyllaNode(Node):
         if 'alternator_port' in data or 'alternator_https_port' in data:
             data['alternator_address'] = data['listen_address']
         with open(conf_file, 'w') as f:
-            yaml.safe_dump(data, f, default_flow_style=False)
+            yaml.dump(data, f)
 
         # TODO: - for now create a cassandra conf file leaving only
         # cassandra config items - this should be removed once tools are
@@ -1315,7 +1318,7 @@ class ScyllaNode(Node):
                 cassandra_data[key] = data[key]
 
         with open(cassandra_conf_file, 'w') as f:
-            yaml.safe_dump(cassandra_data, f, default_flow_style=False)
+            yaml.dump(cassandra_data, f)
 
     def __update_yaml_dse(self):
         raise NotImplementedError('ScyllaNode.__update_yaml_dse')

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -19,10 +19,10 @@ from typing import Any, Dict, List, Optional
 import logging
 
 import psutil
-from ruamel.yaml import YAML
 import glob
 import re
 import requests
+from ruamel.yaml import YAML
 
 from ccmlib.common import CASSANDRA_SH, BIN_DIR, wait_for, copy_directory, print_if_standalone
 
@@ -34,9 +34,6 @@ from ccmlib.node import TimeoutError
 from ccmlib.scylla_repository import setup, get_scylla_version
 from ccmlib.utils.version import parse_version
 
-
-yaml = YAML(typ='safe')
-yaml.default_flow_style = False
 
 class ScyllaNode(Node):
 
@@ -117,7 +114,7 @@ class ScyllaNode(Node):
 
     @property
     def scylla_yaml(self) -> Dict[str, Any]:
-        return yaml.load(Path(self.get_conf_dir()) / common.SCYLLA_CONF)
+        return YAML().load(Path(self.get_conf_dir()) / common.SCYLLA_CONF)
 
     @property
     def api_port(self) -> int:
@@ -383,18 +380,18 @@ class ScyllaNode(Node):
         data['s3'] = {"endpoint": os.getenv("AWS_S3_ENDPOINT"), "provider": "Minio"}
 
         with open(conf_file, 'w') as f:
-            yaml.dump(data, f)
+            YAML().dump(data, f)
         return conf_file
 
     def update_agent_config(self, new_settings, restart_agent_after_change=True):
         conf_file = os.path.join(self.get_conf_dir(), 'scylla-manager-agent.yaml')
         with open(conf_file, 'r') as f:
-            current_config = yaml.load(f)
+            current_config = YAML().load(f)
 
         current_config.update(new_settings)
 
         with open(conf_file, 'w') as f:
-            yaml.dump(current_config, f)
+            YAML().dump(current_config, f)
 
         if restart_agent_after_change:
             self.restart_scylla_manager_agent(gently=True, recreate_config=False)
@@ -427,7 +424,7 @@ class ScyllaNode(Node):
             pid_file.write(str(self._process_agent.pid))
 
         with open(config_file, 'r') as f:
-            current_config = yaml.load(f)
+            current_config = YAML().load(f)
             # Extracting currently configured port
             current_listening_port = int(current_config['https'].split(":")[1])
 
@@ -580,7 +577,7 @@ class ScyllaNode(Node):
         # from config file scylla#59
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = YAML().load(f)
         jvm_args = jvm_args + ['--api-address', data['api_address']]
 
         args = [launch_bin, '--options-file', options_file, '--log-to-stdout', '1']
@@ -1155,7 +1152,7 @@ class ScyllaNode(Node):
         # TODO: copied from node.py
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
         with open(conf_file, 'r') as f:
-            data = yaml.load(f)
+            data = YAML().load(f)
 
         data['cluster_name'] = self.cluster.name
         data['auto_bootstrap'] = self.auto_bootstrap
@@ -1216,7 +1213,7 @@ class ScyllaNode(Node):
         if 'alternator_port' in data or 'alternator_https_port' in data:
             data['alternator_address'] = data['listen_address']
         with open(conf_file, 'w') as f:
-            yaml.dump(data, f)
+            YAML().dump(data, f)
 
         # TODO: - for now create a cassandra conf file leaving only
         # cassandra config items - this should be removed once tools are
@@ -1326,7 +1323,7 @@ class ScyllaNode(Node):
                 cassandra_data[key] = data[key]
 
         with open(cassandra_conf_file, 'w') as f:
-            yaml.dump(cassandra_data, f)
+            YAML().dump(cassandra_data, f)
 
     def __update_yaml_dse(self):
         raise NotImplementedError('ScyllaNode.__update_yaml_dse')

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import NamedTuple, Literal
 
 import requests
-import yaml
+from ruamel.yaml import YAML
 import packaging.version
 
 from ccmlib.common import (
@@ -22,6 +22,10 @@ from ccmlib.common import (
     DOWNLOAD_IN_PROGRESS_FILE, print_if_standalone, LockFile, get_installed_scylla_package_hash)
 from ccmlib.utils.download import download_file, download_version_from_s3, get_url_hash, save_source_file
 from ccmlib.utils.version import parse_version
+
+yaml = YAML()
+yaml.default_flow_style = False
+
 
 GIT_REPO = "http://github.com/scylladb/scylla.git"
 
@@ -193,7 +197,7 @@ def read_build_manifest(url):
     #
     #    url-id: 2022-08-29T08:05:34Z
     #    docker-image-name: scylla-nightly:5.2.0-dev-0.20220829.67c91e8bcd61
-    return yaml.safe_load(res.content)
+    return yaml.load(res.content)
 
 
 def normalize_scylla_version(version):

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -14,17 +14,14 @@ from pathlib import Path
 from typing import NamedTuple, Literal
 
 import requests
-from ruamel.yaml import YAML
 import packaging.version
+from ruamel.yaml import YAML
 
 from ccmlib.common import (
     ArgumentError, CCMError, get_default_path, rmdirs, validate_install_dir, get_scylla_version, aws_bucket_ls,
     DOWNLOAD_IN_PROGRESS_FILE, print_if_standalone, LockFile, get_installed_scylla_package_hash)
 from ccmlib.utils.download import download_file, download_version_from_s3, get_url_hash, save_source_file
 from ccmlib.utils.version import parse_version
-
-yaml = YAML()
-yaml.default_flow_style = False
 
 
 GIT_REPO = "http://github.com/scylladb/scylla.git"
@@ -197,7 +194,7 @@ def read_build_manifest(url):
     #
     #    url-id: 2022-08-29T08:05:34Z
     #    docker-image-name: scylla-nightly:5.2.0-dev-0.20220829.67c91e8bcd61
-    return yaml.load(res.content)
+    return YAML().load(res.content)
 
 
 def normalize_scylla_version(version):

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -648,7 +648,7 @@ def get_manager_release_url(version: str = '', architecture: Architecture = None
 
     url = f"{BASE_DOWNLOADS_URL}/downloads/scylla-manager/relocatable"
 
-    version_regex = re.compile('scylla-manager_(.*)-0')
+    version_regex = re.compile('scylla-manager_(.*)_')
     # filter only specific architecture and version
     all_packages = reversed(aws_bucket_ls(url))
     latest_package = next(filter(lambda tar: architecture in tar and version in version_regex.search(tar)[0], all_packages))

--- a/ccmlib/utils/sni_proxy.py
+++ b/ccmlib/utils/sni_proxy.py
@@ -11,12 +11,15 @@ from textwrap import dedent
 from shutil import copytree
 from dataclasses import dataclass
 
-import yaml
+from ruamel.yaml import YAML
 
 from ccmlib.utils.ssl_utils import generate_ssl_stores
 from ccmlib.common import wait_for
 
 logger = logging.getLogger(__name__)
+
+yaml = YAML()
+yaml.default_flow_style = False
 
 @contextmanager
 def file_or_memory(path=None, data=None):
@@ -64,7 +67,7 @@ def create_cloud_config(ssl_dir, port, address, nodes_info, username='cassandra'
                   currentContext='default')
 
     with open(os.path.join(ssl_dir, 'config_data.yaml'), 'w') as config_file:
-        config_file.write(yaml.safe_dump(config, sort_keys=False))
+        yaml.dump(config, config_file)
 
     datacenters = {}
 
@@ -83,7 +86,7 @@ def create_cloud_config(ssl_dir, port, address, nodes_info, username='cassandra'
                   currentContext='default')
 
     with open(os.path.join(ssl_dir, 'config_path.yaml'), 'w') as config_file:
-        config_file.write(yaml.safe_dump(config, sort_keys=False))
+        yaml.dump(config, config_file)
 
     return os.path.join(ssl_dir, 'config_data.yaml'), os.path.join(ssl_dir, 'config_path.yaml')
 

--- a/ccmlib/utils/sni_proxy.py
+++ b/ccmlib/utils/sni_proxy.py
@@ -18,8 +18,6 @@ from ccmlib.common import wait_for
 
 logger = logging.getLogger(__name__)
 
-yaml = YAML()
-yaml.default_flow_style = False
 
 @contextmanager
 def file_or_memory(path=None, data=None):
@@ -67,7 +65,7 @@ def create_cloud_config(ssl_dir, port, address, nodes_info, username='cassandra'
                   currentContext='default')
 
     with open(os.path.join(ssl_dir, 'config_data.yaml'), 'w') as config_file:
-        yaml.dump(config, config_file)
+        YAML().dump(config, config_file)
 
     datacenters = {}
 
@@ -86,7 +84,7 @@ def create_cloud_config(ssl_dir, port, address, nodes_info, username='cassandra'
                   currentContext='default')
 
     with open(os.path.join(ssl_dir, 'config_path.yaml'), 'w') as config_file:
-        yaml.dump(config, config_file)
+        YAML().dump(config, config_file)
 
     return os.path.join(ssl_dir, 'config_data.yaml'), os.path.join(ssl_dir, 'config_path.yaml')
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688221086,
-        "narHash": "sha256-cdW6qUL71cNWhHCpMPOJjlw0wzSRP0pVlRn2vqX/VVg=",
+        "lastModified": 1703134684,
+        "narHash": "sha256-SQmng1EnBFLzS7WSRyPM9HgmZP2kLJcPAz+Ug/nug6o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd99c2b3c9f160cd004318e0697f90bbd5960825",
+        "rev": "d6863cbcbbb80e71cecfc03356db1cda38919523",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@ localhost.";
 
   outputs = { self, nixpkgs, flake-utils }:
     let
-      prepare_python_requirements = python: python.withPackages (ps: with ps; [ pytest pyyaml psutil six requests packaging boto3 tqdm setuptools ]);
+      prepare_python_requirements = python: python.withPackages (ps: with ps; [ pytest ruamel-yaml psutil six requests packaging boto3 tqdm setuptools ]);
       make_ccm_package = {python, jdk, pkgs}: python.pkgs.buildPythonApplication {
         pname = "scylla_ccm";
         version = "0.1";

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='https://github.com/pcmanus/ccm',
     packages=['ccmlib', 'ccmlib.cmds', 'ccmlib.utils'],
     scripts=[ccmscript],
-    install_requires=['pyYaml', 'psutil', 'requests', 'packaging', 'boto3', 'tqdm', 'urllib3<2'],
+    install_requires=['ruamel.yaml', 'psutil', 'requests', 'packaging', 'boto3', 'tqdm', 'urllib3<2'],
     tests_require=['pytest'],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,7 +2,7 @@ import tempfile
 import os
 
 import pytest
-import yaml
+import ruamel
 
 from ccmlib.common import scylla_extract_mode, LockFile, parse_settings
 
@@ -94,5 +94,5 @@ def test_parse_settings():
     assert res == {'experimental_features': ['udf', 'tablets']}
 
     # would break if incorrect yaml format is passed in the value
-    with pytest.raises(yaml.parser.ParserError):
+    with pytest.raises(ruamel.yaml.parser.ParserError):
         parse_settings(["experimental_features:['udf',\"tablets\""])

--- a/tests/test_internal_functions.py
+++ b/tests/test_internal_functions.py
@@ -85,11 +85,8 @@ test_cases = [
     }
 ]
 
-@pytest.mark.parametrize("test_case", test_cases, ids=[tc["id"] for tc in test_cases])
-def test_parse_tasks(test_case):
-    output = test_case["output"]
-    expected_tasks = test_case["expected_tasks"]
-
+@pytest.mark.parametrize("output, expected_tasks", [pytest.param(t["output"], t["expected_tasks"], id=t["id"]) for t in test_cases])
+def test_parse_tasks(output, expected_tasks):
     for ks, cf, expected in expected_tasks:
         n = Node._parse_tasks(output, ks, cf)
         assert n == expected, f"Expected {expected} tasks for {ks}.{cf}, but got {n}"

--- a/tests/test_internal_functions.py
+++ b/tests/test_internal_functions.py
@@ -1,40 +1,95 @@
+import pytest
+import textwrap
 from ccmlib.node import Node
 
-def test_parse_pending_tasks():
-    def verify_result(output, keyspace, column_family, expected):
-        n = Node._parse_pending_tasks(output, keyspace, column_family)
-        assert n == expected
+# Define the test cases and corresponding outputs
+test_cases = [
+    {
+        "id": "only_pending",
+        "output": textwrap.dedent("""\
+            pending tasks: 6
+            - system_schema.tables: 1
+            - system_schema.columns: 2
+            - keyspace1.standard1: 3\
+        """),
+        "expected_tasks": [
+            ("system_schema", "tables", 1),
+            ("system_schema", "columns", 2),
+            ("system_schema", None, 3),
+            ("keyspace1", "standard1", 3),
+            ("keyspace1", None, 3),
+            (None, None, 6),
+            ("keyspace1x", None, 0),
+            ("keyspace1x", "table1x", 0),
+        ]
+    },
+    {
+        "id": "pending_and_in_progress",
+        "output": textwrap.dedent("""\
+            pending tasks: 6
+            - system_schema.tables: 1
+            - system_schema.columns: 2
+            - keyspace1.standard1: 3
 
-    def verify_cases(output, cases):
-        for ks, cf, expected in cases:
-            verify_result(output, ks, cf, expected)
+            id                                   compaction type keyspace      table   completed total unit progress
+            8e1f2d90-a252-11ee-a7f4-1bf9ae4e6ffd COMPACTION      system_schema columns 1         640   keys 0.16%
+            Active compaction remaining time :        n/a\
+        """),
+        "expected_tasks": [
+            ("system_schema", "tables", 1),
+            ("system_schema", "columns", 3),
+            ("system_schema", None, 4),
+            ("keyspace1", "standard1", 3),
+            ("keyspace1", None, 3),
+            (None, None, 7),
+            ("keyspace1x", None, 0),
+            ("keyspace1x", "table1x", 0),
+        ]
+    },
+    {
+        "id": "only_in_progress",
+        "output": textwrap.dedent("""\
+            pending tasks: 0
 
-    for output in [
-        '''
-        pending tasks: 6
-        - system_schema.tables: 1
-        - system_schema.columns: 2
-        - keyspace1.standard1: 3
-        ''',
-        '''
-        pending tasks: 6
-        - system_schema.tables: 1
-        - system_schema.columns: 2
-        - keyspace1.standard1: 3
+            id                                   compaction type keyspace      table   completed total unit progress
+            8e1f2d90-a252-11ee-a7f4-1bf9ae4e6ffd COMPACTION      system_schema columns 1         640   keys 0.16%
+            Active compaction remaining time :        n/a\
+        """),
+        "expected_tasks": [
+            ("system_schema", "tables", 0),
+            ("system_schema", "columns", 1),
+            ("system_schema", None, 1),
+            ("keyspace1", "standard1", 0),
+            ("keyspace1", None, 0),
+            (None, None, 1),
+            ("keyspace1x", None, 0),
+            ("keyspace1x", "table1x", 0),
+        ]
+    },
+    {
+        "id": "no_tasks",
+        "output": textwrap.dedent("""\
+            pending tasks: 0
+            \
+        """),
+        "expected_tasks": [
+            ("system_schema", "tables", 0),
+            ("system_schema", "columns", 0),
+            ("system_schema", None, 0),
+            ("keyspace1", "standard1", 0),
+            ("keyspace1", None, 0),
+            (None, None, 0),
+            ("keyspace1x", None, 0),
+            ("keyspace1x", "table1x", 0),
+        ]
+    }
+]
 
-        id                                   compaction type keyspace      table   completed total unit progress
-        8e1f2d90-a252-11ee-a7f4-1bf9ae4e6ffd COMPACTION      system_schema columns 1         640   
-    keys 0.16%
-        Active compaction remaining time :        n/a
-        '''
-    ]:
-        verify_cases(output, [
-                        ('system_schema', 'tables', 1),
-                        ('system_schema', 'columns', 2),
-                        ('system_schema', None, 3),
-                        ('keyspace1', 'standard1', 3),
-                        ('keyspace1', None, 3),
-                        (None, None, 6),
-                        ('keyspace1x', None, 0),
-                        ('keyspace1x', 'table1x', 0),
-                     ])
+@pytest.mark.parametrize("test_case", test_cases, ids=[tc["id"] for tc in test_cases])
+def test_parse_tasks(test_case):
+    output = test_case["output"]
+    expected_tasks = test_case["expected_tasks"]
+
+    for ks, cf, expected in expected_tasks:
+        n = Node._parse_tasks(output, ks, cf)
+        assert n == expected, f"Expected {expected} tasks for {ks}.{cf}, but got {n}"


### PR DESCRIPTION
Currently, when using `wait_for_compactions`, only pending tasks are considered. If there are active compaction tasks, the function will return anyway and this causes flakyness in tests, as sometimes the active task finishes before the next operation, but sometimes it doesn't.

- Rename Node._parse_pending_tasks to Node._parse_tasks
- Count all tasks, pending and active
- Allow searching for tasks based on only keyspace
- Update and refactor test to allow more varied cases

closes: #610 
refs: https://github.com/scylladb/scylla-dtest/issues/4702


