### PR TITLE
.github/workflows/ci-tests.yml: start CI on PRs to master

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -8,6 +8,7 @@ on:
 
   pull_request:
     branches:
+     - master
      - next*
 
 jobs:


### PR DESCRIPTION
no that we moved to not working with next in CCM,
PRs to master should start running the CI