### PR TITLE
Preserve ipprefix in cluster.conf

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -265,13 +265,11 @@ class Cluster(object):
     #     For example, {'DC1': {'RC1-1': 2, 'RC1-2': 2, 'RC1-3': 2}, 'DC2': {'RC2-1': 3, 'RC2-2': 3}}
     def populate(self, nodes, debug=False, tokens=None, use_vnodes=False, ipprefix=None, ipformat=None):
         if ipprefix:
-            self.ipprefix = ipprefix
-        elif not self.ipprefix:
-            self.ipprefix = '127.0.0.'
+            self.set_ipprefix(ipprefix)
         if ipformat:
             self.ipformat = ipformat
         elif not self.ipformat:
-            self.ipformat = self.ipprefix + "%d"
+            self.ipformat = self.get_ipprefix() + "%d"
         self.use_vnodes = use_vnodes
         topology = OrderedDict()
         if isinstance(nodes, int):
@@ -350,7 +348,7 @@ class Cluster(object):
         return Node(name, self, auto_bootstrap, None, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface)
 
     def get_ipprefix(self):
-        return self.ipprefix if self.ipprefix is not None else '127.0.0.'
+        return self.ipprefix or '127.0.0.'
 
     def get_ipformat(self):
         return self.ipformat if self.ipformat is not None else f'{self.get_ipprefix()}%d'

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -49,6 +49,8 @@ class ClusterFactory():
                 cluster.__log_level = data['log_level']
             if 'use_vnodes' in data:
                 cluster.use_vnodes = data['use_vnodes']
+            if 'ipprefix' in data:
+                cluster.ipprefix = data['ipprefix']
             if 'sni_proxy_docker_ids' in data and data['sni_proxy_docker_ids']:
                 cluster.sni_proxy_docker_ids = data['sni_proxy_docker_ids']
             if 'sni_proxy_listen_port' in data and data['sni_proxy_listen_port']:

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -614,7 +614,7 @@ class ScyllaNode(Node):
                     except Exception as msg:
                         print_if_standalone(f"{msg}. Looking for offending processes...", debug_callback=logging.error)
                         for proc in psutil.process_iter():
-                            if any(self.cluster.ipprefix in cmd for cmd in proc.cmdline()):
+                            if any(self.cluster.get_ipprefix() in cmd for cmd in proc.cmdline()):
                                 print_if_standalone(f"name={proc.name()} pid={proc.pid} cmdline={proc.cmdline()}",  debug_callback=logging.error)
                         raise msg
 


### PR DESCRIPTION
Two changes:
1. Handle empty `ipprefix` properly
2. Load `ipprefix` from cluster config

Problem:
ip_prefix is not preserved between ccm calls.
It breaks following case:
```
ccm remove test-ccm-bug                                            
ccm create --scylla -n 1:0 -i 127.0.1. -v release:6.2 -b test-ccm-bug
ccm start --wait-other-notice --wait-for-binary-proto --jvm_arg=--skip-wait-for-gossip-to-settle=0
ccm add -b -j 7200 -r 2200 --scylla node2
ccm node2 start --wait-other-notice --wait-for-binary-proto --jvm_arg=--skip-wait-for-gossip-to-settle=0
```

```
➜  ~ cat ~/.ccm/test-ccm-bug/node*/conf/scylla.yaml| grep 'listen_address:'
listen_address: 127.0.1.1
listen_address: 127.0.0.2
```

While it should be:
```
➜  ~ cat ~/.ccm/test-ccm-bug/node*/conf/scylla.yaml| grep 'listen_address:'
listen_address: 127.0.1.1
listen_address: 127.0.1.2
```

