### PR TITLE
Add ability to provide custom java directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Requirements
     # ... add more as needed
     ```
 
+By default ccm will look for Java in `/usr/lib/jvm` directory. If you have a custom Java installation directory,
+you can provide `CUSTOM_JAVA_HOME` env variable. When this environment, ccm will assume Java binary is available
+under `$CUSTOM_JAVA_HOME/bin/java` path.  
+
 Known Issues
 ------------
 


### PR DESCRIPTION
Updates the code searching for the Java binary to allow providing a custom Java directory through the JAVA_HOME environment variable.

This will allow running ccm with custom Java installations, which may be necessary for macOS users or Linux users without sudo.

Fixes: #709 