### PR TITLE
Update and fix workflows and tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -15,9 +15,9 @@ jobs:
     name: CCM Integration tests
     uses: ./.github/workflows/integration-tests.yml
     with:
-      reloc_version: "2023-04-13T13:31:00Z"
+      reloc_version: "2025-01-19T09:39:05Z"
   ci-with-nix:
     name: CCM Integration tests (using Nix)
     uses: ./.github/workflows/nix.yml
     with:
-      reloc_version: "2023-04-13T13:31:00Z"
+      reloc_version: "2025-01-19T09:39:05Z"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '8'
+        java-version: '11'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,12 +37,8 @@ jobs:
         java-version: '11'
 
     - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install python2
-        
+      run: |       
         pip install -U pip setuptools
-
         pip install .
 
         if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,12 +18,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-test.txt') }}
@@ -31,7 +31,7 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Setup java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '8'
@@ -49,7 +49,7 @@ jobs:
 
     - name: Cache binary versions
       id: cache-versions
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.ccm/repository

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: cachix/install-nix-action@v20
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Cache binary versions
       id: cache-versions
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.ccm/repository

--- a/flake.nix
+++ b/flake.nix
@@ -38,20 +38,20 @@ localhost.";
       in
       rec {
         packages = rec {
-          scylla_ccm = python: make_ccm_package { inherit python pkgs ; jdk = pkgs.jdk8; };
+          scylla_ccm = python: make_ccm_package { inherit python pkgs ; jdk = pkgs.jdk11; };
           default = scylla_ccm pkgs.python311;
         };
         devShell =
           pkgs.mkShell {
-            buildInputs = [ pkgs.poetry pkgs.glibcLocales (prepare_python_requirements pkgs.python39) (prepare_python_requirements pkgs.python311) pkgs.jdk8];
+            buildInputs = [ pkgs.poetry pkgs.glibcLocales (prepare_python_requirements pkgs.python39) (prepare_python_requirements pkgs.python311) pkgs.jdk11];
             shellHook = ''
-              set JAVA_HOME ${pkgs.jdk8}
+              set JAVA_HOME ${pkgs.jdk11}
             '';
         };
       }
     ) // rec {
       overlays.default = final: prev: {
-        scylla_ccm = python: make_ccm_package { inherit python; jdk = final.jdk8; pkgs = final; };
+        scylla_ccm = python: make_ccm_package { inherit python; jdk = final.jdk11; pkgs = final; };
       };
     };
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,6 @@ TEST_ID = os.environ.get("CCM_TEST_ID", None)
 SCYLLA_DOCKER_IMAGE = os.environ.get(
     "SCYLLA_DOCKER_IMAGE", "scylladb/scylla-nightly:666.development-0.20201015.8068272b466")
 SCYLLA_RELOCATABLE_VERSION = os.environ.get(
-    "SCYLLA_VERSION", "unstable/master:2023-04-13T13:31:00Z")
+    "SCYLLA_VERSION", "release:2024.2.3")
 
 # Feb/8 comment to refresh the action cache

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,6 @@ RESULTS_DIR = "test_results"
 TEST_ID = os.environ.get("CCM_TEST_ID", None)
 SCYLLA_DOCKER_IMAGE = os.environ.get(
     "SCYLLA_DOCKER_IMAGE", "scylladb/scylla-nightly:666.development-0.20201015.8068272b466")
-SCYLLA_RELOCATABLE_VERSION = os.environ.get(
-    "SCYLLA_VERSION", "release:2024.2.3")
+SCYLLA_RELOCATABLE_VERSION = "release:2024.2.3"
 
 # Feb/8 comment to refresh the action cache

--- a/tests/test_scylla_relocatable_cluster.py
+++ b/tests/test_scylla_relocatable_cluster.py
@@ -11,11 +11,11 @@ from ccmlib.node import Node, ToolError
 class TestScyllaRelocatableCluster:
     def test_get_scylla_full_version(self, relocatable_cluster):
         install_dir = relocatable_cluster.get_install_dir()
-        assert get_scylla_full_version(install_dir) == '5.3.0-dev-0.20230413.37fe820e0a35'
+        assert get_scylla_full_version(install_dir) == '2024.2.3-0.20250108.931ce203dcf5'
 
     def test_get_scylla_version(self, relocatable_cluster):
         install_dir = relocatable_cluster.get_install_dir()
-        assert get_scylla_version(install_dir) == '5.3.0-dev'
+        assert get_scylla_version(install_dir) == '2024.2.3'
 
     def test_nodetool_timeout(self, relocatable_cluster):
         node1: Node = relocatable_cluster.nodelist()[0]
@@ -71,6 +71,6 @@ class TestScyllaRelocatableCluster:
         install_dir = relocatable_cluster.get_install_dir()
         scylla_yaml = get_default_scylla_yaml(install_dir)
         assert scylla_yaml.get('native_transport_port') == 9042
-        assert scylla_yaml.get('consistent_cluster_management') == True
+        assert scylla_yaml.get('num_tokens') == 256
         assert scylla_yaml.get('listen_address') == 'localhost'
 

--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -185,18 +185,18 @@ class TestReinstallPackages:
         - run setup again. It expected that the package will be downloaded again. The download time should be not short.
         Actually time without download should be less than 3 ms, and with download about 9 ms. I put here more than 20
         """
-        cdir, version = scylla_setup(version="unstable/master:2023-04-03T22:38:18Z", verbose=True, skip_downloads=False)
-        assert '2023-04-03T22_38_18Z' in cdir
-        assert version == '5.3.0-dev'
+        cdir, version = scylla_setup(version="unstable/master:2025-01-19T09:39:05Z", verbose=True, skip_downloads=False)
+        assert '2025-01-19T09_39_05Z' in cdir
+        assert version == '2025.1.0-dev'
 
         self.corrupt_hash_value(Path(cdir) / CORE_PACKAGE_DIR_NAME / SOURCE_FILE_NAME)
 
         start_time = time.time()
-        cdir, version = scylla_setup(version="unstable/master:2023-04-03T22:38:18Z", verbose=True, skip_downloads=False)
+        cdir, version = scylla_setup(version="unstable/master:2025-01-19T09:39:05Z", verbose=True, skip_downloads=False)
         end_time = time.time()
         assert (end_time - start_time) > 5
-        assert '2023-04-03T22_38_18Z' in cdir
-        assert version == '5.3.0-dev'
+        assert '2025-01-19T09_39_05Z' in cdir
+        assert version == '2025.1.0-dev'
 
 
 @pytest.mark.parametrize('architecture', argvalues=typing.get_args(Architecture))

--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -107,8 +107,8 @@ class TestScyllaRepositoryRelease:
         ("release:2021.1", '2021.1'),
         ("release:2021.1.10", '2021.1.10'),
         ("release:2024.2~rc0", '2024.2.0~rc0'),
-        ("release:2024.2", '2024.2.0'),
-        ("release:2024.2:debug", '2024.2.0'),
+        ("release:2024.2", '2024.2'),
+        ("release:2024.2:debug", '2024.2'),
     ])
     def test_setup_release_enterprise(self, version, expected_cdir):
         cdir, packages = scylla_setup(version=version, verbose=True, skip_downloads=True)


### PR DESCRIPTION
* Updates Scylla version to `2025-01-19T09:39:05Z`
  * Affects both workflows and tests 
  * Update `test_get_default_scylla_yaml` to fetch different variable, `consistent_cluster_management` is no longer in default config
* Update to Java 11
   * `2025-01-19T09:39:05Z` does not work with Java 8
* Fix `test_config` getting SCYLLA_VERSION from env
   * Tests have hardcoded version
* Fix version specification for 2024.2
   * We cannot expect `2024.2.0` as newer releases are already out