### PR TITLE
scylla_cluster: run nodetool on a node

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -287,7 +287,7 @@ class ScyllaCluster(Cluster):
         """
         self.nodetool("repair")
 
-        stdout, _ = self.nodetool('help')
+        stdout, _ = self.nodes[0].nodetool('help')
         if "  cluster  " in stdout:
             for node in list(self.nodes.values()):
                 if node.is_running():


### PR DESCRIPTION
Currently, ScyllaCluster::repair checks whether the nodetool cluster repair operation is supported by nodetool using ScyllaCluster::nodetool. However the method does not return the nodetool output.

Use ScyllaNode::nodetool in ScyllaCluster::repair.