### PR TITLE
scylla_repository: cache setups

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -13,7 +13,7 @@ import tempfile
 import time
 from typing import List
 import urllib
-
+from functools import lru_cache
 
 from ccmlib.utils.version import ComparableCassandraVersion
 from ccmlib.common import (ArgumentError, CCMError, get_default_path,
@@ -26,7 +26,7 @@ ARCHIVE = "http://archive.apache.org/dist/cassandra"
 GIT_REPO = "http://git-wip-us.apache.org/repos/asf/cassandra.git"
 GITHUB_TAGS = "https://api.github.com/repos/apache/cassandra/git/refs/tags"
 
-
+@lru_cache(maxsize=None)
 def setup(version, verbose=False):
     binary = True
     fallback = True

--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -10,6 +10,7 @@ import urllib
 import logging
 import random
 import time
+from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple, Literal
 
@@ -222,6 +223,7 @@ def extract_major_version(version):
     return major_version
 
 
+@lru_cache(maxsize=None)
 def setup(version, verbose=True, skip_downloads=False):
     """
     :param version:
@@ -450,6 +452,7 @@ def download_packages(version_dir, packages, s3_url, version, verbose):
     return package_version, packages
 
 
+@lru_cache(maxsize=None)
 def setup_scylla_manager(scylla_manager_package=None, verbose=False):
 
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
  {name="ScyllaDB Contributors"}
 ]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "ruamel-yaml",
     "psutil",

--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -191,6 +191,8 @@ class TestReinstallPackages:
 
         self.corrupt_hash_value(Path(cdir) / CORE_PACKAGE_DIR_NAME / SOURCE_FILE_NAME)
 
+        scylla_setup.cache_clear()
+        
         start_time = time.time()
         cdir, version = scylla_setup(version="unstable/master:2025-01-19T09:39:05Z", verbose=True, skip_downloads=False)
         end_time = time.time()


### PR DESCRIPTION
so we won't hit s3 urls on each start of a test (cause of multiple calls to `scylla_repository.setup()`)

we gonna cache this call for the time of the test session

on a new test session, those would be called only once