### PR TITLE
Fix fetching scylla 2025.x relocatables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ ccm.egg-info/
 .coverage
 tests/test_results
 .direnv/
+.vscode/
 
 .envrc
 ccmlib/tests/

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -274,7 +274,8 @@ def setup(version, verbose=True, skip_downloads=False):
         s3_version = type_n_version[1]
 
         if type_n_version[0] == 'release':
-            scylla_product = 'scylla-enterprise' if parse_version(extract_major_version(s3_version)) > parse_version("2018.1") else 'scylla'
+            parsed_major = parse_version(extract_major_version(s3_version))
+            scylla_product = 'scylla-enterprise' if parsed_major > parse_version("2018.1") and parsed_major < parse_version("2025.1") else 'scylla'
             major_version = extract_major_version(s3_version)
 
             s3_url = get_relocatable_s3_url('', major_version, RELEASE_RELOCATABLE_URLS_BASE)


### PR DESCRIPTION
Fixes: https://github.com/scylladb/scylla-ccm/issues/638

The problem is well described in the linked issue. TLDR, it looks like we dropped "scylla-enterprise-" prefix for 2025.x relocatables. New prefix is "scylla-" (as for previous open source versions).