### PR TITLE
scylla_node: ignore scylla-tools config files if scylla-tools is missing

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -978,7 +978,12 @@ class ScyllaNode(Node):
 
     def copy_config_files(self):
         Node.copy_config_files(self)
-        conf_pattern = os.path.join(self.get_tools_java_dir(), 'conf', "jvm*.options")
+        tools_java_dir = self.get_tools_java_dir()
+        if not tools_java_dir:
+            # in newer scylla, the java-base scylla-tools is dropped, so this
+            # directory cannot be found in that case.
+            return
+        conf_pattern = os.path.join(tools_java_dir, 'conf', "jvm*.options")
         for filename in glob.glob(conf_pattern):
             if os.path.isfile(filename):
                 shutil.copy(filename, self.get_conf_dir())


### PR DESCRIPTION
before this change, in `ScyllaNode.copy_config_files()`we always try to copy the jvm settings packaged by scylla-tools-java package, but we plan to drop this package. but if that package is installed, `get_tools_java_dir()` would return `None`. this breaks `copy_config_files()`, like:

```
21:44:43  Traceback (most recent call last):
21:44:43    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/bin/ccm", line 74, in <module>
21:44:43      cmd.run()
21:44:43    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/cmds/cluster_cmds.py", line 269, in run
21:44:43      cluster.populate(self.nodes, self.options.debug, use_vnodes=self.options.vnodes, ipprefix=self.options.ipprefix, ipformat=self.options.ipformat)
21:44:43    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/cluster.py", line 327, in populate
21:44:43      self.new_node(i, debug=debug, initial_token=tk, data_center=dc, rack=rack)
21:44:43    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/cluster.py", line 334, in new_node
21:44:43      node = self.create_node(name=f'node{i}',
21:44:43             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21:44:43    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/scylla_cluster.py", line 93, in create_node
21:44:43      return ScyllaNode(name, self, auto_bootstrap, None,
21:44:43             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21:44:43    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/scylla_node.py", line 51, in __init__
21:44:43      super().__init__(name, cluster, auto_bootstrap,
21:44:43    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/node.py", line 126, in __init__
21:44:43      self.import_config_files()
21:44:43    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/scylla_node.py", line 975, in import_config_files
21:44:43      self.copy_config_files()
21:44:43    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/scylla_node.py", line 981, in copy_config_files
21:44:43      conf_pattern = os.path.join(self.get_tools_java_dir(), 'conf', "jvm*.options")
21:44:43                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
21:44:43    File "<frozen posixpath>", line 76, in join
21:44:43  TypeError: expected str, bytes or os.PathLike object, not NoneType
```

in this change, we enumerate the directory only if it exists.

Fixes #617
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>