### PR TITLE
scylla_repository.py: attend to python 3.12 related warnings

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -43,11 +43,11 @@ jobs:
 
     - name: Test with pytest (python 3.9)
       run: |
-        nix develop --command python3.9 -m pytest ./tests -x
+        nix develop --command python3.9 -m pytest ./tests -x -W ignore
 
     - name: Test with pytest (python 3.11)
       run: |
-        nix develop --command python3.11 -m pytest ./tests -x
+        nix develop --command python3.11 -m pytest ./tests -x -W ignore
 
     - name: Copy logs/results
       if: contains(github.event.pull_request.labels.*.name, 'PR-upload-log')

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -519,7 +519,11 @@ def download_version(version, url=None, verbose=False, target_dir=None, unified=
         if verbose:
             print(f"Extracting {target} ({url}, {target_dir}) as version {version} ...")
         tar = tarfile.open(target)
-        tar.extractall(path=target_dir)
+        if sys.version_info >= (3, 12):
+            kwargs = {'path': target_dir, 'filter': 'data'}
+        else:
+            kwargs = {'path': target_dir}
+        tar.extractall(**kwargs)
         tar.close()
 
         # if relocatable package format >= 2, need to extract files under subdir

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,7 @@ markers =
   reloc: Run tests with relocatable packages
   cassandra: Run tests with cassandra binaries
   repo_tests: Run test for testing get versions
+
+filterwarnings =
+    error
+    ignore::ResourceWarning


### PR DESCRIPTION
taking care about warnings around unsafe usage of the built-in tarlib