### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,8 @@
 name: CCM Integration tests
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-ccm/security/code-scanning/3](https://github.com/scylladb/scylla-ccm/security/code-scanning/3)

In general, the fix is to explicitly define a `permissions` block so that the GITHUB_TOKEN has only the scopes required by this workflow. Since this workflow: (a) checks out code, (b) uses caches, (c) runs tests, and (d) uploads artifacts, it only needs read access to repository contents. It does not perform any writes to GitHub (no pushes, releases, or issue/pull-request mutations).

The best minimal fix without changing existing functionality is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`). This will apply to all jobs that don’t override it. For this workflow, `permissions: contents: read` is sufficient. No other permissions (like `pull-requests: write`) are required by the shown steps. Concretely, in `.github/workflows/integration-tests.yml`, between the existing `name: CCM Integration tests` and the `on:` block, add:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
