### PR TITLE
[Backport 2025.1] Modify Node::repair method for nodetool cluster repair

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -287,7 +287,7 @@ class ScyllaCluster(Cluster):
         """
         self.nodetool("repair")
 
-        stdout, _ = self.nodetool('help')
+        stdout, _ = self.nodes[0].nodetool('help')
         if "  cluster  " in stdout:
             for node in list(self.nodes.values()):
                 if node.is_running():

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -281,6 +281,19 @@ class ScyllaCluster(Cluster):
 
         self._update_config(install_dir=self.nodelist()[0].node_install_dir)
 
+    def repair(self):
+        """
+        Repairs the whole cluster, both vnode (with nodetool repair) and tablet (with nodetool cluster repair) keyspaces
+        """
+        self.nodetool("repair")
+
+        stdout, _ = self.nodetool('help')
+        if "  cluster  " in stdout:
+            for node in list(self.nodes.values()):
+                if node.is_running():
+                    node.nodetool("cluster repair")
+                    break
+
 
 class ScyllaManager:
     def __init__(self, scylla_cluster, install_dir=None):

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -287,7 +287,7 @@ class ScyllaCluster(Cluster):
         """
         self.nodetool("repair")
 
-        stdout, _ = self.nodes[0].nodetool('help')
+        stdout, _ = self.nodelist()[0].nodetool('help')
         if "  cluster  " in stdout:
             for node in list(self.nodes.values()):
                 if node.is_running():


### PR DESCRIPTION
Since https://github.com/scylladb/scylladb/pull/22905 nodetool repair
should repair only vnode keyspaces. To repair tablet keyspaces, you need
to use nodetool cluster repair.
    
Add ScyllaNode::repair that uses the appropriate nodetool command
to repair specified tables. ScyllaNode::repair method gets repair
parameters as arguments.
