### PR TITLE
Bring python 3.8 back

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.11", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
  {name="ScyllaDB Contributors"}
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 dependencies = [
     "ruamel-yaml",
     "psutil",


### PR DESCRIPTION
python-driver still supports 3.8, we can't test it without CCM support.