### PR TITLE
Fix for Redundant assignment

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -318,7 +318,7 @@ def setup(version, verbose=True, skip_downloads=False):
                 elif scylla_noarch_package_path in aws_files:
                     scylla_package_path = scylla_noarch_package_path
                 elif scylla_package_path in aws_files:
-                    scylla_package_path = scylla_package_path
+                    pass
                 else:
                     raise RuntimeError("Can't find %s or %s in the %s",
                                        scylla_arch_package_path, scylla_noarch_package_path, s3_url)


### PR DESCRIPTION
The problem should be fixed by deleting the redundant line.  
- Remove line 321: `scylla_package_path = scylla_package_path`. This line presents no functional effect and its removal will not alter the existing logic or outputs of the current code.
- No other changes are necessary: imports, methods, or variable definitions remain unchanged.
- Only touch the direct region containing this line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._