### PR TITLE
Fix Nix build failing because lack of setup.py

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -49,6 +49,10 @@ jobs:
       run: |
         nix develop --command python3.11 -m pytest ./tests -x -W ignore
 
+    - name: Verify that installation with Nix works
+      run: |
+        nix profile install .
+
     - name: Copy logs/results
       if: contains(github.event.pull_request.labels.*.name, 'PR-upload-log')
       uses: actions/upload-artifact@v4

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@ localhost.";
       make_ccm_package = {python, jdk, pkgs}: python.pkgs.buildPythonApplication {
         pname = "scylla_ccm";
         version = "0.1";
-
+        format = "pyproject";
         src = ./. ;
 
         checkInputs = with python.pkgs; [ pytestCheckHook ];


### PR DESCRIPTION
When trying to update my CCM installation I noticed that it no longer builds :(
This is because buildPythonApplication looks for setup.py by default, whichwas replaced by pyproject.toml.
The fix is simple according to NixOs wiki: https://nixos.wiki/wiki/Packaging/Python#Fix_Missing_setup.py , we just need to add `format = "pyproject";`

I also added a step to CI that verifies if installation works, to prevent such issues in the future.