### PR TITLE
Store node rack in node.conf

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1585,6 +1585,8 @@ class Node(object):
             values['remote_debug_port'] = self.remote_debug_port
         if self.data_center:
             values['data_center'] = self.data_center
+        if self.rack:
+            values['rack'] = self.rack
         if self.workload is not None:
             values['workload'] = self.workload
         with open(filename, 'w') as f:


### PR DESCRIPTION
Rack is not preserved in node.conf.
As result, next call of `__update_topology_files` overwrites rack information and all nodes dropped to rack1 