### PR TITLE
fix(manager): increase HTTP server waiting timeout

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -445,7 +445,7 @@ class ScyllaManager:
 
         api_interface = common.parse_interface(self._get_api_address(), 5080)
         # With more nodes in cluster it may take longer for the manager to start HTTP server
-        timeout = 180 if len(self.scylla_cluster.nodes) < 6 else 240
+        timeout = 300
         if not common.check_socket_listening(api_interface, timeout=timeout):
             raise Exception("scylla manager interface %s:%s is not listening after %s seconds, scylla manager may have failed to start."
                           % (api_interface[0], api_interface[1], timeout))


### PR DESCRIPTION
With more nodes in cluster, it may take longer for the manager to start. 
The check for 6+ nodes was not enough, there are tests with 5 nodes where the server may fail to start in 3 minutes.
Extend the timeout to 5 minutes should cover most cases of slow start and only leave actual issue to throw an exception here.

Example failure with 5 nodes: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/cezar/job/dtest-byo/70/testReport/manager_restore_tests/TestScyllaMgmtRestore/FullDtest___full_split001___test_restore_different_size_cluster_rclone_5_3_/
Example failure with 4 nodes: https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/cezar/job/dtest-byo/75/testReport/manager_backup_tests/TestScyllaMgmtBackup/FullDtest___full_split001___test_shutting_down_node_during_backup_native_/