### PR TITLE
.github/workflows/trigger_jenkins.yaml: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trigger_jenkins.yaml
+++ b/.github/workflows/trigger_jenkins.yaml
@@ -1,5 +1,8 @@
 name: Trigger next gating
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-ccm/security/code-scanning/1](https://github.com/scylladb/scylla-ccm/security/code-scanning/1)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions for the workflow or for the specific job. This constrains what the automatically provided token can do, instead of relying on repository/organization defaults that may be read‑write.

The best fix with no functional change is to add a `permissions:` block at the workflow root (top level, alongside `name` and `on`). The job only needs to read basic repository metadata used by the workflow expressions, so `contents: read` is sufficient in most cases. Adding it at the root will apply to all jobs in this workflow (currently just `trigger-jenkins`) and does not affect the use of Jenkins or Slack secrets, since those rely on `secrets.*`, not `GITHUB_TOKEN`. Concretely, in `.github/workflows/trigger_jenkins.yaml` add:

```yaml
permissions:
  contents: read
```

between the `name:` and `on:` keys. No new imports or methods are required, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
