### PR TITLE
Prepare for ScyllaDB move to host ids instead of ips

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -522,7 +522,7 @@ class Node(object):
         the log is watched from the beginning.
         """
         tofind = nodes if isinstance(nodes, list) else [nodes]
-        tofind = [f"{node.address()}.* now (dead|DOWN)" for node in tofind]
+        tofind = [f"({node.address()}|{node.hostid()}).* now (dead|DOWN)" for node in tofind]
         self.watch_log_for(tofind, from_mark=from_mark, timeout=timeout, filename=filename)
 
     def watch_log_for_alive(self, nodes, from_mark=None, timeout=120, filename='system.log'):
@@ -531,7 +531,7 @@ class Node(object):
         nodes are marked UP. This method works similarly to watch_log_for_death.
         """
         tofind = nodes if isinstance(nodes, list) else [nodes]
-        tofind = [f"{node.address()}.* now UP" for node in tofind]
+        tofind = [f"({node.address()}|{node.hostid()}).* now UP" for node in tofind]
         self.watch_log_for(tofind, from_mark=from_mark, timeout=timeout, filename=filename)
 
     def wait_for_binary_interface(self, **kwargs):

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -1449,6 +1449,10 @@ class ScyllaNode(Node):
     def hostid(self, timeout=60, force_refresh=False):
         if self.node_hostid and not force_refresh:
             return self.node_hostid
+        m = self.grep_log("init - Setting local host id to (.+?)$")
+        if m:
+            self.node_hostid = m[-1][1].group(1)
+            return self.node_hostid
         try:
             node_address = self.address()
             url = f"http://{node_address}:{self.api_port}/storage_service/hostid/local"


### PR DESCRIPTION
Moving ScyllaDB to host ids changes some output to use ids instead of ips. Prepare for that by checking for both.

### Testing
- [x] 🟡 https://jenkins.scylladb.com/job/scylla-staging/job/dtest-pytest-gating/894/ (Gossip - OSS)
- [x] :green_circle: https://jenkins.scylladb.com/job/scylla-staging/job/dtest-pytest-gating/895/ (Raft - OSS)
- [x] :green_circle: https://jenkins.scylladb.com/job/scylla-staging/job/dtest-pytest-gating/896/ (Tablets - OSS)