### PR TITLE
fix(scyll_node.start): remove unsupported parameter for old version

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -744,6 +744,10 @@ class ScyllaNode(Node):
         if max_networking_io_control_blocks_supported and '--max-networking-io-control-blocks' not in args:
             args += ['--max-networking-io-control-blocks', '1000']
 
+        if '--rf-rack-valid-keyspaces' in args and parse_version(current_node_version) <= parse_version('2025.1'):
+            arg_index = args.index('--rf-rack-valid-keyspaces')
+            del args[arg_index+1],args[arg_index]
+        
         ext_env = {}
         scylla_ext_env = os.getenv('SCYLLA_EXT_ENV', "").strip()
         if scylla_ext_env:


### PR DESCRIPTION
New parameter --rf-rack-valid-keyspaces cause scylla start failing for node with scylla versions 6.2, 2024.x. This cause upgrade tests from these version to failed at the begining.
The parameter --rf-rack-valid-keyspaces mostly passed via env parameter SCYLLA_EXT_OPTS for dtest runs.
Remove such parameter from the env variable before node start if scylla version on node is <2025.1