### PR TITLE
fix(scylla_cluster): improve version str extraction for Manager

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -312,7 +312,9 @@ class ScyllaManager:
     @property
     def version(self):
         stdout, _ = self.sctool(["version"], ignore_exit_status=True)
-        version_string = stdout[stdout.find(": ") + 2:].strip()  # Removing unnecessary information
+        # from stdout = 'Client version: 3.6.0-0.20250807.b9c9d5d94\nServer version: 3.6.0-0.20250807.b9c9d5d94'
+        # to version_string = '3.6.0-0.20250807.b9c9d5d94'
+        version_string = stdout.splitlines()[0][stdout.find(": ") + 2:].strip()
         version_code = ComparableScyllaVersion(version_string)
         return version_code
 


### PR DESCRIPTION
stdout returned by `sctool version` contains two versions and looks like `Client version: 3.6.0\nServer version: 3.6.0\n`. 

In Manager, server and client version are always the same, thus, stdout can be splitlined and the first part taken and passed to `ComparableScyllaVersion()`.

In current implemented the input like `3.6.0\nServer version: 3.6.0\n` is set, which `ComparableScyllaVersion()` somehow manages to handle but which is not technically correct.

**Testing:**
- [ ] 