### PR TITLE
fix(manager): extend HTTP server waiting timeout for >=6 nodes cluster

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -431,9 +431,11 @@ class ScyllaManager:
             pid_file.write(str(self._process_scylla_manager.pid))
 
         api_interface = common.parse_interface(self._get_api_address(), 5080)
-        if not common.check_socket_listening(api_interface, timeout=180):
-            raise Exception("scylla manager interface %s:%s is not listening after 180 seconds, scylla manager may have failed to start."
-                          % (api_interface[0], api_interface[1]))
+        # With more nodes in cluster it may take longer for the manager to start HTTP server
+        timeout = 180 if len(self.scylla_cluster.nodes) < 6 else 240
+        if not common.check_socket_listening(api_interface, timeout=timeout):
+            raise Exception("scylla manager interface %s:%s is not listening after %s seconds, scylla manager may have failed to start."
+                          % (api_interface[0], api_interface[1], timeout))
 
         return self._process_scylla_manager
 


### PR DESCRIPTION
With more nodes in cluster, it may take longer for the manager to start. Existing tests confirm this observation - for 6-nodes cluster, from time to time, Manager fails to start HTTP server in 3 minutes.

Manager log for one of the tests with multiDC cluster (6 nodes in total):
```
{"L":"INFO","T":"2024-11-04T12:44:22.691+0100","M":"Scylla Manager Server","version":"3.4.0-dev-0.20241009.4c1407684-SNAPSHOT","pid":508024,"_trace_id":"QtH-7NtpRhqE5gdiayQw4w"}**
{"L":"INFO","T":"2024-11-04T12:44:24.426+0100","M":"Using config","c":{"HTTP":"127.0.28.1:5080","HTTPS":"","TLSVersion":"TLSv1.2","TLSCertFile":"","TLSKeyFile":"","TLSCAFile":"","Prometheus":"127.0.28.1:56091","Debug":"127.0.28.1:5611","ClientCacheTimeout":900000000000,"Logger":{"mode":"stderr","level":"info","sampling":null,"encoding":"json","Development":false},"Database":{"Hosts":["127.0.28.1"],"SSL":false,"User":"","Password":"","LocalDC":"","Keyspace":"scylla_manager","MigrateTimeout":30000000000,"MigrateMaxWaitSchemaAgreement":300000000000,"ReplicationFactor":3,"Timeout":1000000000,"TokenAware":true,"Port":9042,"InitAddr":""},"SSL":{"CertFile":"","Validate":true,"UserCertFile":"","UserKeyFile":""},"Healthcheck":{"NodeInfoTTL":300000000000,"MaxTimeout":1000000000,"Probes":0,"RelativeTimeout":0},"ConfigCache":{"UpdateFrequency":300000000000},"Backup":{"DiskSpaceFreeMinPercent":10,"LongPollingTimeoutSeconds":10,"AgeMax":86400000000000},"Restore":{"DiskSpaceFreeMinPercent":10,"LongPollingTimeoutSeconds":10},"Repair":{"PollInterval":50000000,"LongPollingTimeoutSeconds":10,"AgeMax":0,"GracefulStopTimeout":30000000000,"ForceRepairType":"auto","Murmur3PartitionerIgnoreMSBBits":12},"TimeoutConfig":{"Timeout":30000000000,"MaxTimeout":3600000000000,"ListTimeout":300000000000,"Backoff":{"WaitMin":1000000000,"WaitMax":30000000000,"MaxRetries":9,"Multiplier":2,"Jitter":0.2},"InteractiveBackoff":{"WaitMin":1000000000,"WaitMax":0,"MaxRetries":1,"Multiplier":0,"Jitter":0},"PoolDecayDuration":1800000000000}},"config_files":["/home/mikita/.dtest/dtest-999pkndr/test/scylla-manager/scylla-manager.yaml"],"_trace_id":"QtH-7NtpRhqE5gdiayQw4w"}
{"L":"INFO","T":"2024-11-04T12:44:24.426+0100","M":"Checking database connectivity...","_trace_id":"QtH-7NtpRhqE5gdiayQw4w"}
{"L":"INFO","T":"2024-11-04T12:44:24.441+0100","M":"Creating keyspace","keyspace":"scylla_manager","_trace_id":"QtH-7NtpRhqE5gdiayQw4w"}
...
...
{"L":"INFO","T":"2024-11-04T12:47:29.264+0100","M":"Starting HTTP server","address":"127.0.28.1:5080","_trace_id":"QtH-7NtpRhqE5gdiayQw4w"}
```
It takes 187 seconds to start HTTP server.

Example of failed runs:
https://jenkins.scylladb.com/job/manager-master/job/dtest-enterprise-no-tablets/43/
https://jenkins.scylladb.com/job/manager-master/job/dtest-enterprise-no-tablets/52

This PR addresses this setting the timeout to 240 seconds for 6 or more nodes cluster.

**Testing:**
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/dtest-enterprise-no-tablets/6/