### PR TITLE
scylla_cluster: access a node through ScyllaCluster::nodelist

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -287,7 +287,7 @@ class ScyllaCluster(Cluster):
         """
         self.nodetool("repair")
 
-        stdout, _ = self.nodes[0].nodetool('help')
+        stdout, _ = self.nodelist()[0].nodetool('help')
         if "  cluster  " in stdout:
             for node in list(self.nodes.values()):
                 if node.is_running():


### PR DESCRIPTION
Currently, ScyllaCluster::repair accesses the first of nodes in a cluster
by calling nodes[0]. However nodes is a dict, keys of which aren't number.

Replace nodes with nodelist() that returns the list of nodes.