### PR TITLE
Do not read host-id on watch_log_for_alive

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1439,15 +1439,18 @@ class Node(object):
 
     def hostid(self, timeout=60, force_refresh=False):
         if not hasattr(self, 'node_hostid') or force_refresh:
-            info = self.nodetool('info', capture_output=True, timeout=timeout)[0]
-            id_lines = [s for s in info.split('\n')
-                        if s.startswith('ID')]
-            if not len(id_lines) == 1:
-                msg = ('Expected output from `nodetool info` to contain exactly 1 '
-                    'line starting with "ID". Found:\n') + info
-                raise RuntimeError(msg)
-            id_line = id_lines[0].replace(":", "").split()
-            self.node_hostid = id_line[1]
+            try:
+                info = self.nodetool('info', capture_output=True, timeout=timeout)[0]
+                id_lines = [s for s in info.split('\n')
+                            if s.startswith('ID')]
+                if not len(id_lines) == 1:
+                    msg = ('Expected output from `nodetool info` to contain exactly 1 '
+                        'line starting with "ID". Found:\n') + info
+                    raise RuntimeError(msg)
+                id_line = id_lines[0].replace(":", "").split()
+                self.node_hostid = id_line[1]
+            except Exception as e:
+                self.error(f"Failed to get hostid via nodetool: {e}")
         return self.node_hostid
 
     def get_datacenter_name(self):

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -523,7 +523,7 @@ class Node(object):
         the log is watched from the beginning.
         """
         tofind = nodes if isinstance(nodes, list) else [nodes]
-        tofind = [f"({node.address()}|{node.hostid()}).* now (dead|DOWN)" for node in tofind]
+        tofind = [f"{node.identifier_pattern}.* now (dead|DOWN)" for node in tofind]
         self.watch_log_for(tofind, from_mark=from_mark, timeout=timeout, filename=filename)
 
     def watch_log_for_alive(self, nodes, from_mark=None, timeout=120, filename='system.log'):
@@ -532,7 +532,7 @@ class Node(object):
         nodes are marked UP. This method works similarly to watch_log_for_death.
         """
         tofind = nodes if isinstance(nodes, list) else [nodes]
-        tofind = [f"({node.address()}|{node.hostid()}).* now UP" for node in tofind]
+        tofind = [f"{node.identifier_pattern}.* now UP" for node in tofind]
         self.watch_log_for(tofind, from_mark=from_mark, timeout=timeout, filename=filename)
 
     def wait_for_binary_interface(self, **kwargs):
@@ -1458,6 +1458,17 @@ class Node(object):
         except Exception as e:
             self.error(f"Failed to get hostid via nodetool: {e}")
         return self.node_hostid
+
+    @property
+    def identifier_pattern(self):
+        # Returns a pattern that identifies the node.
+        # When hostid is available, the pattern is `(ip-address|host-id)`.
+        # Otherwise, it returns just an ip address.
+        host_id = self.hostid()
+        ip_address = self.address().replace('.', '\\.')
+        if host_id:
+            return f'({ip_address}|{host_id})'
+        return ip_address
 
     def get_datacenter_name(self):
         info = self.nodetool('info', capture_output=True)[0]


### PR DESCRIPTION
`host-id` requires API to be up and running, which is not always the case right away.
Ignoring it there will help to reduce chance of having host-id reading error while node is starting.

Fixes: https://github.com/scylladb/scylla-ccm/issues/646
