### PR TITLE
Revert ".github/workflows: Migrate workflows to Blacksmith runners"

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/trigger_jenkins.yaml
+++ b/.github/workflows/trigger_jenkins.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   trigger-jenkins:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Determine Jenkins Job Name
         run: |


### PR DESCRIPTION
seems like it's not needed for OSS ones, reverting it for now

Reverts scylladb/scylla-ccm#680