### PR TITLE
Remove pinning from urllib3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "packaging",
     "boto3",
     "tqdm",
-    "urllib3 < 2",
+    "urllib3",
 ]
 [project.urls]
 Repository = "https://github.com/scylladb/scylla-ccm"


### PR DESCRIPTION
this pinning isn't needed, and boto/botocore#2926 is fixed long long ago, removing the pinning

Fixes: scylladb/scylla-ccm#454