### PR TITLE
upgrade: merge new version's scylla.yaml defaults during node upgrade

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -2158,6 +2158,28 @@ class NodeUpgrader:
             self.node.node_install_dir = self.orig_install_dir
             raise NodeUpgradeError(f"Failed to import executables files. {exc}")
 
+    def _merge_new_config_defaults(self, install_dir):
+        """Replace the node's scylla.yaml with the target version's defaults,
+        then re-apply all cluster and node config overrides.
+
+        During upgrade, binaries are swapped but scylla.yaml is kept from the
+        old version. Config defaults that change between versions (e.g.,
+        sstable_format from 'me' to 'ms') would be missed, causing the upgraded
+        node to behave differently from a freshly-installed node.
+
+        This copies the new version's scylla.yaml (picking up all new defaults)
+        and then calls update_yaml() which re-applies cluster-level and
+        node-level config overrides on top, so any config explicitly set by
+        the test or CLI is preserved.
+        """
+        new_conf_file = os.path.join(install_dir, 'conf', common.SCYLLA_CONF)
+        if not os.path.exists(new_conf_file):
+            return
+
+        node_conf_file = os.path.join(self.node.get_conf_dir(), common.SCYLLA_CONF)
+        shutil.copy(new_conf_file, node_conf_file)
+        self.node.update_yaml()
+
     def _recover_system_tables(self):
         """
         Part of the rollback procedure is to restore system tables.
@@ -2220,6 +2242,7 @@ class NodeUpgrader:
             raise NodeUpgradeError(f"Node {self.node.name} failed to stop before upgrade")
 
         self._import_executables(cdir)
+        self._merge_new_config_defaults(cdir)
         self.node.clean_runtime_file()
 
         if recover_system_tables:


### PR DESCRIPTION
## Summary
- During rolling upgrades, CCM swaps the binary but keeps the old `scylla.yaml`. Config defaults that change between versions (e.g., `sstable_format` from `me` to `ms`) are missed, causing upgraded nodes to behave differently from freshly-installed nodes of the same version.
- After importing executables, copy the target version's `scylla.yaml` and re-apply all cluster/node config overrides via `update_yaml()`. This picks up all new defaults while preserving any config explicitly set by tests or CLI.

## Background
Discovered when `test_add_remove_node` in scylla-dtest failed: upgraded nodes reported `chosen_sstable_version='me'` while a freshly-added node reported `'ms'`. Root cause: the old yaml had `sstable_format: me` (compiled-in default), while the new version's `conf/scylla.yaml` ships with `sstable_format: ms`. The `get_preferred_sstable_version()` in Scylla requires **both** the cluster feature AND the config to be `ms` — so upgraded nodes couldn't produce `ms` sstables even though the binary supported it.

## Test plan
- [x] `test_add_remove_node` passes — all nodes now report `chosen_sstable_version=ms` after upgrade
- [x] Verify existing rolling upgrade tests (`test_rolling_upgrade`) still pass
- [x] Verify rollback tests still work (rollback calls `upgrade()` with `recover_system_tables=True`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)