### PR TITLE
scylla_node: ignore scylla-tools config files if scylla-tools is missing

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -201,9 +201,11 @@ class ScyllaNode(Node):
     def get_tool(self, toolname):
         candidate_dirs = [
             os.path.join(self.node_install_dir, 'share', 'cassandra', BIN_DIR),
-            os.path.join(self.get_tools_java_dir(), BIN_DIR),
             os.path.join(self.get_cqlsh_dir(), BIN_DIR),
         ]
+        tools_java_dir = self.get_tools_java_dir()
+        if tools_java_dir:
+            candidate_dirs.append(os.path.join(tools_java_dir, BIN_DIR))
         for candidate_dir in candidate_dirs:
             candidate = shutil.which(toolname, path=candidate_dir)
             if candidate:
@@ -217,7 +219,10 @@ class ScyllaNode(Node):
         update_conf = not self.__conf_updated
         if update_conf:
             self.__conf_updated = True
-        return common.make_cassandra_env(self.get_install_cassandra_root(),
+        install_cassandra_root = self.get_install_cassandra_root()
+        if not install_cassandra_root:
+            return {}
+        return common.make_cassandra_env(install_cassandra_root,
                                          self.get_node_cassandra_root(), update_conf=update_conf)
 
     def _get_environ(self, extra_env = None, /, **kwargs):
@@ -1050,7 +1055,10 @@ class ScyllaNode(Node):
         return os.path.join(self.node_install_dir, 'tools', 'cqlsh')
 
     def __copy_logback_files(self):
-        shutil.copy(os.path.join(self.get_tools_java_dir(), 'conf', 'logback-tools.xml'),
+        tools_java_dir = self.get_tools_java_dir()
+        if not tools_java_dir:
+            return
+        shutil.copy(os.path.join(tools_java_dir, 'conf', 'logback-tools.xml'),
                     os.path.join(self.get_conf_dir(), 'logback-tools.xml'))
 
     def import_dse_config_files(self):
@@ -1096,22 +1104,24 @@ class ScyllaNode(Node):
 
     def import_bin_files(self, exist_ok=False, replace=False):
         # selectively copying files to reduce risk of using unintended items
-        self._copy_binaries(files=[CASSANDRA_SH, 'nodetool'],
-                            src_path=os.path.join(self.get_tools_java_dir(), BIN_DIR),
-                            dest_path=os.path.join(self.get_path(), 'resources', 'cassandra', BIN_DIR),
-                            exist_ok=exist_ok,
-                            replace=replace
-                            )
+        tools_java_dir = self.get_tools_java_dir()
+        if tools_java_dir:
+            self._copy_binaries(files=[CASSANDRA_SH, 'nodetool'],
+                                src_path=os.path.join(tools_java_dir, BIN_DIR),
+                                dest_path=os.path.join(self.get_path(), 'resources', 'cassandra', BIN_DIR),
+                                exist_ok=exist_ok,
+                                replace=replace
+                                )
 
-        # selectively copying files to reduce risk of using unintended items
-        # Copy sstable tools
-        self._copy_binaries(files=['sstabledump', 'sstablelevelreset', 'sstablemetadata',
-                                   'sstablerepairedset', 'sstablesplit'],
-                            src_path=os.path.join(self.get_tools_java_dir(), 'tools', BIN_DIR),
-                            dest_path=os.path.join(self.get_path(), 'resources', 'cassandra', 'tools', BIN_DIR),
-                            exist_ok=exist_ok,
-                            replace=replace
-                            )
+            # selectively copying files to reduce risk of using unintended items
+            # Copy sstable tools
+            self._copy_binaries(files=['sstabledump', 'sstablelevelreset', 'sstablemetadata',
+                                       'sstablerepairedset', 'sstablesplit'],
+                                src_path=os.path.join(tools_java_dir, 'tools', BIN_DIR),
+                                dest_path=os.path.join(self.get_path(), 'resources', 'cassandra', 'tools', BIN_DIR),
+                                exist_ok=exist_ok,
+                                replace=replace
+                                )
 
         # TODO: - currently no scripts only executable - copying exec
         if self.is_scylla_reloc():


### PR DESCRIPTION
this change is created in the same spirit of 3a886404, so that we don't assume the existence of scylla-tools. otherwise we could have following failure:

```
07:51:05  Traceback (most recent call last):
07:51:05    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/bin/ccm", line 74, in <module>
07:51:05      cmd.run()
07:51:05    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/cmds/cluster_cmds.py", line 269, in run
07:51:05      cluster.populate(self.nodes, self.options.debug, use_vnodes=self.options.vnodes, ipprefix=self.options.ipprefix, ipformat=self.options.ipformat)
07:51:05    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/cluster.py", line 330, in populate
07:51:05      self.new_node(i, debug=debug, initial_token=tk, data_center=dc, rack=rack)
07:51:05    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/cluster.py", line 337, in new_node
07:51:05      node = self.create_node(name=f'node{i}',
07:51:05             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
07:51:05    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/scylla_cluster.py", line 94, in create_node
07:51:05      return ScyllaNode(name, self, auto_bootstrap, None,
07:51:05             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
07:51:05    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/scylla_node.py", line 53, in __init__
07:51:05      super().__init__(name, cluster, auto_bootstrap,
07:51:05    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/node.py", line 128, in __init__
07:51:05      self.import_config_files()
07:51:05    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/scylla_node.py", line 979, in import_config_files
07:51:05      self.__copy_logback_files()
07:51:05    File "/jenkins/workspace/scylla-master/gating-dtest-release/scylla/.local/lib/python3.12/site-packages/ccmlib/scylla_node.py", line 1003, in __copy_logback_files
07:51:05      shutil.copy(os.path.join(self.get_tools_java_dir(), 'conf', 'logback-tools.xml'),
```

Fixes #617
Signed-off-by: Kefu Chai <tchaikov@gmail.com>