### PR TITLE
node_cmds.py: Remove cli command from the list

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -33,7 +33,6 @@ def node_cmds():
         "updateconf",
         "updatelog4j",
         "stress",
-        "cli",
         "cqlsh",
         "scrub",
         "verify",

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,15 @@
+def test_help_works(ccm_reloc_cluster):
+    proc = ccm_reloc_cluster.run_command([ccm_reloc_cluster.ccm_bin])
+    (stdout, _) = proc.communicate()
+    # No error messages
+    assert 'Internal error' not in stdout
+    assert 'unknown command' not in stdout
+    # CCM always returns 1 when printing help
+    assert proc.returncode == 1
+    # Check some of the commends that should be present in the help
+    # Pause and resume are chosen, because they are low on the list.
+    # If some command above them failed, they would not be shown.
+    assert 'pause' in stdout
+    assert 'resume' in stdout
+    assert 'nodetool' in stdout
+    assert 'show' in stdout


### PR DESCRIPTION
This command implementation was previosuly removed in commit [06a2adf303c292239b9a84b6a674824e0204797c](https://github.com/scylladb/scylla-ccm/commit/06a2adf303c292239b9a84b6a674824e0204797c)
Unfortunately this commit did not remove the command from the command list, which caused "--help" to error out, and not print some other commands.

I also added a test to prevent such errors in the future.