### PR TITLE
Add hotfix relocatable URL support

### DIFF
--- a/ccmlib/scylla_repository.py
+++ b/ccmlib/scylla_repository.py
@@ -36,6 +36,7 @@ RELOCATABLE_URLS_BASE = ['https://s3.amazonaws.com/downloads.scylladb.com/unstab
                          'https://s3.amazonaws.com/downloads.scylladb.com/enterprise/relocatable/unstable/{0}/{1}']
 RELEASE_RELOCATABLE_URLS_BASE = ['https://s3.amazonaws.com/downloads.scylladb.com/downloads/scylla/relocatable/scylladb-{1}',
                                  'https://s3.amazonaws.com/downloads.scylladb.com/downloads/scylla-enterprise/relocatable/scylladb-{1}']
+HOTFIX_RELOCATABLE_URLS_BASE = ['https://s3.amazonaws.com/downloads.scylladb.com/hotfix/{0}/relocatable/{1}']
 
 
 def run(cmd, cwd=None):
@@ -282,8 +283,11 @@ def setup(version, verbose=True, skip_downloads=False):
 
             packages, type_n_version[1] = release_packages(s3_url=s3_url, version=s3_version, arch=scylla_arch, scylla_product=scylla_product + scylla_mode_suffix)
         else:
-            _, branch = type_n_version[0].split("/")
-            s3_url = get_relocatable_s3_url(branch, s3_version, RELOCATABLE_URLS_BASE)
+            type_prefix, branch = type_n_version[0].split("/", 1)
+            if type_prefix == 'hotfix':
+                s3_url = get_relocatable_s3_url(branch, s3_version, HOTFIX_RELOCATABLE_URLS_BASE)
+            else:
+                s3_url = get_relocatable_s3_url(branch, s3_version, RELOCATABLE_URLS_BASE)
 
             try:
                 build_manifest = read_build_manifest(s3_url)

--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -145,6 +145,17 @@ class TestScyllaRepositoryRelease:
         assert re.sub(":", "_", expected_cdir) in cdir
         assert packages.scylla_unified_package == f'http://s3.amazonaws.com/downloads.scylladb.com/unstable/scylla-enterprise/enterprise/relocatable/{expected_cdir}/scylla-enterprise{"-debug" if scylla_debug else ""}-unified-2023.3.0~dev-0.20230910.4629201aceec.x86_64.tar.gz'
 
+@pytest.mark.repo_tests
+class TestScyllaRepositoryHotfix:
+    @pytest.mark.parametrize(argnames=['version', 'expected_cdir'], argvalues=[
+        ("hotfix/privateLinkTest.v.0.0.12:2026-01-30T23:27:33Z", "hotfix/privateLinkTest.v.0.0.12/2026-01-30T23_27_33Z"),
+    ])
+    def test_setup_hotfix(self, version, expected_cdir):
+        cdir, packages = scylla_setup(version=version, verbose=True, skip_downloads=True)
+        assert expected_cdir in cdir
+        assert packages.scylla_unified_package or packages.scylla_package
+
+
 class TestReinstallPackages:
     @staticmethod
     def corrupt_hash_value(source_file):


### PR DESCRIPTION
## Summary
- Add support for `hotfix/<name>:<date>` version strings in `scylla_repository.setup()`
- Enables installation of hotfix relocatable packages hosted at `downloads.scylladb.com/hotfix/<name>/relocatable/<date>/`
- Uses `split("/", 1)` for safer parsing of both hotfix and existing unstable paths

## Test plan
- [x] All existing tests pass (43 passed, 1 skipped)
- [x] Run hotfix integration test: `pytest tests/test_scylla_repository.py -v -k TestScyllaRepositoryHotfix -m repo_tests`
- [x] Manual: `ccm create test --scylla --version hotfix/privateLinkTest.v.0.0.12:2026-01-30T23:27:33Z`