### PR TITLE
ccmlib: add podman-based container support with topology-aware network simulation

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -799,3 +799,7 @@ class Cluster(object):
     @staticmethod
     def is_docker():
         return False
+
+    @staticmethod
+    def is_podman():
+        return False

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -29,6 +29,10 @@ class ClusterFactory():
             if install_dir is None and 'cassandra_dir' in data:
                 install_dir = data['cassandra_dir']
                 repository.validate(install_dir)
+            # IMPORTANT: the 'network_topology' check MUST come before the
+            # 'docker_image' check because podman clusters save BOTH keys
+            # in cluster.conf.  Reordering would silently load podman
+            # clusters as ScyllaDockerCluster.
             if 'network_topology' in data:
                 net_topo_data = data['network_topology']
                 cluster = ScyllaPodmanCluster(
@@ -37,6 +41,7 @@ class ClusterFactory():
                     inter_rack_delay_ms=net_topo_data.get('inter_rack_delay_ms', 1),
                     inter_dc_delay_ms=net_topo_data.get('inter_dc_delay_ms', 50),
                     packet_loss_percent=net_topo_data.get('packet_loss_percent', 0.0),
+                    pinning=data.get('pinning', False),
                     create_directory=False,
                 )
                 cluster.network_topology = PodmanNetworkTopology.from_dict(data['name'], net_topo_data)

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -8,6 +8,7 @@ from ccmlib.cluster import Cluster
 from ccmlib.dse_cluster import DseCluster
 from ccmlib.scylla_cluster import ScyllaCluster
 from ccmlib.scylla_docker_cluster import ScyllaDockerCluster
+from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster, PodmanNetworkTopology
 from ccmlib.node import Node
 
 
@@ -28,7 +29,18 @@ class ClusterFactory():
             if install_dir is None and 'cassandra_dir' in data:
                 install_dir = data['cassandra_dir']
                 repository.validate(install_dir)
-            if 'docker_image' in data and data['docker_image']:
+            if 'network_topology' in data:
+                net_topo_data = data['network_topology']
+                cluster = ScyllaPodmanCluster(
+                    path, data['name'],
+                    docker_image=data.get('docker_image'),
+                    inter_rack_delay_ms=net_topo_data.get('inter_rack_delay_ms', 1),
+                    inter_dc_delay_ms=net_topo_data.get('inter_dc_delay_ms', 50),
+                    packet_loss_percent=net_topo_data.get('packet_loss_percent', 0.0),
+                    create_directory=False,
+                )
+                cluster.network_topology = PodmanNetworkTopology.from_dict(data['name'], net_topo_data)
+            elif 'docker_image' in data and data['docker_image']:
                 cluster = ScyllaDockerCluster(path, data['name'], docker_image=data['docker_image'],
                                               container_runtime=data.get('container_runtime'),
                                               install_dir=install_dir, create_directory=False)

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -45,6 +45,9 @@ class ClusterFactory():
                     create_directory=False,
                 )
                 cluster.network_topology = PodmanNetworkTopology.from_dict(data['name'], net_topo_data)
+                # populate() is never called on load; wire the shared managers so
+                # loaded nodes get working log streaming and event monitoring.
+                cluster._ensure_managers()
             elif 'docker_image' in data and data['docker_image']:
                 cluster = ScyllaDockerCluster(path, data['name'], docker_image=data['docker_image'],
                                               container_runtime=data.get('container_runtime'),

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -10,6 +10,7 @@ from ccmlib.common import ArgumentError
 from ccmlib.dse_cluster import DseCluster
 from ccmlib.scylla_cluster import ScyllaCluster
 from ccmlib.scylla_docker_cluster import ScyllaDockerCluster, ScyllaDockerNode
+from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
 from ccmlib.scylla_node import ScyllaNode
 from ccmlib.dse_node import DseNode
 from ccmlib.node import Node, NodeError
@@ -141,6 +142,15 @@ class ClusterCreateCmd(Cmd):
         parser.add_option('--scylla-unified-package-uri', type="string", dest="scylla_unified_package_uri",
                           help="The path scylla relocatable unified package", default=None)
 
+        parser.add_option("--podman-image", type="string", dest="podman_image",
+                          help="Create a podman-based Scylla cluster using this container image", default=None)
+        parser.add_option("--inter-rack-delay", type="float", dest="inter_rack_delay",
+                          help="Simulated latency in ms between racks in the same DC (podman only)", default=1)
+        parser.add_option("--inter-dc-delay", type="float", dest="inter_dc_delay",
+                          help="Simulated latency in ms between DCs (podman only)", default=50)
+        parser.add_option("--packet-loss", type="float", dest="packet_loss",
+                          help="Simulated packet loss percentage for cross-DC traffic (podman only)", default=0.0)
+
         parser.epilog = """
         
         Examples of using relocatable packages:
@@ -175,10 +185,19 @@ class ClusterCreateCmd(Cmd):
         return parser
 
     def validate(self, parser, options, args):
-        # Docker-based clusters don't need install_dir
-        if options.scylla and not options.install_dir and not options.docker_image:
-            parser.error("must specify install_dir or --docker-image when using scylla")
+        # Docker/Podman-based clusters don't need install_dir
+        if options.scylla and not options.install_dir and not options.docker_image and not options.podman_image:
+            parser.error("must specify install_dir, --docker-image, or --podman-image when using scylla")
         Cmd.validate(self, parser, options, args, cluster_name=True)
+        if options.podman_image and options.docker_image:
+            parser.error("--podman-image and --docker-image cannot be used together")
+        if options.inter_rack_delay is not None and options.inter_rack_delay < 0:
+            parser.error("--inter-rack-delay must be non-negative")
+        if options.inter_dc_delay is not None and options.inter_dc_delay < 0:
+            parser.error("--inter-dc-delay must be non-negative")
+        if options.packet_loss is not None:
+            if options.packet_loss < 0 or options.packet_loss > 100:
+                parser.error("--packet-loss must be between 0 and 100")
         if options.ipprefix and options.ipformat:
             parser.print_help()
             parser.error(f"{parser.get_option('-i')} and {parser.get_option('-I')} may not be used together")
@@ -194,7 +213,7 @@ class ClusterCreateCmd(Cmd):
             parser.print_help()
             sys.exit(1)
 
-        if not options.version and not options.docker_image:
+        if not options.version and not options.docker_image and not options.podman_image:
             try:
                 common.validate_install_dir(options.install_dir)
             except ArgumentError:
@@ -222,7 +241,15 @@ class ClusterCreateCmd(Cmd):
     def run(self):
         try:
             if self.options.scylla:
-                if self.options.docker_image:
+                if self.options.podman_image:
+                    cluster = ScyllaPodmanCluster(
+                        self.path, self.name,
+                        podman_image=self.options.podman_image,
+                        inter_rack_delay_ms=self.options.inter_rack_delay,
+                        inter_dc_delay_ms=self.options.inter_dc_delay,
+                        packet_loss_percent=self.options.packet_loss,
+                    )
+                elif self.options.docker_image:
                     # Create Docker-based Scylla cluster
                     cluster = ScyllaDockerCluster(
                         self.path, 
@@ -373,6 +400,11 @@ class ClusterAddCmd(Cmd):
         self.initial_token = options.initial_token
 
     def run(self):
+        if self.cluster.is_podman():
+            print("ccm add is not supported for podman clusters yet; "
+                  "recreate the cluster with the full topology instead",
+                  file=sys.stderr)
+            sys.exit(1)
         try:
             if self.options.scylla_node:
                 if self.cluster.is_docker():

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -150,6 +150,8 @@ class ClusterCreateCmd(Cmd):
                           help="Simulated latency in ms between DCs (podman only)", default=50)
         parser.add_option("--packet-loss", type="float", dest="packet_loss",
                           help="Simulated packet loss percentage for cross-DC traffic (podman only)", default=0.0)
+        parser.add_option("--pinning", action="store_true", dest="pinning",
+                          help="Pin each podman node to dedicated CPU cores (podman only, requires enough host CPUs)", default=False)
 
         parser.epilog = """
         
@@ -188,9 +190,11 @@ class ClusterCreateCmd(Cmd):
         # Docker/Podman-based clusters don't need install_dir
         if options.scylla and not options.install_dir and not options.docker_image and not options.podman_image:
             parser.error("must specify install_dir, --docker-image, or --podman-image when using scylla")
-        Cmd.validate(self, parser, options, args, cluster_name=True)
+        if options.podman_image and not options.scylla:
+            parser.error("--podman-image requires --scylla")
         if options.podman_image and options.docker_image:
             parser.error("--podman-image and --docker-image cannot be used together")
+        Cmd.validate(self, parser, options, args, cluster_name=True)
         if options.inter_rack_delay is not None and options.inter_rack_delay < 0:
             parser.error("--inter-rack-delay must be non-negative")
         if options.inter_dc_delay is not None and options.inter_dc_delay < 0:
@@ -248,6 +252,7 @@ class ClusterCreateCmd(Cmd):
                         inter_rack_delay_ms=self.options.inter_rack_delay,
                         inter_dc_delay_ms=self.options.inter_dc_delay,
                         packet_loss_percent=self.options.packet_loss,
+                        pinning=self.options.pinning,
                     )
                 elif self.options.docker_image:
                     # Create Docker-based Scylla cluster
@@ -297,7 +302,7 @@ class ClusterCreateCmd(Cmd):
             common.switch_cluster(self.path, self.name)
             print(f'Current cluster is now: {self.name}')
 
-        if not (self.options.ipprefix or self.options.ipformat):
+        if not cluster.is_podman() and not (self.options.ipprefix or self.options.ipformat):
             self.options.ipformat = '127.0.0.%d'
 
         if self.options.ssl_path:
@@ -459,7 +464,7 @@ class ClusterPopulateCmd(Cmd):
             if self.cluster.cassandra_version() >= "1.2" and self.options.vnodes:
                 self.cluster.set_configuration_options({'num_tokens': 256})
 
-            if not (self.options.ipprefix or self.options.ipformat):
+            if not self.cluster.is_podman() and not (self.options.ipprefix or self.options.ipformat):
                 self.options.ipformat = '127.0.0.%d'
 
             self.cluster.populate(self.nodes, self.options.debug, use_vnodes=self.options.vnodes, ipprefix=self.options.ipprefix, ipformat=self.options.ipformat)

--- a/ccmlib/container_client.py
+++ b/ccmlib/container_client.py
@@ -9,8 +9,9 @@ import json
 import logging
 import os
 import shutil
+import threading
 from abc import ABC, abstractmethod
-from subprocess import run, PIPE, CalledProcessError
+from subprocess import run, Popen, PIPE, STDOUT, CalledProcessError, TimeoutExpired
 from typing import Dict, List, Optional, Tuple
 
 LOGGER = logging.getLogger("ccm")
@@ -52,6 +53,9 @@ class ContainerClient(ABC):
                 f"{self.runtime_name} is not installed or not accessible. "
                 f"Please install {self.runtime_name} and ensure it's in your PATH."
             )
+        # Resolved binary path for callers that exec/spawn it directly
+        # (e.g. get_tool(), ContainerLogManager) instead of via _run_command().
+        self.runtime_path = shutil.which(self.runtime_name) or self.runtime_name
         LOGGER.debug(f"Initialized {self.runtime_name} client")
     
     @abstractmethod
@@ -67,23 +71,27 @@ class ContainerClient(ABC):
             result = run([self.runtime_name, 'version'], 
                         stdout=PIPE, stderr=PIPE, timeout=5)
             return result.returncode == 0
-        except (FileNotFoundError, CalledProcessError):
+        except (FileNotFoundError, CalledProcessError, TimeoutExpired):
             return False
     
-    def _run_command(self, cmd: List[str], check: bool = True) -> Tuple[int, str, str]:
+    def _run_command(
+        self, cmd: List[str], check: bool = True, timeout: Optional[float] = None
+    ) -> Tuple[int, str, str]:
         """
         Run a container runtime command.
         
         Args:
             cmd: Command and arguments to run
             check: If True, raise exception on non-zero return code
+            timeout: Optional timeout in seconds. On expiry, returns
+                     (-1, '', 'timed out') instead of raising.
             
         Returns:
             Tuple of (returncode, stdout, stderr)
         """
         LOGGER.debug(f"Running command: {' '.join(cmd)}")
         try:
-            result = run(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+            result = run(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True, timeout=timeout)
             LOGGER.debug(f"Command exit code: {result.returncode}")
             if result.stdout:
                 LOGGER.debug(f"Command stdout: {result.stdout[:500]}")
@@ -98,12 +106,16 @@ class ContainerClient(ABC):
             raise ContainerRuntimeNotFoundError(
                 f"{self.runtime_name} command not found. Is {self.runtime_name} installed?"
             )
+        except TimeoutExpired:
+            LOGGER.debug(f"Command timed out after {timeout}s: {' '.join(cmd)}")
+            return -1, '', f'command timed out after {timeout}s'
     
     def run_container(
         self,
         image: str,
         name: str,
         volumes: Optional[Dict[str, str]] = None,
+        volumes_no_relabel: Optional[List[str]] = None,
         ports: Optional[Dict[str, str]] = None,
         env: Optional[Dict[str, str]] = None,
         network: Optional[str] = None,
@@ -115,6 +127,10 @@ class ContainerClient(ABC):
         tmpfs: Optional[List[str]] = None,
         detach: bool = True,
         remove: bool = False,
+        ip: Optional[str] = None,
+        labels: Optional[Dict[str, str]] = None,
+        cpuset_cpus: Optional[str] = None,
+        hostname: Optional[str] = None,
     ) -> str:
         """
         Run a container.
@@ -123,6 +139,9 @@ class ContainerClient(ABC):
             image: Container image to run
             name: Name for the container
             volumes: Dictionary of host_path: container_path volume mounts
+            volumes_no_relabel: Host paths (subset of `volumes`' keys) to
+                mount without podman's `:z` SELinux relabel suffix (e.g.
+                `/tmp`, which shouldn't be relabeled).
             ports: Dictionary of host_port: container_port port mappings
             env: Dictionary of environment variables
             network: Network to connect to
@@ -132,6 +151,10 @@ class ContainerClient(ABC):
             cap_add: List of Linux capabilities to add
             detach: Run in detached mode
             remove: Remove container when it exits
+            ip: Static IP address to assign on `network` (requires `network`)
+            labels: Dictionary of label_key: label_value container labels
+            cpuset_cpus: CPU set to pin the container to (e.g. "0,1" or "0-3")
+            hostname: Container hostname
 
         Returns:
             Container ID
@@ -156,12 +179,24 @@ class ContainerClient(ABC):
             for mount in tmpfs:
                 cmd.extend(['--tmpfs', mount])
 
+        if labels:
+            for key, value in labels.items():
+                cmd.extend(['--label', f'{key}={value}'])
+
+        if cpuset_cpus:
+            cmd.extend(['--cpuset-cpus', cpuset_cpus])
+
+        if hostname:
+            cmd.extend(['--hostname', hostname])
+
         cmd.extend(['--name', name])
 
         if volumes:
-            # Podman needs :z for SELinux relabeling on shared volumes
-            vol_suffix = ':z' if self.runtime_name == 'podman' else ''
+            # Podman relabels (:z) by default, except paths in volumes_no_relabel.
+            no_relabel = set(volumes_no_relabel or [])
             for host_path, container_path in volumes.items():
+                relabel = self.runtime_name == 'podman' and host_path not in no_relabel
+                vol_suffix = ':z' if relabel else ''
                 cmd.extend(['-v', f'{host_path}:{container_path}{vol_suffix}'])
 
         if ports:
@@ -174,6 +209,9 @@ class ContainerClient(ABC):
 
         if network:
             cmd.extend(['--network', network])
+
+        if ip:
+            cmd.extend(['--ip', ip])
 
         if entrypoint:
             cmd.extend(['--entrypoint', entrypoint])
@@ -204,6 +242,7 @@ class ContainerClient(ABC):
         interactive: bool = False,
         tty: bool = False,
         user: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> Tuple[int, str, str]:
         """
         Execute a command in a running container.
@@ -214,6 +253,7 @@ class ContainerClient(ABC):
             interactive: Keep STDIN open
             tty: Allocate a pseudo-TTY
             user: User to run command as
+            timeout: Optional timeout in seconds for the exec call itself
             
         Returns:
             Tuple of (returncode, stdout, stderr)
@@ -232,7 +272,7 @@ class ContainerClient(ABC):
         cmd.append(container_id)
         cmd.extend(command)
         
-        return self._run_command(cmd, check=False)
+        return self._run_command(cmd, check=False, timeout=timeout)
     
     def stop_container(self, container_id: str, timeout: int = 10) -> None:
         """
@@ -255,6 +295,7 @@ class ContainerClient(ABC):
         container_id: str,
         force: bool = False,
         volumes: bool = False,
+        check: bool = False,
     ) -> None:
         """
         Remove a container.
@@ -263,23 +304,72 @@ class ContainerClient(ABC):
             container_id: Container ID or name
             force: Force removal (kill if running)
             volumes: Remove associated volumes
+            check: If True, raise `ContainerExecError` on failure instead of
+                   just logging a warning (for safety-critical callers).
         """
-        cmd = [self.runtime_name, 'rm']
-        
-        if force:
-            cmd.append('-f')
-        
-        if volumes:
-            cmd.append('-v')
-        
-        cmd.append(container_id)
-        
+        cmd = [self.runtime_name, 'rm'] + self._force_remove_flags(force) + (['-v'] if volumes else []) + [container_id]
+
         returncode, stdout, stderr = self._run_command(cmd, check=False)
         
         if returncode != 0:
+            if check:
+                raise ContainerExecError(
+                    f"Failed to remove container '{container_id}': {stderr}"
+                )
             LOGGER.warning(f"Failed to remove container '{container_id}': {stderr}")
         else:
             LOGGER.info(f"Removed container: {container_id[:12]}")
+
+    def _force_remove_flags(self, force: bool) -> List[str]:
+        """Flags for an instant force-remove (kill, no grace period).
+
+        Docker's `rm -f` is already an immediate SIGKILL. Podman's `rm -f`
+        still honors the default 10s stop-grace-period before SIGKILL unless
+        `--time 0` is given, which podman-specifically supports on `rm`.
+        """
+        if not force:
+            return []
+        if self.runtime_name == 'podman':
+            return ['-f', '--time', '0']
+        return ['-f']
+
+    def remove_containers(
+        self,
+        container_ids: List[str],
+        force: bool = False,
+        volumes: bool = False,
+        chunk_size: int = 10,
+    ) -> List[str]:
+        """
+        Remove multiple containers, batching several IDs into each `rm`
+        invocation instead of spawning one subprocess per container.
+
+        Args:
+            container_ids: Container IDs/names to remove
+            force: Force removal (kill if running)
+            volumes: Remove associated volumes
+            chunk_size: Max container IDs per `rm` invocation
+
+        Returns:
+            The subset of container_ids whose chunk reported a failure, so
+            callers can retry/fallback on just those (e.g. by name).
+        """
+        failed: List[str] = []
+        base_cmd = [self.runtime_name, 'rm'] + self._force_remove_flags(force) + (['-v'] if volumes else [])
+
+        for i in range(0, len(container_ids), chunk_size):
+            chunk = container_ids[i:i + chunk_size]
+            returncode, stdout, stderr = self._run_command(base_cmd + chunk, check=False)
+            if returncode != 0:
+                # A batch failure could be one bad container among several
+                # good ones; punt the whole chunk back to the caller rather
+                # than guessing which ones actually succeeded.
+                failed.extend(chunk)
+                LOGGER.warning(f"Failed to remove some containers in batch {chunk}: {stderr}")
+            else:
+                LOGGER.info(f"Removed {len(chunk)} containers: {', '.join(c[:12] for c in chunk)}")
+
+        return failed
     
     def inspect_container(self, container_id: str) -> Optional[Dict]:
         """
@@ -294,7 +384,7 @@ class ContainerClient(ABC):
         cmd = [self.runtime_name, 'inspect', container_id]
         returncode, stdout, stderr = self._run_command(cmd, check=False)
         
-        if returncode != 0:
+        if returncode != 0 or not stdout.strip():
             return None
         
         try:
@@ -333,6 +423,94 @@ class ContainerClient(ABC):
 
         ip = stdout.strip()
         return ip if ip else None
+
+    def get_container_pid(self, container_id: str) -> Optional[int]:
+        """
+        Get the host-visible PID of a container's init process, for use
+        with ``nsenter`` to enter its namespaces from the host.
+
+        Args:
+            container_id: Container ID or name
+
+        Returns:
+            The host PID as an int, or None if the container isn't running
+            or the PID couldn't be determined.
+        """
+        cmd = [self.runtime_name, 'inspect', '--format', '{{.State.Pid}}', container_id]
+        returncode, stdout, stderr = self._run_command(cmd, check=False)
+        if returncode != 0:
+            return None
+        try:
+            pid = int(stdout.strip())
+        except ValueError:
+            LOGGER.error(
+                f"Unexpected PID value in inspect output for '{container_id}': {stdout!r}"
+            )
+            return None
+        return pid if pid > 0 else None
+
+    def get_container_status(self, container_id: str) -> Optional[str]:
+        """
+        Get the lifecycle status of a container (e.g. 'running', 'exited').
+
+        Args:
+            container_id: Container ID or name
+
+        Returns:
+            The status string, or None if the container was not found.
+        """
+        cmd = [self.runtime_name, 'inspect', '--format', '{{.State.Status}}', container_id]
+        returncode, stdout, stderr = self._run_command(cmd, check=False)
+        if returncode != 0:
+            return None
+        status = stdout.strip()
+        return status or None
+
+    def get_container_labels(self, container_id: str) -> Dict[str, str]:
+        """
+        Get the labels attached to a container.
+
+        Args:
+            container_id: Container ID or name
+
+        Returns:
+            Dictionary of labels (empty if the container was not found or has
+            no labels).
+        """
+        info = self.inspect_container(container_id)
+        if info is None:
+            return {}
+        labels = info.get("Config", {}).get("Labels", {})
+        return labels if isinstance(labels, dict) else {}
+
+    def copy_from_container(self, container_id: str, container_path: str) -> bytes:
+        """
+        Copy a file or directory out of a container as a tar archive stream.
+
+        Args:
+            container_id: Container ID or name
+            container_path: Path inside the container to copy (e.g. '/etc/scylla/')
+
+        Returns:
+            Raw tar archive bytes (as produced by ``<runtime> container cp -a``).
+
+        Raises:
+            ContainerExecError: if the copy failed.
+        """
+        cmd = [self.runtime_name, 'container', 'cp', '-a', f'{container_id}:{container_path}', '-']
+        LOGGER.debug(f"Running command: {' '.join(cmd)}")
+        try:
+            result = run(cmd, stdout=PIPE, stderr=PIPE)
+        except FileNotFoundError:
+            raise ContainerRuntimeNotFoundError(
+                f"{self.runtime_name} command not found. Is {self.runtime_name} installed?"
+            )
+        if result.returncode != 0:
+            stderr_text = result.stderr.decode('utf-8', errors='replace') if isinstance(result.stderr, bytes) else result.stderr
+            raise ContainerExecError(
+                f"Failed to copy '{container_path}' from container '{container_id}': {stderr_text}"
+            )
+        return result.stdout
     
     def container_exists(self, container_name: str) -> bool:
         """
@@ -407,7 +585,7 @@ class ContainerClient(ABC):
         if follow:
             cmd.append('-f')
         
-        if tail:
+        if tail is not None:
             cmd.extend(['--tail', str(tail)])
         
         cmd.append(container_id)
@@ -417,17 +595,41 @@ class ContainerClient(ABC):
         # Combine stdout and stderr as container logs can be in either
         return stdout + stderr
     
-    def create_network(self, network_name: str) -> bool:
+    def create_network(
+        self,
+        network_name: str,
+        subnet: Optional[str] = None,
+        gateway: Optional[str] = None,
+        labels: Optional[Dict[str, str]] = None,
+    ) -> bool:
         """
         Create a container network.
         
         Args:
             network_name: Name for the network
+            subnet: CIDR subnet for the network (e.g. '10.89.1.0/24')
+            gateway: Gateway IP for the network (requires `subnet`)
+            labels: Dictionary of label_key: label_value network labels
             
         Returns:
-            True if successful, False otherwise
+            True if successful (or the network already exists)
+
+        Raises:
+            ContainerStartError: if `subnet`/`gateway`/`labels` was given and
+                creation failed for a reason other than already existing.
+                Plain `create_network(name)` keeps the legacy bool-return
+                behaviour for existing callers.
         """
-        cmd = [self.runtime_name, 'network', 'create', network_name]
+        cmd = [self.runtime_name, 'network', 'create']
+        if labels:
+            for key, value in labels.items():
+                cmd.extend(['--label', f'{key}={value}'])
+        if subnet:
+            cmd.extend(['--subnet', subnet])
+        if gateway:
+            cmd.extend(['--gateway', gateway])
+        cmd.append(network_name)
+
         returncode, stdout, stderr = self._run_command(cmd, check=False)
         
         if returncode != 0:
@@ -435,26 +637,86 @@ class ContainerClient(ABC):
             if 'already exists' in stderr.lower():
                 LOGGER.debug(f"Network '{network_name}' already exists")
                 return True
+            if subnet or gateway or labels:
+                raise ContainerStartError(
+                    f"Failed to create network '{network_name}': {stderr}"
+                )
             LOGGER.error(f"Failed to create network '{network_name}': {stderr}")
             return False
         
         LOGGER.info(f"Created network: {network_name}")
         return True
     
-    def remove_network(self, network_name: str) -> None:
+    def remove_network(self, network_name: str, force: bool = False, check: bool = False) -> None:
         """
         Remove a container network.
         
         Args:
             network_name: Name of the network to remove
+            force: Force removal (disconnect any attached containers first)
+            check: If True, raise `ContainerExecError` on failure instead of
+                   just logging a warning.
         """
-        cmd = [self.runtime_name, 'network', 'rm', network_name]
+        cmd = [self.runtime_name, 'network', 'rm']
+        if force:
+            cmd.append('-f')
+        cmd.append(network_name)
         returncode, stdout, stderr = self._run_command(cmd, check=False)
         
         if returncode != 0:
+            if check:
+                raise ContainerExecError(
+                    f"Failed to remove network '{network_name}': {stderr}"
+                )
             LOGGER.warning(f"Failed to remove network '{network_name}': {stderr}")
         else:
             LOGGER.info(f"Removed network: {network_name}")
+
+    def inspect_network(self, network_name: str) -> Optional[Dict]:
+        """
+        Inspect a network and return its metadata.
+
+        Args:
+            network_name: Network name or ID
+
+        Returns:
+            Network metadata as dictionary, or None if not found
+        """
+        cmd = [self.runtime_name, 'network', 'inspect', network_name]
+        returncode, stdout, stderr = self._run_command(cmd, check=False)
+
+        if returncode != 0 or not stdout.strip():
+            return None
+
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            LOGGER.warning(f"Failed to parse network inspect output for '{network_name}'")
+            return None
+        if isinstance(data, list):
+            return data[0] if data else None
+        return data
+
+    def list_networks(self) -> List[Dict]:
+        """
+        List all networks known to the container runtime.
+
+        Returns:
+            List of network metadata dictionaries (empty list on error).
+        """
+        cmd = [self.runtime_name, 'network', 'ls', '--format', 'json']
+        returncode, stdout, stderr = self._run_command(cmd, check=False)
+
+        if returncode != 0:
+            LOGGER.warning(f"Failed to list networks: {stderr}")
+            return []
+
+        try:
+            networks = json.loads(stdout)
+        except json.JSONDecodeError:
+            LOGGER.warning("Failed to parse network ls output as JSON")
+            return []
+        return networks if isinstance(networks, list) else []
 
 
 class DockerClient(ContainerClient):
@@ -467,9 +729,29 @@ class DockerClient(ContainerClient):
 class PodmanClient(ContainerClient):
     """Podman implementation of the container client."""
 
-
     def _get_runtime_name(self) -> str:
         return 'podman'
+
+    def unshare(self, command: List[str], check: bool = False) -> Tuple[int, str, str]:
+        """
+        Run a command via ``podman unshare`` (rootless user namespace).
+        Podman-specific escape hatch for host-side chown/chmod on
+        bind-mounts owned by the container's user namespace.
+
+        Args:
+            command: Command and arguments to run inside the user namespace
+            check: If True, raise `ContainerExecError` on non-zero return code
+
+        Returns:
+            Tuple of (returncode, stdout, stderr)
+        """
+        cmd = [self.runtime_name, 'unshare'] + list(command)
+        returncode, stdout, stderr = self._run_command(cmd, check=False)
+        if check and returncode != 0:
+            raise ContainerExecError(
+                f"'podman unshare {' '.join(command)}' failed: {stderr}"
+            )
+        return returncode, stdout, stderr
 
 
 def get_container_client(runtime: Optional[str] = None) -> ContainerClient:
@@ -505,3 +787,134 @@ def get_container_client(runtime: Optional[str] = None) -> ContainerClient:
                 raise ContainerRuntimeNotFoundError(
                     "No container runtime found. Please install Docker or Podman."
                 )
+
+
+class _LogStreamState:
+    """Internal state for a single container's log stream."""
+    __slots__ = ("log_file_path", "stop_event", "thread", "process", "lock")
+
+    def __init__(self, log_file_path: str):
+        self.log_file_path = log_file_path
+        self.stop_event = threading.Event()
+        self.thread: Optional[threading.Thread] = None
+        # Guards `process`, set by the background thread once Popen()
+        # succeeds; read by stop_stream()/stop_all() to terminate it early.
+        self.process: Optional[Popen] = None
+        self.lock = threading.Lock()
+
+
+class ContainerLogManager:
+    """Streams `<runtime> logs -f <id>` to per-container log files.
+
+    One daemon thread per container. Shared by the Docker and Podman
+    cluster implementations to avoid duplicating log-capture logic.
+    """
+
+    def __init__(self, client: ContainerClient):
+        self._client = client
+        self._runtime_path = client.runtime_path
+        self._streams: Dict[str, _LogStreamState] = {}
+        self._lock = threading.Lock()
+
+    def start_stream(self, container_id: str, log_file_path: str) -> None:
+        """Begin streaming logs for *container_id* to *log_file_path*.
+
+        A no-op if a stream for this container is already active.
+        """
+        with self._lock:
+            if container_id in self._streams:
+                return
+            state = _LogStreamState(log_file_path)
+            self._streams[container_id] = state
+        thread = threading.Thread(
+            target=self._stream_logs,
+            args=(container_id, state),
+            name=f"{self._client.runtime_name}-log-{container_id[:12]}",
+            daemon=True,
+        )
+        thread.start()
+        state.thread = thread
+
+    def stop_stream(self, container_id: str) -> None:
+        """Stop the log stream for *container_id*, if one is active."""
+        with self._lock:
+            state = self._streams.pop(container_id, None)
+        if state is not None:
+            self._terminate_state(state)
+
+    def stop_all(self) -> None:
+        """Stop all managed log streams."""
+        with self._lock:
+            states = list(self._streams.values())
+            self._streams.clear()
+        for state in states:
+            self._terminate_state(state)
+
+    @staticmethod
+    def _terminate_state(state: "_LogStreamState") -> None:
+        """Stop a stream and kill its process now (not on the next log line).
+
+        The streaming thread only checks stop_event between reads on a
+        blocking pipe, so a quiet container would otherwise linger.
+        """
+        state.stop_event.set()
+        with state.lock:
+            process = state.process
+        if process is not None:
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                pass
+
+    def _stream_logs(self, container_id: str, state: _LogStreamState) -> None:
+        """Background: run ``<runtime> logs -f`` and append output to the log file."""
+        try:
+            with open(state.log_file_path, 'a') as f:
+                process = Popen(
+                    [self._runtime_path, 'logs', '-f', container_id],
+                    stdout=PIPE,
+                    stderr=STDOUT,
+                    universal_newlines=True,
+                    bufsize=1,
+                )
+                with state.lock:
+                    already_stopped = state.stop_event.is_set()
+                    if not already_stopped:
+                        state.process = process
+                if already_stopped:
+                    # Raced with stop_stream()/stop_all(); kill it now.
+                    try:
+                        process.terminate()
+                    except ProcessLookupError:
+                        pass
+                    try:
+                        process.wait(timeout=5)
+                    except Exception:
+                        pass
+                    return
+                try:
+                    for line in process.stdout:
+                        if state.stop_event.is_set():
+                            break
+                        f.write(line)
+                        f.flush()
+                except (ValueError, OSError):
+                    pass
+                finally:
+                    try:
+                        process.terminate()
+                    except ProcessLookupError:
+                        pass
+                    try:
+                        process.wait(timeout=5)
+                    except Exception:
+                        pass
+        except Exception:
+            LOGGER.warning(
+                "Log stream failed for container %s", container_id, exc_info=True,
+            )
+        finally:
+            # Drop the state if the thread exits on its own (e.g. Popen
+            # failure) so start_stream() can be retried for this container.
+            with self._lock:
+                self._streams.pop(container_id, None)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -207,6 +207,10 @@ class Node(object):
     def is_docker():
         return False
 
+    @staticmethod
+    def is_podman():
+        return False
+
     def get_node_cassandra_root(self):
         return self.get_path()
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -162,6 +162,8 @@ class Node(object):
                 node.pid = int(data['pid'])
             if 'docker_id' in data:
                 node.pid = data['docker_id']
+            if 'podman_name' in data:
+                node.podman_name = data['podman_name']
             if 'install_dir' in data:
                 node.__install_dir = data['install_dir']
             if 'config_options' in data:

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -470,6 +470,9 @@ class Node(object):
         log_file = os.path.join(self.get_path(), 'logs', filename)
         while not os.path.exists(log_file):
             time.sleep(.1)
+            if time.time() > deadline:
+                raise TimeoutError(time.strftime("%d %b %Y %H:%M:%S", time.gmtime()) + " [" + self.name + "] Missing: " + str(
+                    [e.pattern for e in tofind]) + ":\nLog file " + log_file + " does not exist")
             if process:
                 process.poll()
                 if process.returncode is not None:

--- a/ccmlib/scylla_docker_cluster.py
+++ b/ccmlib/scylla_docker_cluster.py
@@ -1,6 +1,4 @@
 import os
-import shutil
-import subprocess
 import types
 import warnings
 from shutil import copyfile
@@ -17,6 +15,7 @@ from ccmlib.container_client import (
     get_container_client,
     ContainerClientError,
     ContainerImageNotFoundError,
+    ContainerLogManager,
 )
 
 LOGGER = logging.getLogger("ccm")
@@ -28,6 +27,7 @@ class ScyllaDockerCluster(ScyllaCluster):
         self.docker_image = kwargs['docker_image']
         self.container_runtime = kwargs.get('container_runtime', None)
         self._container_client = None
+        self._log_manager = None
         self.cluster_network = None
 
         # Podman requires fully-qualified image names (no short names)
@@ -52,6 +52,12 @@ class ScyllaDockerCluster(ScyllaCluster):
                 LOGGER.error(f"Failed to initialize container client: {e}")
                 raise
         return self._container_client
+
+    def get_log_manager(self):
+        """Get or create the shared log-streaming manager for this cluster's containers."""
+        if self._log_manager is None:
+            self._log_manager = ContainerLogManager(self.get_container_client())
+        return self._log_manager
     
     def _validate_docker_image(self):
         """Validate that the Docker image exists or can be pulled."""
@@ -100,9 +106,11 @@ class ScyllaDockerCluster(ScyllaCluster):
 
     def remove(self, node=None, wait_other_notice=False, other_nodes=None):
         # Remove containers first, before super().remove() deletes node dirs
-        # and before removing the network (containers must disconnect first)
-        for n in list(self.nodes.values()):
-            n.remove()
+        # and before removing the network (containers must disconnect first).
+        # Batched into one/few `rm` calls instead of one subprocess per node.
+        targets = [ref for n in list(self.nodes.values()) if (ref := (n.pid or n.docker_name))]
+        if targets:
+            self.get_container_client().remove_containers(targets, force=True, volumes=True, chunk_size=10)
 
         super(ScyllaDockerCluster, self).remove(node=node, wait_other_notice=wait_other_notice, other_nodes=other_nodes)
 
@@ -199,6 +207,10 @@ class ScyllaDockerNode(ScyllaNode):
     def get_container_client(self):
         """Get the container client from the cluster."""
         return self.cluster.get_container_client()
+
+    def get_log_manager(self):
+        """Get the shared log-streaming manager from the cluster."""
+        return self.cluster.get_log_manager()
 
     def _get_directories(self):
         dirs = {}
@@ -350,6 +362,7 @@ class ScyllaDockerNode(ScyllaNode):
                     image=self.cluster.docker_image,
                     name=self.docker_name,
                     volumes=volumes,
+                    volumes_no_relabel=['/tmp'],
                     ports=ports if ports else None,
                     network=self.cluster.cluster_network,
                     entrypoint='/bin/bash',
@@ -366,10 +379,10 @@ class ScyllaDockerNode(ScyllaNode):
                 LOGGER.error(f"Failed to create Docker container: {e}")
                 raise BaseException(f'Failed to create docker {self.docker_name}: {e}')
 
-            # Start log thread
+            # Start log streaming
             if not self.log_thread:
-                self.log_thread = DockerLogger(self, os.path.join(self.get_path(), 'logs', 'system.log'))
-                self.log_thread.start()
+                self.get_log_manager().start_stream(self.pid, os.path.join(self.get_path(), 'logs', 'system.log'))
+                self.log_thread = True
 
             self.watch_log_for("supervisord started with", from_mark=0, timeout=30)
 
@@ -382,8 +395,8 @@ class ScyllaDockerNode(ScyllaNode):
             self._has_jmx = (rc == 0)
 
         if not self.log_thread:
-            self.log_thread = DockerLogger(self, os.path.join(self.get_path(), 'logs', 'system.log'))
-            self.log_thread.start()
+            self.get_log_manager().start_stream(self.pid, os.path.join(self.get_path(), 'logs', 'system.log'))
+            self.log_thread = True
 
         # Get container IP address
         client = self.get_container_client()
@@ -681,8 +694,7 @@ class ScyllaDockerNode(ScyllaNode):
     def get_tool(self, toolname):
         """Get command to run a tool in the Docker container."""
         client = self.get_container_client()
-        runtime_path = shutil.which(client.runtime_name) or client.runtime_name
-        return [runtime_path, 'exec', '-i', f'{self.pid}', f'{toolname}']
+        return [client.runtime_path, 'exec', '-i', f'{self.pid}', f'{toolname}']
 
     def _find_cmd(self, command_name):
         return self.get_tool(command_name)
@@ -769,35 +781,3 @@ class ScyllaDockerNode(ScyllaNode):
                 stdout=PIPE, stderr=PIPE)
 
         super(ScyllaDockerNode, self).rmtree(path)
-
-
-class DockerLogger:
-    def __init__(self, node, target_log_file: str):
-        self._node = node
-        self._target_log_file = target_log_file
-        self._process = None
-        self._thread = None
-
-    def _stream_logs(self):
-        """Read from docker logs pipe and write each line to file immediately."""
-        try:
-            with open(self._target_log_file, 'a') as f:
-                for line in self._process.stdout:
-                    f.write(line)
-                    f.flush()
-        except (ValueError, OSError):
-            pass
-
-    def start(self):
-        import threading
-        client = self._node.get_container_client()
-        runtime_path = shutil.which(client.runtime_name) or client.runtime_name
-        self._process = subprocess.Popen(
-            [runtime_path, 'logs', '-f', self._node.pid],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            universal_newlines=True,
-            bufsize=1,
-        )
-        self._thread = threading.Thread(target=self._stream_logs, daemon=True)
-        self._thread.start()

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -773,12 +773,16 @@ class ScyllaNode(Node):
         # Lets search for default overrides in SCYLLA_EXT_OPTS
         env_args = process_opts(os.getenv('SCYLLA_EXT_OPTS', "").split())
 
+        # use '--smp' from SCYLLA_EXT_OPTS unless set by the test
+        # (jvm_args may still override it below)
+        if not self._smp_set_during_test and '--smp' in env_args:
+            self._smp = int(env_args['--smp'][0])
+
         # precalculate self._mem_mb_per_cpu if --memory is given in SCYLLA_EXT_OPTS
         # and it wasn't set explicitly by the test
         if not self._mem_mb_set_during_test and '--memory' in env_args:
             memory = self.parse_size(env_args['--memory'][0])
-            smp = int(env_args['--smp'][0]) if '--smp' in env_args else self._smp
-            self._mem_mb_per_cpu = int((memory / smp) // MB)
+            self._mem_mb_per_cpu = int((memory / self._smp) // MB)
 
         cmd_args = process_opts(jvm_args)
 

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -894,7 +894,7 @@ class ScyllaNode(Node):
                 raise NodeError(e_msg, scylla_process)
 
         self._update_pid(scylla_process)
-        if not wait_for(func=lambda: self.is_running(), timeout=30, first=5, step=0.5):
+        if not wait_for(func=lambda: self.is_running(), timeout=30, first=0, step=0.5):
             raise NodeError(f"{self.name} did not become UP within 30 s")
 
         if self.scylla_manager and self.scylla_manager.is_agent_available:

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -894,7 +894,8 @@ class ScyllaNode(Node):
                 raise NodeError(e_msg, scylla_process)
 
         self._update_pid(scylla_process)
-        wait_for(func=lambda: self.is_running(), timeout=10, step=0.01)
+        if not wait_for(func=lambda: self.is_running(), timeout=30, first=5, step=0.5):
+            raise NodeError(f"{self.name} did not become UP within 30 s")
 
         if self.scylla_manager and self.scylla_manager.is_agent_available:
             self.start_scylla_manager_agent()
@@ -970,7 +971,7 @@ class ScyllaNode(Node):
             nodetool.extend(['-h', host, '-p', str(self.api_port)])
             nodetool.extend(cmd.split())
             return self._do_run_nodetool(nodetool, capture_output, wait, timeout, verbose)
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             pass
 
         # the java nodetool depends on JMX

--- a/ccmlib/scylla_podman_cluster.py
+++ b/ccmlib/scylla_podman_cluster.py
@@ -1,5 +1,6 @@
 # ccm podman-based scylla cluster with network topology support
 
+import concurrent.futures
 import ipaddress
 import hashlib
 import json
@@ -22,6 +23,7 @@ from ccmlib import common
 from ccmlib.node import (
     NodeError,
     Status,
+    TimeoutError,
 )
 from ccmlib.scylla_cluster import ScyllaCluster
 from ccmlib.scylla_node import ScyllaNode
@@ -371,7 +373,7 @@ def _get_container_host_pid(container_id):
         ) from exc
 
 
-def _nsenter_net_run(container_id, command, check=False):
+def _nsenter_net_run(container_id, command, check=False, host_pid=None):
     """Run a command inside a container's network namespace using nsenter.
 
     Uses ``nsenter --user --net`` to enter the container's user and network
@@ -383,11 +385,13 @@ def _nsenter_net_run(container_id, command, check=False):
         container_id: podman container name or ID
         command: list of command arguments (e.g. ["ip", "route", "add", ...])
         check: if True, raise on non-zero exit
+        host_pid: cached host PID (avoids an extra ``podman inspect`` call)
 
     Returns:
         subprocess.CompletedProcess
     """
-    host_pid = _get_container_host_pid(container_id)
+    if host_pid is None:
+        host_pid = _get_container_host_pid(container_id)
     full_cmd = ["nsenter", "-t", str(host_pid), "--user", "--net"] + list(command)
     try:
         res = run(full_cmd, stdout=PIPE, stderr=PIPE, text=True)
@@ -1029,6 +1033,9 @@ class ScyllaPodmanCluster(ScyllaCluster):
         self._cpu_assignments_lock = threading.Lock()
         # Lock protecting the one-time image config extraction (see _get_image_conf_cache_dir).
         self._image_conf_cache_lock = threading.Lock()
+        # Shared managers for log streaming and event monitoring (Optimization 1 & 4).
+        self._log_manager = None
+        self._event_monitor = None
         # Pass docker_image to parent so it skips install_dir validation
         kwargs["docker_image"] = self.podman_image
         super(ScyllaPodmanCluster, self).__init__(*args, **kwargs)
@@ -1058,6 +1065,16 @@ class ScyllaPodmanCluster(ScyllaCluster):
 
     def get_install_dir(self):
         return None
+
+    def _ensure_managers(self):
+        # Shared log streaming and event monitoring; also used on the
+        # ClusterFactory load path where populate() is never called.  The
+        # event monitor is started lazily on the first node start (see
+        # PodmanEventMonitor.register) so read-only commands on a loaded
+        # cluster don't spawn a `podman events --stream` subprocess.
+        if self._log_manager is None:
+            self._log_manager = PodmanLogManager()
+            self._event_monitor = PodmanEventMonitor(self._log_manager)
 
     def populate(
         self,
@@ -1131,6 +1148,10 @@ class ScyllaPodmanCluster(ScyllaCluster):
                 for _ in range(n):
                     node_locations.append((dc, rack))
 
+        # Initialize shared log manager and event monitor for this cluster.
+        self._ensure_managers()
+        self._event_monitor.start()
+
         if dcs != [None]:
             self.set_configuration_options(values={"endpoint_snitch": self.snitch})
 
@@ -1174,6 +1195,12 @@ class ScyllaPodmanCluster(ScyllaCluster):
             self.network_topology.destroy_networks()
             raise
 
+        # Prepare directory permissions for all nodes before starting
+        # containers.  This runs the expensive ``podman unshare chmod -R``
+        # exactly once during cluster setup instead of O(N) times during
+        # node start.
+        self._prepare_cluster_permissions()
+
         self.cluster_cleanup()
         if self.pinning:
             self._refresh_cpu_assignments()
@@ -1190,6 +1217,42 @@ class ScyllaPodmanCluster(ScyllaCluster):
             self.default_wait_for_binary_proto, node_count,
         )
         return self
+
+    def _prepare_cluster_permissions(self):
+        """Perform the expensive ``podman unshare chmod -R a+rwX`` once for all nodes.
+
+        Called during ``populate()`` after node directories are created and
+        their ownership has been handed to the container user.  This avoids
+        repeating the recursive chmod per-node during ``create_container()``,
+        which is a significant bottleneck when starting 50-100 containers
+        concurrently.
+        """
+        runtime_user = _get_image_runtime_user(self.podman_image)
+        if runtime_user is None:
+            LOGGER.warning(
+                "Unable to determine runtime user for image %s; "
+                "skipping cluster-level permission setup",
+                self.podman_image,
+            )
+            return
+        uid, gid = runtime_user
+        for node in self.nodelist():
+            for directory in node.share_directories:
+                host_path = os.path.join(node.get_path(), directory)
+                if not os.path.exists(host_path):
+                    continue
+                _chown_path_for_container(host_path, uid, gid)
+                res = run(
+                    ["podman", "unshare", "chmod", "-R", "a+rwX", host_path],
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    text=True,
+                )
+                if res.returncode != 0:
+                    LOGGER.warning(
+                        "Failed to chmod %s to a+rwX via podman unshare: %s",
+                        host_path, res.stderr,
+                    )
 
     def _compute_cpu_assignments(self):
         """Compute non-overlapping CPU assignments for each node.
@@ -1730,12 +1793,16 @@ class ScyllaPodmanNode(ScyllaNode):
             ]
         )
         self.jmx_port = "7199"
-        self.log_thread = None
         self._host_pid = None
         self._fresh_container = False
         self._last_status_check = 0.0
         self._cached_nodetool_support = {}
         self._cached_supervisor_programs = None
+        # References to cluster-level managers (set after cluster init)
+        self._log_manager = getattr(self.cluster, "_log_manager", None)
+        self._event_monitor = getattr(self.cluster, "_event_monitor", None)
+        # Default to 1 CPU (not 2 like ScyllaNode) to reduce resource usage
+        self._smp = 1
 
     def _supervisor_program_names(self):
         if self.pid is None:
@@ -1781,92 +1848,8 @@ class ScyllaPodmanNode(ScyllaNode):
     def has_jmx(self):
         return self._jmx_service_name() is not None
 
-    def nodetool(self, cmd, capture_output=True, wait=True, timeout=None, verbose=True):
-        """Run nodetool inside the podman container via 'podman exec'."""
-        if self.pid is None:
-            raise RuntimeError(
-                f"Cannot run nodetool on {self.name}: no running container"
-            )
-        nodetool = ["podman", "exec", self.pid, "scylla", "nodetool"]
-        # Check if the command is supported by the native nodetool
-        command = next(
-            (arg for arg in cmd.split() if not arg.startswith("-")), None
-        )
-        if command is None:
-            raise RuntimeError(f"Could not determine nodetool subcommand from: {cmd!r}")
-        cache = getattr(self, "_cached_nodetool_support", None)
-        if cache is None:
-            cache = {}
-            self._cached_nodetool_support = cache
-        if command not in cache:
-            try:
-                subprocess.check_call(
-                    nodetool + [command, "--help"],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.STDOUT,
-                    timeout=30,
-                )
-                cache[command] = True
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-                cache[command] = False
-        if cache[command]:
-            nodetool.extend(["-h", "localhost", "-p", str(self.api_port)])
-            nodetool.extend(cmd.split())
-            return self._do_run_nodetool(
-                nodetool, capture_output, wait, timeout, verbose
-            )
-
-        if not self.has_jmx:
-            raise RuntimeError(
-                f"Node {self.name}: native nodetool does not support '{cmd}' "
-                f"and JMX is not available for fallback"
-            )
-        # Fall back to java nodetool via JMX (running inside the container)
-        jmx_nodetool = [
-            "podman",
-            "exec",
-            self.pid,
-            "nodetool",
-            f"-Dcom.scylladb.apiPort={self.api_port}",
-        ] + cmd.split()
-        return self._do_run_nodetool(
-            jmx_nodetool, capture_output, wait, timeout, verbose
-        )
-
     def _prepare_bind_mounts(self):
         _make_path_container_writable(self.local_yaml_path)
-        runtime_user = _get_image_runtime_user(self.cluster.podman_image)
-        for host_path in [
-            os.path.join(self.get_path(), directory)
-            for directory in self.share_directories
-        ]:
-            _make_path_container_writable(host_path)
-            if runtime_user is not None:
-                uid, gid = runtime_user
-                _chown_path_for_container(host_path, uid, gid)
-                # After handing ownership to the container user via podman unshare,
-                # the host user (uid != container subuid) can no longer write into
-                # these directories.  Run chmod a+rwX inside the same user-namespace
-                # so that both the container user AND the host user retain write
-                # access.  This is critical for the logs/ directory: PodmanLogger
-                # opens logs/system.log from the host side after the container has
-                # taken ownership of the directory.
-                res = run(
-                    ["podman", "unshare", "chmod", "-R", "a+rwX", host_path],
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    text=True,
-                )
-                if res.returncode != 0:
-                    LOGGER.warning(
-                        "Failed to chmod %s to a+rwX via podman unshare: %s",
-                        host_path, res.stderr,
-                    )
-                # Do NOT call _make_path_container_writable() here a second time.
-                # After podman unshare chown, the host user no longer owns these
-                # directories and os.chmod() would fail with EPERM.  The
-                # podman unshare chmod -R a+rwX above already grants both the
-                # container user and the host user write access.
 
     def _pinning_container_args(self):
         """Return podman run flags for CPU pinning, or empty list if not pinned."""
@@ -2096,11 +2079,12 @@ class ScyllaPodmanNode(ScyllaNode):
             )
             # Clean up the dead container
             run(["podman", "rm", "-f", self.pid], stdout=DEVNULL, stderr=DEVNULL)
-            self.pid = None
             self._cached_supervisor_programs = None
-            if self.log_thread:
-                self.log_thread.stop()
-                self.log_thread = None
+            if self._log_manager:
+                self._log_manager.stop_stream(self.pid)
+            if self._event_monitor:
+                self._event_monitor.unregister(self.pid)
+            self.pid = None
 
         if not self.cluster.network_topology:
             raise RuntimeError(
@@ -2108,7 +2092,8 @@ class ScyllaPodmanNode(ScyllaNode):
                 f"cluster network topology is not initialized"
             )
 
-        self.cluster.network_topology.create_networks()
+        # Networks were created during populate() and verified there;
+        # no need to re-inspect them during container creation.
 
         node_ip = self._get_rack_ip()
         network_name = self.cluster.network_topology.get_node_network(self.name)
@@ -2118,10 +2103,9 @@ class ScyllaPodmanNode(ScyllaNode):
         # populate().  The bind mount below makes it visible inside the
         # container.  Supervisord starts Scylla automatically; no
         # stop/start cycle is needed.
-        node1 = self.cluster.nodelist()[0]
         seed_args = []
-        if self.name != node1.name:
-            seed_args = ["--seeds", node1.network_interfaces["storage"][0]]
+        if self.name != self.cluster.seeds[0].name:
+            seed_args = ["--seeds", self.cluster.seeds[0].network_interfaces["storage"][0]]
 
         scylla_yaml = self.read_scylla_yaml()
         # Do not publish Alternator to fixed host ports. Each node already has a
@@ -2192,13 +2176,10 @@ class ScyllaPodmanNode(ScyllaNode):
         self._fresh_container = True
 
         try:
-            # Start log streaming immediately so startup logs are captured.
-            if self.log_thread:
-                self.log_thread.stop()
-            self.log_thread = PodmanLogger(
-                self, os.path.join(self.get_path(), "logs", "system.log")
-            )
-            self.log_thread.start()
+            # Log streaming is on-demand.  Skipping it here avoids one
+            # ``podman logs -f`` subprocess per container.
+            if self._event_monitor:
+                self._event_monitor.register(self, self.pid)
 
             # Update network interfaces with the actual rack IP.
             self.network_interfaces = {
@@ -2219,9 +2200,10 @@ class ScyllaPodmanNode(ScyllaNode):
             )
             self._cached_supervisor_programs = None
             self._cached_nodetool_support = {}
-            if self.log_thread:
-                self.log_thread.stop()
-                self.log_thread = None
+            if self._log_manager and self.pid:
+                self._log_manager.stop_stream(self.pid)
+            if self._event_monitor and self.pid:
+                self._event_monitor.unregister(self.pid)
             if self.pid:
                 run(
                     ["podman", "rm", "--volumes", "-f", self.pid],
@@ -2293,15 +2275,32 @@ class ScyllaPodmanNode(ScyllaNode):
         # Remove any existing root qdisc so we can re-apply rules cleanly
         # (e.g. on restart when the container was not recreated).
         # Failure is expected on first start (no qdisc to delete).
-        _nsenter_net_run(self.pid, ["sh", "-c", f"tc qdisc del dev {CONTAINER_NET_INTERFACE} root 2>/dev/null || true"])
+        # Build the full tc script and apply it in a single nsenter call.
+        script_parts = [
+            f"tc qdisc del dev {CONTAINER_NET_INTERFACE} root 2>/dev/null || true",
+        ]
+        script_parts.extend(tc_commands)
 
-        for cmd in tc_commands:
-            res = _nsenter_net_run(self.pid, ["sh", "-c", cmd])
-            if res.returncode != 0:
-                LOGGER.warning(
-                    "Failed to apply tc rule in %s: cmd=%s stderr=%s",
-                    self.name, cmd, res.stderr,
-                )
+        # Fail fast: "&&" (not ";") so a failing command stops the script
+        # instead of being masked by the final command's exit code.
+        script = " && ".join(script_parts)
+
+        host_pid = getattr(self, "_host_pid", None)
+        if host_pid is not None:
+            full_cmd = [
+                "nsenter", "-t", str(host_pid), "--user", "--net",
+                "sh", "-c", script,
+            ]
+            res = run(full_cmd, stdout=PIPE, stderr=PIPE, text=True)
+        else:
+            res = _nsenter_net_run(
+                self.pid,
+                ["sh", "-c", script],
+            )
+        if res.returncode != 0:
+            raise RuntimeError(
+                f"Failed to apply tc rules in {self.name}: {res.stderr}"
+            )
 
     def service_start(self, service_name):
         # Clear any FATAL/EXITED state so supervisord will accept the start
@@ -2384,23 +2383,10 @@ class ScyllaPodmanNode(ScyllaNode):
     def wait_for_binary_interface(self, **kwargs):
         timeout = kwargs.get("timeout", 420)
         process = kwargs.get("process")
-        from_mark = kwargs.get("from_mark")
         start = time.time()
 
         def remaining_timeout():
             return max(0.0, timeout - (time.time() - start))
-
-        if self.cluster.version() and parse_version(self.cluster.version()) >= parse_version("1.2"):
-            # 0.2 s log polling instead of the 10 ms default.  This wait can
-            # last minutes during Raft topology bootstrap; 10 ms spinning
-            # wastes CPU that the joining Scylla shards need.
-            self.watch_log_for(
-                "Starting listening for CQL clients",
-                from_mark=from_mark,
-                process=process,
-                timeout=remaining_timeout(),
-                polling_interval=0.2,
-            )
 
         binary_itf = self.network_interfaces["binary"]
         container_id = self.pid
@@ -2414,22 +2400,29 @@ class ScyllaPodmanNode(ScyllaNode):
                     )
             if container_id is None:
                 return False
-            res = run(
-                [
-                    "podman",
-                    "exec",
-                    container_id,
-                    "bash",
-                    "-c",
-                    f"echo > /dev/tcp/{binary_itf[0]}/{binary_itf[1]}",
-                ],
-                stdout=DEVNULL,
-                stderr=DEVNULL,
-            )
-            return res.returncode == 0
+            try:
+                res = run(
+                    [
+                        "podman",
+                        "exec",
+                        container_id,
+                        "bash",
+                        "-c",
+                        f"echo > /dev/tcp/{binary_itf[0]}/{binary_itf[1]}",
+                    ],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                    timeout=5,
+                )
+                return res.returncode == 0
+            except subprocess.TimeoutExpired:
+                return False
 
+        n = len(self.cluster.nodes)
+        first = min(10.0 + n * 0.3, 60.0)
+        step = min(1.0 + n * 0.05, 5.0)
         remaining = remaining_timeout()
-        if not common.wait_for(func=is_binary_interface_listening, timeout=remaining, step=0.2):
+        if not common.wait_for(func=is_binary_interface_listening, timeout=remaining, first=first, step=step):
             raise TimeoutError(
                 f"Binary interface {binary_itf[0]}:{binary_itf[1]} did not start listening within {timeout} seconds"
             )
@@ -2602,12 +2595,11 @@ class ScyllaPodmanNode(ScyllaNode):
             )
         self.create_container(args)
 
-        # Restart the log streamer if it was stopped (e.g. after do_stop)
-        if not self.log_thread and self.pid:
-            self.log_thread = PodmanLogger(
-                self, os.path.join(self.get_path(), "logs", "system.log")
-            )
-            self.log_thread.start()
+        # Log streaming is on-demand, started when a watch_log_for_* method
+        # is called.  Skipping here avoids one ``podman logs -f`` subprocess
+        # per container.
+        if self._event_monitor and self.pid:
+            self._event_monitor.register(self, self.pid)
 
         # supervisord auto-starts Scylla in fresh containers, so no explicit
         # service_start is needed here.  Only restarted containers (after
@@ -2640,9 +2632,10 @@ class ScyllaPodmanNode(ScyllaNode):
 
     def do_stop(self, gently=True):
         # Stop the log streamer so it doesn't become orphaned
-        if self.log_thread:
-            self.log_thread.stop()
-            self.log_thread = None
+        if self._log_manager and self.pid:
+            self._log_manager.stop_stream(self.pid)
+        if self._event_monitor and self.pid:
+            self._event_monitor.unregister(self.pid)
 
         if not self.pid:
             return
@@ -2760,9 +2753,10 @@ class ScyllaPodmanNode(ScyllaNode):
         super(ScyllaPodmanNode, self).clear(*args, **kwargs)
 
     def remove(self):
-        if self.log_thread:
-            self.log_thread.stop()
-            self.log_thread = None
+        if self._log_manager and self.pid:
+            self._log_manager.stop_stream(self.pid)
+        if self._event_monitor and self.pid:
+            self._event_monitor.unregister(self.pid)
         # Invalidate caches tied to the container — a new container may have
         # different supervisor programs or nodetool support.
         self._cached_supervisor_programs = None
@@ -2822,12 +2816,13 @@ class ScyllaPodmanNode(ScyllaNode):
         return self.status == Status.UP
 
     def _update_podman_status(self):
-        # Cache UP status for _STATUS_CACHE_TTL seconds to avoid podman DB
+        # Cache UP and DOWN status for _STATUS_CACHE_TTL seconds to avoid podman DB
         # lock contention when many threads poll concurrently during the
         # final is_running() wait in start().  Still detects process death
         # within the TTL window, unlike permanent caching.
         now = time.time()
-        if self.status == Status.UP and now - self._last_status_check < self._STATUS_CACHE_TTL:
+        last_check = getattr(self, "_last_status_check", 0.0)
+        if now - last_check < self._STATUS_CACHE_TTL:
             return
         self._last_status_check = now
 
@@ -2847,6 +2842,18 @@ class ScyllaPodmanNode(ScyllaNode):
         if new_status != self.status:
             self.status = new_status
             self._update_config()
+
+    def _notify_container_died(self):
+        """Called by the event monitor when the container dies."""
+        if self.status == Status.UP or self.status == Status.DECOMMISSIONED:
+            self.status = Status.DOWN
+            self._update_config()
+        if self._log_manager and self.pid:
+            self._log_manager.stop_stream(self.pid)
+
+    def _notify_container_started(self):
+        """Called by the event monitor when the container starts/restarts."""
+        pass
 
     def _wait_java_up(self, ip_addr, jmx_port):
         return True
@@ -3043,100 +3050,179 @@ class ScyllaPodmanNode(ScyllaNode):
         super(ScyllaPodmanNode, self).rmtree(path)
 
 
-class PodmanLogger:
-    """Streams podman container logs to a local file.
+class PodmanLogManager:
+    """Manages log streaming for all containers using per-container daemon threads.
 
-    Uses subprocess.Popen so the process can be tracked and stopped cleanly.
+    Each container's log stream runs a ``podman logs -f`` process in a dedicated
+    daemon thread so that log streaming is available for every container regardless
+    of cluster size.
     """
 
-    def __init__(self, node, target_log_file: str):
-        self._node = node
-        self._target_log_file = target_log_file
-        self._process = None
-        self._log_file = None
-        self._reader_thread = None
-        self._stop_event = threading.Event()
+    def __init__(self):
+        self._streams: dict[str, "_LogStreamState"] = {}
 
-    def start(self):
-        """Start streaming container logs to the target file.
-
-        Uses a background thread that reads from ``podman logs -f`` and writes
-        each line to the log file with an explicit flush.  This ensures that
-        ``watch_log_for`` sees new lines promptly, regardless of OS-level
-        write buffering on the pipe-to-file path.
-        """
-        self.stop()  # Clean up any previous process
-        self._stop_event.clear()
-        self._log_file = open(self._target_log_file, "a", encoding="utf-8")
-        try:
-            self._process = Popen(
-                ["podman", "logs", "-f", self._node.pid],
-                stdout=PIPE,
-                stderr=STDOUT,
-            )
-            self._reader_thread = threading.Thread(
-                target=self._reader_loop, daemon=True
-            )
-            self._reader_thread.start()
-        except Exception:
-            if self._process is not None:
-                try:
-                    self._process.kill()
-                    self._process.wait(timeout=5)
-                except Exception:
-                    pass
-                self._process = None
-            self._log_file.close()
-            self._log_file = None
-            raise
-
-    def _reader_loop(self):
-        """Read lines from the podman logs process and write them with flush."""
-        log_file = self._log_file
-        if log_file is None:
+    def start_stream(self, container_id: str, log_file_path: str):
+        """Begin streaming logs for *container_id* to *log_file_path*."""
+        if container_id in self._streams:
             return
+        state = _LogStreamState(log_file_path)
+        self._streams[container_id] = state
+        thread = threading.Thread(
+            target=self._stream_logs,
+            args=(container_id, state),
+            name=f"podman-log-{container_id[:12]}",
+            daemon=True,
+        )
+        thread.start()
+        state.thread = thread
+
+    def stop_stream(self, container_id: str):
+        """Stop the log stream for *container_id*."""
+        state = self._streams.pop(container_id, None)
+        if state is not None:
+            state.stop_event.set()
+
+    def stop_all(self):
+        """Stop all managed log streams."""
+        for container_id, state in list(self._streams.items()):
+            state.stop_event.set()
+        self._streams.clear()
+
+    def _stream_logs(self, container_id, state):
+        """Background: run ``podman logs -f`` and write to the log file."""
         try:
-            for line in self._process.stdout:
-                if self._stop_event.is_set():
-                    break
+            with open(state.log_file_path, "a", encoding="utf-8") as f:
+                process = Popen(
+                    ["podman", "logs", "-f", container_id],
+                    stdout=PIPE,
+                    stderr=STDOUT,
+                )
                 try:
-                    log_file.write(line.decode("utf-8", errors="replace"))
-                    log_file.flush()
+                    for line in process.stdout:
+                        if state.stop_event.is_set():
+                            break
+                        f.write(line.decode("utf-8", errors="replace"))
+                        f.flush()
                 except Exception:
-                    LOGGER.debug(
-                        "Podman log writer error for %s (skipping line)",
-                        self._node.name,
+                    LOGGER.warning(
+                        "Podman log stream exception for %s", container_id,
                         exc_info=True,
                     )
-                    continue
+                finally:
+                    process.terminate()
+                    process.wait(timeout=5)
         except Exception:
-            LOGGER.debug(
-                "Podman log reader stopped for %s", self._node.name, exc_info=True
+            LOGGER.warning(
+                "Podman log stream failed to start for %s", container_id,
+                exc_info=True,
             )
 
+
+class _LogStreamState:
+    """Internal state for a single container's log stream."""
+    __slots__ = ("log_file_path", "stop_event", "thread")
+
+    def __init__(self, log_file_path):
+        self.log_file_path = log_file_path
+        self.stop_event = threading.Event()
+        self.thread = None
+
+
+class PodmanEventMonitor:
+    """A single daemon thread that subscribes to ``podman events --stream``.
+
+    All ``ScyllaPodmanNode`` instances register with this monitor on creation.
+    When a container ``die`` / ``stop`` event is received, the corresponding
+    node is marked ``DOWN`` immediately.  This replaces per-node polling of
+    ``podman exec supervisorctl status`` and per-node ``PodmanLogger`` threads.
+    """
+
+    def __init__(self, log_manager: PodmanLogManager):
+        self._log_manager = log_manager
+        self._containers: dict[str, "ScyllaPodmanNode"] = {}
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+    def register(self, node: "ScyllaPodmanNode", container_id: str):
+        """Register a node so the monitor updates its status on death events."""
+        self.start()
+        with self._lock:
+            self._containers[container_id] = node
+
+    def unregister(self, container_id: str):
+        """Remove a container from the monitor."""
+        with self._lock:
+            self._containers.pop(container_id, None)
+
+    def start(self):
+        """Start the event listener thread."""
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._event_loop, daemon=True,
+            name="podman-event-monitor",
+        )
+        self._thread.start()
+
     def stop(self):
-        """Stop the log streaming process, join the reader thread, and close the file handle."""
+        """Stop the event listener thread."""
         self._stop_event.set()
-        if self._process is not None:
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def _event_loop(self):
+        """Background: run ``podman events --stream`` and dispatch events."""
+        while not self._stop_event.is_set():
             try:
-                self._process.terminate()
-                self._process.wait(timeout=5)
-            except Exception:
-                try:
-                    self._process.kill()
-                    self._process.wait(timeout=5)
-                except Exception:
-                    pass
-            self._process = None
-        # Join the reader thread to ensure it has finished writing before we
-        # close the file handle.  This prevents a race where start() reopens
-        # the file while the old thread is still flushing.
-        if self._reader_thread is not None:
-            self._reader_thread.join(timeout=5)
-            self._reader_thread = None
-        if self._log_file is not None:
+                process = Popen(
+                    ["podman", "events", "--stream", "--format", "json"],
+                    stdout=PIPE,
+                    stderr=DEVNULL,
+                )
+            except FileNotFoundError:
+                LOGGER.warning("podman binary not found; event monitor disabled")
+                return
+
             try:
-                self._log_file.close()
+                for line in process.stdout:
+                    if self._stop_event.is_set():
+                        break
+                    try:
+                        event = json.loads(line)
+                        self._dispatch(event)
+                    except json.JSONDecodeError:
+                        continue
             except Exception:
-                pass
-            self._log_file = None
+                LOGGER.debug("Podman event stream ended", exc_info=True)
+            finally:
+                process.terminate()
+                process.wait(timeout=5)
+                if not self._stop_event.is_set():
+                    time.sleep(1)
+
+    def _dispatch(self, event):
+        """Handle a single podman event."""
+        event_type = event.get("Type")
+        event_status = event.get("Status", "")
+        container_id = event.get("ID")
+        if event_type != "container" or not container_id:
+            return
+
+        with self._lock:
+            node = self._containers.get(container_id)
+
+        if node is None:
+            return
+
+        if event_status in ("die", "stop", "kill", "oom"):
+            node._notify_container_died()
+        elif event_status in ("start", "restart"):
+            node._notify_container_started()
+
+    _event_statuses: dict[str, str] = {}
+
+    def get_event_status(self, container_id):
+        """Return the last-known status for *container_id* or None."""
+        return self._event_statuses.get(container_id)

--- a/ccmlib/scylla_podman_cluster.py
+++ b/ccmlib/scylla_podman_cluster.py
@@ -1,0 +1,2334 @@
+# ccm podman-based scylla cluster with network topology support
+
+import ipaddress
+import json
+import logging
+import os
+import re
+import subprocess
+import threading
+import warnings
+from collections import OrderedDict
+from shutil import copyfile
+from subprocess import run, PIPE, DEVNULL, STDOUT, Popen
+
+from ruamel.yaml import YAML
+
+from ccmlib import common
+from ccmlib.node import (
+    NodeError,
+    Status,
+)
+from ccmlib.scylla_cluster import ScyllaCluster
+from ccmlib.scylla_node import ScyllaNode
+
+LOGGER = logging.getLogger("ccm")
+
+# Subnet allocation scheme:
+#   Rack networks:  10.{prefix_octet}.{rack_idx}.0/24  (rack_idx starts at 1)
+#   Gateway for each rack network: 10.{prefix_octet}.{rack_idx}.254
+#   Node IPs within a rack: 10.{prefix_octet}.{rack_idx}.{node_idx}
+#   Client container on Rack1: 10.{prefix_octet}.1.100
+DEFAULT_RACK_SUBNET_PREFIX = "10.89"
+RACK_GATEWAY_HOST = 254
+CLIENT_CONTAINER_HOST = 100
+SUBNET_PREFIX_ENV = "CCM_PODMAN_SUBNET_PREFIX"
+PODMAN_RESOURCE_OWNER_LABEL = "org.scylladb.ccm-owner-pid"
+_IMAGE_RUNTIME_USER_CACHE = {}
+_CACHE_NEGATIVE = object()  # sentinel for caching failed lookups
+
+
+class PodmanProcess:
+    """A lightweight adapter that mimics subprocess.Popen for podman containers.
+
+    The parent ScyllaNode.start() expects _start_scylla() to return a Popen-like
+    object with a .pid attribute. This adapter wraps a podman container ID to
+    satisfy that interface.
+    """
+
+    def __init__(self, container_id):
+        self.pid = container_id
+        self.returncode = None
+
+    def poll(self):
+        """Check if the container is still running; update returncode if it exited."""
+        if self.returncode is not None:
+            return self.returncode
+        try:
+            res = run(
+                [
+                    "podman",
+                    "inspect",
+                    "--format",
+                    "{{.State.Status}}:{{.State.ExitCode}}",
+                    self.pid,
+                ],
+                stdout=PIPE,
+                stderr=DEVNULL,
+                text=True,
+            )
+            if res.returncode != 0:
+                # Container doesn't exist anymore
+                self.returncode = -1
+                return self.returncode
+            output = res.stdout.strip()
+            if ":" in output:
+                status, exit_code = output.rsplit(":", 1)
+                if status not in ("running", "created"):
+                    self.returncode = int(exit_code)
+        except Exception:
+            LOGGER.debug("poll() failed for container %s", self.pid, exc_info=True)
+        return self.returncode
+
+
+def _get_container_host_pid(container_id):
+    """Return the host-visible PID of a podman container's init process.
+
+    This PID is used with ``nsenter`` to enter the container's network namespace
+    from the host, allowing us to run ``ip`` and ``tc`` commands using the host's
+    binaries rather than requiring them inside the container.
+    """
+    res = run(
+        ["podman", "inspect", "--format", "{{.State.Pid}}", container_id],
+        stdout=PIPE,
+        stderr=PIPE,
+        text=True,
+    )
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"Failed to get host PID for container {container_id}: {res.stderr}"
+        )
+    pid = res.stdout.strip()
+    if not pid or pid == "0":
+        raise RuntimeError(f"Container {container_id} is not running (host PID={pid})")
+    return int(pid)
+
+
+def _nsenter_net_run(container_id, command, check=False):
+    """Run a command inside a container's network namespace using nsenter.
+
+    Uses ``nsenter --user --net`` to enter the container's user and network
+    namespaces, then executes the given command using the *host's* binaries
+    (e.g. ``ip``, ``tc``).  This avoids installing networking tools inside the
+    container image.
+
+    Args:
+        container_id: podman container name or ID
+        command: list of command arguments (e.g. ["ip", "route", "add", ...])
+        check: if True, raise on non-zero exit
+
+    Returns:
+        subprocess.CompletedProcess
+    """
+    host_pid = _get_container_host_pid(container_id)
+    full_cmd = ["nsenter", "-t", str(host_pid), "--user", "--net"] + list(command)
+    res = run(full_cmd, stdout=PIPE, stderr=PIPE, text=True)
+    if check and res.returncode != 0:
+        raise RuntimeError(
+            f"nsenter command failed (container={container_id}): "
+            f"cmd={command} stderr={res.stderr}"
+        )
+    return res
+
+
+def _make_path_container_writable(path):
+    """Make a host path writable for non-root users inside a bind-mounted container.
+
+    Uses 0o775/0o664 (group-writable) rather than world-writable permissions.
+    The container user (uid=999) typically shares the host user's group via
+    podman's user namespace mapping, so group-write is sufficient.
+    """
+    if not os.path.exists(path):
+        return
+
+    def chmod_if_possible(target_path, mode):
+        try:
+            os.chmod(target_path, mode)
+        except OSError as exc:
+            LOGGER.warning(f"Failed to chmod {target_path} to {oct(mode)}: {exc}")
+
+    if os.path.isdir(path):
+        chmod_if_possible(path, 0o775)
+        for root, dirs, files in os.walk(path):
+            for dirname in dirs:
+                chmod_if_possible(os.path.join(root, dirname), 0o775)
+            for filename in files:
+                chmod_if_possible(os.path.join(root, filename), 0o664)
+    else:
+        chmod_if_possible(path, 0o664)
+
+
+def _get_image_runtime_user(image_name):
+    cached = _IMAGE_RUNTIME_USER_CACHE.get(image_name)
+    if cached is not None:
+        return None if cached is _CACHE_NEGATIVE else cached
+
+    res = run(
+        [
+            "podman",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "sh",
+            image_name,
+            "-lc",
+            "id -u; id -g",
+        ],
+        stdout=PIPE,
+        stderr=PIPE,
+        text=True,
+    )
+    if res.returncode != 0:
+        LOGGER.warning(
+            f"Failed to determine runtime user for image {image_name}: {res.stderr}"
+        )
+        _IMAGE_RUNTIME_USER_CACHE[image_name] = _CACHE_NEGATIVE
+        return None
+
+    lines = [line.strip() for line in res.stdout.splitlines() if line.strip()]
+    if len(lines) < 2:
+        LOGGER.warning(
+            f"Unexpected runtime user output for image {image_name}: {res.stdout}"
+        )
+        _IMAGE_RUNTIME_USER_CACHE[image_name] = _CACHE_NEGATIVE
+        return None
+
+    try:
+        runtime_user = (int(lines[0]), int(lines[1]))
+    except ValueError:
+        LOGGER.warning(
+            f"Invalid runtime user output for image {image_name}: {res.stdout}"
+        )
+        _IMAGE_RUNTIME_USER_CACHE[image_name] = _CACHE_NEGATIVE
+        return None
+
+    _IMAGE_RUNTIME_USER_CACHE[image_name] = runtime_user
+    return runtime_user
+
+
+def _chown_path_for_container(path, uid, gid):
+    res = run(
+        ["podman", "unshare", "chown", "-R", f"{uid}:{gid}", path],
+        stdout=PIPE,
+        stderr=PIPE,
+        text=True,
+    )
+    if res.returncode != 0:
+        LOGGER.warning(
+            f"Failed to chown {path} to {uid}:{gid} for container access: {res.stderr}"
+        )
+        return False
+    return True
+
+
+def _list_podman_ipv4_networks():
+    """Return all IPv4 podman network subnets visible to the local podman daemon."""
+    res = run(
+        ["podman", "network", "ls", "--format", "json"],
+        stdout=PIPE,
+        stderr=PIPE,
+        text=True,
+    )
+    if res.returncode != 0:
+        LOGGER.warning(f"Failed to list podman networks: {res.stderr}")
+        return []
+
+    try:
+        networks = json.loads(res.stdout)
+    except json.JSONDecodeError:
+        LOGGER.warning("Failed to parse podman network ls output as JSON")
+        return []
+
+    subnets = []
+    for network in networks:
+        for subnet_info in network.get("subnets", []):
+            subnet = subnet_info.get("subnet")
+            if not subnet:
+                continue
+            try:
+                parsed = ipaddress.ip_network(subnet, strict=False)
+            except ValueError:
+                continue
+            if parsed.version == 4:
+                subnets.append(parsed)
+    return subnets
+
+
+def _find_available_subnet_prefix(exclude_prefixes=None):
+    """Pick a free 10.x.0.0/16 prefix for podman rack networks."""
+    exclude_prefixes = set(exclude_prefixes or [])
+    env_prefix = os.environ.get(SUBNET_PREFIX_ENV)
+    if env_prefix:
+        # Basic validation: must be "10.X" where X is 0-255
+        parts = env_prefix.split(".")
+        if len(parts) != 2 or parts[0] != "10":
+            raise ValueError(
+                f"{SUBNET_PREFIX_ENV}={env_prefix!r} is invalid; "
+                f"expected format '10.X' where X is 0-255"
+            )
+        try:
+            second = int(parts[1])
+        except ValueError:
+            raise ValueError(
+                f"{SUBNET_PREFIX_ENV}={env_prefix!r} is invalid; "
+                f"second octet must be an integer"
+            )
+        if not 0 <= second <= 255:
+            raise ValueError(
+                f"{SUBNET_PREFIX_ENV}={env_prefix!r} is invalid; "
+                f"second octet must be 0-255, got {second}"
+            )
+        return env_prefix
+
+    used_subnets = _list_podman_ipv4_networks()
+    # Start at 10.89 to avoid common ranges: 10.0/8 (cloud VPCs),
+    # 10.88.0.0/16 (podman default CNI bridge).
+    for second_octet in range(89, 256):
+        prefix = f"10.{second_octet}"
+        if prefix in exclude_prefixes:
+            continue
+        candidate = ipaddress.ip_network(f"{prefix}.0.0/16")
+        if any(candidate.overlaps(used_subnet) for used_subnet in used_subnets):
+            continue
+        return prefix
+
+    raise RuntimeError("Could not find a free 10.x.0.0/16 subnet prefix for podman")
+
+
+def _is_subnet_conflict(stderr_text):
+    if not stderr_text:
+        return False
+    lowered = stderr_text.lower()
+    return "subnet" in lowered and ("already used" in lowered or "overlaps" in lowered)
+
+
+class PodmanNetworkTopology:
+    """Manages podman networks for a topology-aware ScyllaDB cluster.
+
+    Creates one podman network per rack. Nodes in the same rack share a network.
+    The host routes between rack subnets. Latency is simulated by applying
+    ``tc``/``netem`` rules via ``nsenter`` from the host into each container's
+    network namespace — the host's ``tc`` binary is used, so no networking
+    tools need to be installed inside the container image.
+    """
+
+    def __init__(
+        self,
+        cluster_name,
+        topology,
+        inter_rack_delay_ms=1,
+        inter_dc_delay_ms=50,
+        packet_loss_percent=0.0,
+        subnet_prefix=DEFAULT_RACK_SUBNET_PREFIX,
+    ):
+        """
+        Args:
+            cluster_name: CCM cluster name (used in network naming)
+            topology: OrderedDict[dc_name -> OrderedDict[rack_name -> node_count]]
+            inter_rack_delay_ms: Latency in ms between racks in the same DC
+            inter_dc_delay_ms: Latency in ms between different DCs
+            packet_loss_percent: Packet loss percentage for cross-DC traffic
+            subnet_prefix: The 10.x prefix used for rack subnets (for example 10.89)
+        """
+        self.cluster_name = cluster_name
+        self.topology = topology
+        if inter_rack_delay_ms < 0:
+            raise ValueError(
+                f"inter_rack_delay_ms must be >= 0, got {inter_rack_delay_ms}"
+            )
+        if inter_dc_delay_ms < 0:
+            raise ValueError(f"inter_dc_delay_ms must be >= 0, got {inter_dc_delay_ms}")
+        if not (0.0 <= packet_loss_percent <= 100.0):
+            raise ValueError(
+                f"packet_loss_percent must be between 0 and 100, got {packet_loss_percent}"
+            )
+        self.inter_rack_delay_ms = inter_rack_delay_ms
+        self.inter_dc_delay_ms = inter_dc_delay_ms
+        self.packet_loss_percent = packet_loss_percent
+        self.subnet_prefix = subnet_prefix
+
+        # Mapping: (dc, rack) -> {network_name, subnet, gateway, rack_idx}
+        self.rack_networks = OrderedDict()
+        # Mapping: node_name -> {dc, rack, ip, network_name, subnet}
+        self.node_assignments = OrderedDict()
+        # Mapping: dc_name -> set of rack subnets in that DC
+        self.dc_subnets = {}
+        # Mapping: sanitized network_name -> original (dc, rack), to detect
+        # distinct topology names sanitizing to the same network name.
+        self._network_name_sources = {}
+
+        self._build_assignments()
+
+    def _build_assignments(self):
+        """Build the IP/network assignments from the topology."""
+        rack_idx = 0
+        node_idx_global = 0
+
+        for dc, racks in self.topology.items():
+            dc_rack_subnets = []
+            for rack, node_count in racks.items():
+                rack_idx += 1
+                if rack_idx > 255:
+                    raise ValueError(
+                        f"Too many racks ({rack_idx}): max 255 racks supported "
+                        f"(subnet {self.subnet_prefix}.{rack_idx}.0/24 would be invalid)"
+                    )
+                subnet = f"{self.subnet_prefix}.{rack_idx}.0/24"
+                gateway = f"{self.subnet_prefix}.{rack_idx}.{RACK_GATEWAY_HOST}"
+                network_name = self._network_name(dc, rack)
+
+                # Validate node count won't collide with gateway
+                if node_count >= RACK_GATEWAY_HOST:
+                    raise ValueError(
+                        f"Too many nodes ({node_count}) in {dc}/{rack}: "
+                        f"max {RACK_GATEWAY_HOST - 1} nodes per rack "
+                        f"(gateway is at .{RACK_GATEWAY_HOST})"
+                    )
+
+                self.rack_networks[(dc, rack)] = {
+                    "network_name": network_name,
+                    "subnet": subnet,
+                    "gateway": gateway,
+                    "rack_idx": rack_idx,
+                }
+                dc_rack_subnets.append(subnet)
+
+                for node_offset in range(1, node_count + 1):
+                    node_idx_global += 1
+                    node_name = f"node{node_idx_global}"
+                    ip = f"{self.subnet_prefix}.{rack_idx}.{node_offset}"
+                    self.node_assignments[node_name] = {
+                        "dc": dc,
+                        "rack": rack,
+                        "ip": ip,
+                        "network_name": network_name,
+                        "subnet": subnet,
+                        "rack_idx": rack_idx,
+                    }
+            self.dc_subnets[dc] = dc_rack_subnets
+
+        # Validate that the first rack can fit the client container IP
+        if self.rack_networks:
+            first_rack_key = list(self.rack_networks.keys())[0]
+            first_rack_nodes = self.topology[first_rack_key[0]][first_rack_key[1]]
+            if first_rack_nodes >= CLIENT_CONTAINER_HOST:
+                raise ValueError(
+                    f"Too many nodes ({first_rack_nodes}) in first rack: "
+                    f"max {CLIENT_CONTAINER_HOST - 1} nodes in first rack "
+                    f"(client container uses .{CLIENT_CONTAINER_HOST})"
+                )
+
+    def _network_name(self, dc, rack):
+        """Generate a podman network name for a rack.
+
+        Raises ValueError if two distinct (dc, rack) pairs sanitize to the
+        same network name (e.g. "a_b" and "a-b" both becoming "a-b").
+        """
+
+        # Sanitize names for podman (alphanumeric + hyphens only)
+        def sanitize(name):
+            # Replace any non-alphanumeric character with a hyphen, then collapse
+            # multiple hyphens and strip leading/trailing hyphens
+            return re.sub(r"-+", "-", re.sub(r"[^a-z0-9-]", "-", name.lower())).strip(
+                "-"
+            )
+
+        safe_cluster = sanitize(self.cluster_name)
+        safe_dc = sanitize(dc)
+        safe_rack = sanitize(rack)
+        name = f"ccm-{safe_cluster}-{safe_dc}-{safe_rack}"
+
+        source = (dc, rack)
+        existing_source = self._network_name_sources.get(name)
+        if existing_source is not None and existing_source != source:
+            raise ValueError(
+                f"DC/rack names {existing_source} and {source} both sanitize to "
+                f"the same podman network name {name!r}; rename one to avoid "
+                "a subnet conflict"
+            )
+        self._network_name_sources[name] = source
+        return name
+
+    def reassign_subnet_prefix(self, subnet_prefix):
+        self.subnet_prefix = subnet_prefix
+        self.rack_networks = OrderedDict()
+        self.node_assignments = OrderedDict()
+        self.dc_subnets = {}
+        self._build_assignments()
+
+    def create_networks(self):
+        """Create all podman networks for the topology."""
+        for (dc, rack), info in self.rack_networks.items():
+            name = info["network_name"]
+            subnet = info["subnet"]
+            gateway = info["gateway"]
+            # Remove existing network if present (idempotent)
+            run(["podman", "network", "rm", "-f", name], stdout=DEVNULL, stderr=DEVNULL)
+            res = run(
+                [
+                    "podman",
+                    "network",
+                    "create",
+                    "--label",
+                    f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}",
+                    "--subnet",
+                    subnet,
+                    "--gateway",
+                    gateway,
+                    name,
+                ],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+            )
+            if res.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to create podman network {name}: {res.stderr}"
+                )
+            LOGGER.debug(f"Created podman network {name} ({subnet})")
+
+    def destroy_networks(self):
+        """Remove all podman networks for this topology."""
+        for (dc, rack), info in self.rack_networks.items():
+            name = info["network_name"]
+            run(["podman", "network", "rm", "-f", name], stdout=DEVNULL, stderr=DEVNULL)
+            LOGGER.debug(f"Removed podman network {name}")
+
+    def get_node_ip(self, node_name):
+        """Get the assigned rack IP for a node."""
+        return self.node_assignments[node_name]["ip"]
+
+    def get_node_network(self, node_name):
+        """Get the podman network name for a node's rack."""
+        return self.node_assignments[node_name]["network_name"]
+
+    def get_all_rack_subnets(self):
+        """Return list of all rack subnets."""
+        return [info["subnet"] for info in self.rack_networks.values()]
+
+    def get_foreign_subnets(self, node_name):
+        """Get subnets that are not the node's own rack subnet, grouped by relationship.
+
+        Returns:
+            dict with keys 'inter_rack' and 'inter_dc', each a list of subnet strings.
+        """
+        node_info = self.node_assignments[node_name]
+        own_dc = node_info["dc"]
+        own_subnet = node_info["subnet"]
+
+        inter_rack = []
+        inter_dc = []
+
+        for (dc, rack), info in self.rack_networks.items():
+            if info["subnet"] == own_subnet:
+                continue
+            if dc == own_dc:
+                inter_rack.append(info["subnet"])
+            else:
+                inter_dc.append(info["subnet"])
+
+        return {"inter_rack": inter_rack, "inter_dc": inter_dc}
+
+    def get_routes_for_node(self, node_name):
+        """Get the ip route commands needed inside a container for cross-rack connectivity.
+
+        Returns a list of (destination_subnet, gateway_ip) tuples.
+        """
+        node_info = self.node_assignments[node_name]
+        own_subnet = node_info["subnet"]
+        own_gateway = self.rack_networks[(node_info["dc"], node_info["rack"])][
+            "gateway"
+        ]
+
+        routes = []
+        for (dc, rack), info in self.rack_networks.items():
+            if info["subnet"] != own_subnet:
+                routes.append((info["subnet"], own_gateway))
+        return routes
+
+    def build_tc_commands(self, node_name):
+        """Build tc/netem commands to apply inside a container.
+
+        Creates a classful qdisc with prio bands:
+        - Band 1: default (no delay) — intra-rack traffic
+        - Band 2: inter-rack same DC (configurable delay)
+        - Band 3: inter-DC (configurable delay + optional packet loss)
+        """
+        foreign = self.get_foreign_subnets(node_name)
+        commands = []
+
+        # Root qdisc: prio with 4 bands, all traffic defaults to band 1 (no delay)
+        commands.append(
+            "tc qdisc add dev eth0 root handle 1: prio bands 4 "
+            "priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+        )
+
+        # Band 2: inter-rack same DC
+        if foreign["inter_rack"] and self.inter_rack_delay_ms > 0:
+            commands.append(
+                f"tc qdisc add dev eth0 parent 1:2 handle 20: "
+                f"netem delay {self.inter_rack_delay_ms}ms"
+            )
+            for subnet in foreign["inter_rack"]:
+                commands.append(
+                    f"tc filter add dev eth0 parent 1:0 protocol ip u32 "
+                    f"match ip dst {subnet} flowid 1:2"
+                )
+
+        # Band 3: inter-DC
+        if foreign["inter_dc"] and self.inter_dc_delay_ms > 0:
+            loss_str = ""
+            if self.packet_loss_percent > 0:
+                loss_str = f" loss {self.packet_loss_percent}%"
+            commands.append(
+                f"tc qdisc add dev eth0 parent 1:3 handle 30: "
+                f"netem delay {self.inter_dc_delay_ms}ms{loss_str}"
+            )
+            for subnet in foreign["inter_dc"]:
+                commands.append(
+                    f"tc filter add dev eth0 parent 1:0 protocol ip u32 "
+                    f"match ip dst {subnet} flowid 1:3"
+                )
+
+        return commands
+
+    def get_client_ip(self):
+        """Return the IP address for the CQL client container (on Rack1 network)."""
+        # Client sits on the first rack network
+        first_rack_key = list(self.rack_networks.keys())[0]
+        rack_idx = self.rack_networks[first_rack_key]["rack_idx"]
+        return f"{self.subnet_prefix}.{rack_idx}.{CLIENT_CONTAINER_HOST}"
+
+    def get_client_network(self):
+        """Return the podman network name for the CQL client container."""
+        first_rack_key = list(self.rack_networks.keys())[0]
+        return self.rack_networks[first_rack_key]["network_name"]
+
+    def to_dict(self):
+        """Serialize network state for persistence.
+
+        Only the topology and delay parameters are persisted. node_assignments
+        and rack_networks are deterministically recomputed from the topology
+        by _build_assignments() on load.
+        """
+        return {
+            "topology": {dc: dict(racks) for dc, racks in self.topology.items()},
+            "inter_rack_delay_ms": self.inter_rack_delay_ms,
+            "inter_dc_delay_ms": self.inter_dc_delay_ms,
+            "packet_loss_percent": self.packet_loss_percent,
+            "subnet_prefix": self.subnet_prefix,
+        }
+
+    @classmethod
+    def from_dict(cls, cluster_name, data):
+        """Deserialize network state."""
+        topology = OrderedDict()
+        for dc, racks in data["topology"].items():
+            topology[dc] = OrderedDict(racks)
+        return cls(
+            cluster_name=cluster_name,
+            topology=topology,
+            inter_rack_delay_ms=data.get("inter_rack_delay_ms", 1),
+            inter_dc_delay_ms=data.get("inter_dc_delay_ms", 50),
+            packet_loss_percent=data.get("packet_loss_percent", 0.0),
+            subnet_prefix=data.get("subnet_prefix", DEFAULT_RACK_SUBNET_PREFIX),
+        )
+
+
+class ScyllaPodmanCluster(ScyllaCluster):
+    """A ScyllaDB cluster running in podman containers with network topology support.
+
+    Each node runs in a podman container on a per-rack podman network.
+    The host routes between rack networks.  Latency simulation uses the
+    host's ``tc``/``netem`` binaries applied via ``nsenter`` into each
+    container's network namespace — no networking tools need to be
+    installed inside the container image.
+    A dedicated CQL client container sits on Rack1's network.
+    """
+
+    def __init__(self, *args, **kwargs):
+        podman_img = kwargs.pop("podman_image", None)
+        docker_img = kwargs.pop("docker_image", None)
+        self.podman_image = podman_img or docker_img
+        if not self.podman_image:
+            raise common.ArgumentError(
+                "podman_image is required for ScyllaPodmanCluster"
+            )
+        self.inter_rack_delay_ms = kwargs.pop("inter_rack_delay_ms", 1)
+        self.inter_dc_delay_ms = kwargs.pop("inter_dc_delay_ms", 50)
+        self.packet_loss_percent = kwargs.pop("packet_loss_percent", 0.0)
+        self.network_topology = None
+        self._client_container_id = None
+        # Pass docker_image to parent so it skips install_dir validation
+        kwargs["docker_image"] = self.podman_image
+        super(ScyllaPodmanCluster, self).__init__(*args, **kwargs)
+
+    def get_install_dir(self):
+        return None
+
+    def populate(
+        self,
+        nodes,
+        debug=False,
+        tokens=None,
+        use_vnodes=False,
+        ipprefix=None,
+        ipformat=None,
+    ):
+        """Populate the cluster, creating podman networks and assigning IPs based on topology."""
+        if ipprefix is not None:
+            LOGGER.warning(
+                "ipprefix is ignored for podman clusters (IPs come from network topology)"
+            )
+        if ipformat is not None:
+            LOGGER.warning(
+                "ipformat is ignored for podman clusters (IPs come from network topology)"
+            )
+
+        # Parse the topology exactly like the base class does
+        topology = self._parse_topology(nodes)
+
+        # Create the network topology manager
+        tried_prefixes = set()
+        self.network_topology = None
+        max_subnet_retries = 167  # 10.89 through 10.255
+        for _attempt in range(max_subnet_retries):
+            subnet_prefix = _find_available_subnet_prefix(
+                exclude_prefixes=tried_prefixes
+            )
+            tried_prefixes.add(subnet_prefix)
+            self.network_topology = PodmanNetworkTopology(
+                cluster_name=self.name,
+                topology=topology,
+                inter_rack_delay_ms=self.inter_rack_delay_ms,
+                inter_dc_delay_ms=self.inter_dc_delay_ms,
+                packet_loss_percent=self.packet_loss_percent,
+                subnet_prefix=subnet_prefix,
+            )
+            try:
+                self.network_topology.create_networks()
+                break
+            except RuntimeError as exc:
+                # Clean up any partially-created networks before retrying
+                self.network_topology.destroy_networks()
+                if not _is_subnet_conflict(str(exc)) or os.environ.get(
+                    SUBNET_PREFIX_ENV
+                ):
+                    raise
+                LOGGER.warning(
+                    f"Podman subnet prefix {subnet_prefix} is already in use; retrying with another prefix"
+                )
+        else:
+            raise RuntimeError(
+                f"Could not find a free subnet prefix after {max_subnet_retries} attempts"
+            )
+
+        # Override ipformat so that get_node_ip returns our assigned IPs
+        # We can't use the standard ip format since IPs come from the topology
+        self.use_vnodes = use_vnodes
+
+        # Build node_locations from topology
+        node_count = 0
+        node_locations = []
+        dcs = list(topology.keys())
+        for dc, racks in topology.items():
+            for rack, n in racks.items():
+                node_count += n
+                for _ in range(n):
+                    node_locations.append((dc, rack))
+
+        if dcs != [None]:
+            self.set_configuration_options(values={"endpoint_snitch": self.snitch})
+
+        if node_count < 1:
+            raise common.ArgumentError(f"invalid topology {topology}")
+
+        for i in range(1, node_count + 1):
+            if f"node{i}" in self.nodes:
+                raise common.ArgumentError(f"Cannot create existing node node{i}")
+
+        if tokens is None and not use_vnodes:
+            if dcs is None or len(dcs) <= 1:
+                tokens = self.balanced_tokens(node_count)
+            else:
+                tokens = self.balanced_tokens_across_dcs(node_locations)
+
+        try:
+            for i in range(1, node_count + 1):
+                tk = None
+                if tokens is not None and i - 1 < len(tokens):
+                    tk = tokens[i - 1]
+                dc, rack = node_locations[i - 1]
+                self.new_node(
+                    i, debug=debug, initial_token=tk, data_center=dc, rack=rack
+                )
+                self._update_config()
+        except Exception:
+            # Clean up any partially-created node directories, then destroy
+            # networks to avoid leaked resources.
+            LOGGER.warning(
+                "populate() failed; cleaning up %d node(s) and podman networks for cluster %s",
+                len(self.nodes), self.name,
+            )
+            for node in list(self.nodes.values()):
+                try:
+                    LOGGER.debug("Removing node directory: %s", node.get_path())
+                    common.rmdirs(node.get_path())
+                except Exception:
+                    pass
+            self.nodes.clear()
+            self.network_topology.destroy_networks()
+            raise
+
+        self.cluster_cleanup()
+        return self
+
+    def _parse_topology(self, nodes):
+        """Parse the nodes argument into an OrderedDict topology, same as base class."""
+        topology = OrderedDict()
+        if isinstance(nodes, int):
+            topology["dc1"] = OrderedDict([("RAC1", nodes)])
+        elif isinstance(nodes, list):
+            for i, n in enumerate(nodes):
+                dc = f"dc{i + 1}"
+                topology[dc] = OrderedDict([("RAC1", n)])
+        elif isinstance(nodes, dict):
+            for dc, x in nodes.items():
+                if isinstance(x, int):
+                    topology[dc] = OrderedDict([("RAC1", x)])
+                elif isinstance(x, list):
+                    topology[dc] = OrderedDict(
+                        [(f"RAC{i}", n) for i, n in enumerate(x, start=1)]
+                    )
+                elif isinstance(x, dict):
+                    topology[dc] = OrderedDict([(rack, n) for rack, n in x.items()])
+                else:
+                    raise common.ArgumentError(
+                        f"invalid dc racks type {type(x)}: {x}: nodes={nodes}"
+                    )
+        else:
+            raise common.ArgumentError(f"invalid nodes type {type(nodes)}: {nodes}")
+        return topology
+
+    def get_node_ip(self, nodeid):
+        """Return the rack IP for a node from the topology."""
+        if self.network_topology:
+            node_name = f"node{nodeid}"
+            if node_name in self.network_topology.node_assignments:
+                return self.network_topology.node_assignments[node_name]["ip"]
+        # Fallback during early initialization
+        return super().get_node_ip(nodeid)
+
+    def create_node(
+        self,
+        name,
+        auto_bootstrap,
+        storage_interface,
+        jmx_port,
+        remote_debug_port,
+        initial_token,
+        save=True,
+        binary_interface=None,
+        thrift_interface=None,
+    ):
+        if thrift_interface is not None:
+            warnings.warn(
+                "thrift_interface is deprecated and will be removed in a future version",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return ScyllaPodmanNode(
+            name,
+            self,
+            auto_bootstrap,
+            storage_interface,
+            jmx_port,
+            remote_debug_port,
+            initial_token,
+            save=save,
+            binary_interface=binary_interface,
+            scylla_manager=self._scylla_manager,
+        )
+
+    def start_client_container(self):
+        """Start a lightweight CQL client container on Rack1's network."""
+        if not self.network_topology:
+            return
+
+        client_name = self._client_container_name()
+        client_ip = self.network_topology.get_client_ip()
+        client_network = self.network_topology.get_client_network()
+
+        # Remove if already exists
+        run(["podman", "rm", "-f", client_name], stdout=DEVNULL, stderr=DEVNULL)
+
+        # Use the Scylla image so cqlsh is available in the client container.
+        res = run(
+            [
+                "podman",
+                "run",
+                "-d",
+                "--name",
+                client_name,
+                "--network",
+                client_network,
+                "--ip",
+                client_ip,
+                "--label",
+                f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}",
+                "--cap-add",
+                "NET_ADMIN",
+                "--entrypoint",
+                "sh",
+                self.podman_image,
+                "-lc",
+                "sleep infinity",
+            ],
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+
+        if res.returncode != 0:
+            raise RuntimeError(f"Failed to start CQL client container: {res.stderr}")
+
+        self._client_container_id = res.stdout.strip()
+        LOGGER.debug(f"Started CQL client container {client_name} at {client_ip}")
+
+        # Set up routes to other rack subnets.
+        # Routes and tc rules use nsenter (host's ip/tc binaries), so no tools
+        # need to be installed inside the client container.
+        first_node_name = next(iter(self.network_topology.node_assignments))
+        self._setup_container_routes(client_name, first_node_name)
+
+        # Apply tc rules (client is on Rack1, so same rules as a Rack1 node)
+        tc_commands = self.network_topology.build_tc_commands(first_node_name)
+        for cmd in tc_commands:
+            _nsenter_net_run(self._client_container_id, ["sh", "-c", cmd])
+
+    def stop_client_container(self):
+        """Stop and remove the CQL client container."""
+        client_name = self._client_container_name()
+        run(["podman", "rm", "-f", client_name], stdout=DEVNULL, stderr=DEVNULL)
+        self._client_container_id = None
+
+    def _client_container_name(self):
+        return f"ccm-{self.name}-client"
+
+    def get_client_contact_points(self):
+        """Return (host, port) list for CQL clients to connect to from the client container.
+
+        The client container is on Rack1's network, so it can reach all nodes
+        by their rack IPs (through host routing).
+        """
+        contact_points = []
+        for node in self.nodelist():
+            if node.is_running():
+                ip = node.network_interfaces["binary"][0]
+                port = node.network_interfaces["binary"][1]
+                contact_points.append((ip, port))
+        return contact_points
+
+    def run_cqlsh_on_client(self, cql_command, node=None):
+        """Execute a CQL command via the client container.
+
+        Args:
+            cql_command: CQL string to execute
+            node: target node (defaults to first node)
+        """
+        if not self._client_container_id:
+            self.start_client_container()
+        if not self._client_container_id:
+            raise RuntimeError("Client container did not start correctly")
+
+        if node is None:
+            node = self.nodelist()[0]
+
+        ip = node.network_interfaces["binary"][0]
+        port = node.network_interfaces["binary"][1]
+
+        res = run(
+            [
+                "podman",
+                "exec",
+                self._client_container_id,
+                "cqlsh",
+                ip,
+                str(port),
+                "-e",
+                cql_command,
+            ],
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+        return res.stdout, res.stderr
+
+    def _setup_container_routes(self, container_name_or_id, node_name):
+        """Set up IP routes inside a container for cross-rack connectivity.
+
+        Uses ``nsenter`` to run the host's ``ip`` binary in the container's
+        network namespace.
+        """
+        if not self.network_topology:
+            return
+
+        routes = self.network_topology.get_routes_for_node(node_name)
+        for dest_subnet, gateway in routes:
+            res = _nsenter_net_run(
+                container_name_or_id,
+                ["ip", "route", "add", dest_subnet, "via", gateway],
+            )
+            if res.returncode != 0:
+                LOGGER.warning(
+                    f"Failed to add route {dest_subnet} via {gateway} "
+                    f"in {container_name_or_id}: {res.stderr}"
+                )
+
+    def start_nodes(
+        self,
+        nodes=None,
+        no_wait=False,
+        verbose=False,
+        wait_for_binary_proto=None,
+        wait_other_notice=None,
+        wait_normal_token_owner=None,
+        jvm_args=None,
+        profile_options=None,
+        quiet_start=False,
+    ):
+        """Start nodes, then apply tc/netem rules for latency simulation.
+
+        Overrides ScyllaCluster.start_nodes() to defer tc rule application
+        until after all nodes have their CQL interface ready.  This avoids
+        Raft topology bootstrap being slowed by artificial inter-DC latency,
+        which can cause joins to exceed the wait timeout.
+        """
+        started = super().start_nodes(
+            nodes=nodes,
+            no_wait=no_wait,
+            verbose=verbose,
+            wait_for_binary_proto=wait_for_binary_proto,
+            wait_other_notice=wait_other_notice,
+            wait_normal_token_owner=wait_normal_token_owner,
+            jvm_args=jvm_args,
+            profile_options=profile_options,
+            quiet_start=quiet_start,
+        )
+        # Apply tc/netem rules now that all nodes are running
+        if self.network_topology:
+            for node in self.nodelist():
+                if node.is_running() and node.pid:
+                    node._apply_tc_rules()
+        return started
+
+    def clear(self):
+        """Remove all containers and networks, then wipe node data directories.
+
+        Overrides Cluster.clear() because the base implementation only stops
+        the Scylla process inside containers via supervisorctl, leaving the
+        containers themselves running. This override force-removes containers
+        and cleans up podman networks before wiping data, ensuring no leaks.
+        """
+        # Force-stop and remove all node containers (podman rm -f handles running containers)
+        try:
+            self.stop_client_container()
+        except Exception:
+            LOGGER.warning(
+                "Failed to stop client container during clear()", exc_info=True
+            )
+        for n in list(self.nodes.values()):
+            try:
+                n.remove()
+            except Exception:
+                LOGGER.warning(
+                    "Failed to remove container for node %s during clear()",
+                    n.name,
+                    exc_info=True,
+                )
+        # Destroy podman networks
+        if self.network_topology:
+            try:
+                self.network_topology.destroy_networks()
+            except Exception:
+                LOGGER.warning(
+                    "Failed to destroy podman networks during clear()", exc_info=True
+                )
+            self.network_topology = None
+        # Wipe node data directories (node.pid is None after remove() so no container access)
+        for n in list(self.nodes.values()):
+            try:
+                n.clear()
+            except Exception:
+                LOGGER.warning(
+                    "Failed to clear data for node %s during clear()",
+                    n.name,
+                    exc_info=True,
+                )
+
+    def remove(
+        self, node=None, wait_other_notice=False, other_nodes=None, remove_node_dir=True
+    ):
+        """Remove the cluster or a single node: stop containers, remove networks."""
+        if node is not None:
+            # Single-node removal: remove only that node's container
+            node.remove()
+            super(ScyllaPodmanCluster, self).remove(
+                node=node,
+                wait_other_notice=wait_other_notice,
+                other_nodes=other_nodes,
+                remove_node_dir=remove_node_dir,
+            )
+        else:
+            # Full cluster removal: remove all containers, client, and networks.
+            # Wrap each step in try/except to ensure we always attempt network
+            # cleanup, even if earlier steps fail.
+            try:
+                self.stop_client_container()
+            except Exception:
+                LOGGER.warning(
+                    "Failed to stop client container during remove()",
+                    exc_info=True,
+                )
+            for n in list(self.nodes.values()):
+                try:
+                    n.remove()
+                except Exception:
+                    LOGGER.warning(
+                        "Failed to remove container for node %s during remove()",
+                        n.name,
+                        exc_info=True,
+                    )
+            try:
+                super(ScyllaPodmanCluster, self).remove(
+                    node=None,
+                    wait_other_notice=wait_other_notice,
+                    other_nodes=other_nodes,
+                    remove_node_dir=remove_node_dir,
+                )
+            finally:
+                if self.network_topology:
+                    try:
+                        self.network_topology.destroy_networks()
+                    except Exception:
+                        LOGGER.warning(
+                            "Failed to destroy podman networks during remove()",
+                            exc_info=True,
+                        )
+
+    def _update_config(self, install_dir=None):
+        """Persist podman and network topology config to cluster.conf."""
+        node_list = [node.name for node in list(self.nodes.values())]
+        seed_list = [node.name for node in self.seeds]
+        filename = os.path.join(self.get_path(), "cluster.conf")
+
+        cluster_config = {
+            "name": self.name,
+            "nodes": node_list,
+            "seeds": seed_list,
+            "partitioner": self.partitioner,
+            "config_options": self._config_options,
+            "dse_config_options": self._dse_config_options,
+            "log_level": getattr(self, "_Cluster__log_level", "INFO"),
+            "use_vnodes": self.use_vnodes,
+            "id": self.id,
+            "ipprefix": self.ipprefix,
+            "docker_image": self.podman_image,
+        }
+        if self.network_topology:
+            cluster_config["network_topology"] = self.network_topology.to_dict()
+
+        with open(filename, "w") as f:
+            YAML().dump(cluster_config, f)
+
+    def remove_dir_with_retry(self, path):
+        """Use podman to fix permissions before removing directories."""
+        run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "-v",
+                f"{path}:/node",
+                "busybox",
+                "chmod",
+                "-R",
+                "777",
+                "/node",
+            ],
+            stdout=DEVNULL,
+            stderr=DEVNULL,
+        )
+        super(ScyllaPodmanCluster, self).remove_dir_with_retry(path)
+
+    @staticmethod
+    def is_docker():
+        return True
+
+    @staticmethod
+    def is_podman():
+        return True
+
+
+class ScyllaPodmanNode(ScyllaNode):
+    """A ScyllaDB node running in a podman container with topology-aware networking.
+
+    TODO: Cluster startup takes ~2 minutes per node (3-node cluster ~6-7 min total).
+          This is significantly longer than expected; investigate root cause.
+          Candidates: supervisorctl update triggering a second Scylla start cycle,
+          gossip ring settling with --seeds handshake, or iproute install latency.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs["save"] = False
+        self.share_directories = [
+            "data",
+            "commitlogs",
+            "hints",
+            "view_hints",
+            "saved_caches",
+            "keys",
+            "logs",
+        ]
+        super(ScyllaPodmanNode, self).__init__(*args, **kwargs)
+        self.base_data_path = "/usr/lib/scylla"
+        self.local_base_data_path = os.path.join(self.get_path(), "data")
+        self.local_yaml_path = os.path.join(self.get_path(), "conf")
+        dir_name = os.path.basename(os.path.dirname(self.cluster.get_path())).lstrip(".")
+        self.podman_name = f"{dir_name}-{self.cluster.name}-{self.name}"
+        self.jmx_port = "7199"
+        self.log_thread = None
+        self._cached_nodetool_support = {}
+
+    def _supervisor_program_names(self):
+        if self.pid is None:
+            return set()
+        # Return cached result if available (program names don't change
+        # during the lifetime of a container).
+        if (
+            hasattr(self, "_cached_supervisor_programs")
+            and self._cached_supervisor_programs
+        ):
+            return self._cached_supervisor_programs
+        res = run(
+            ["podman", "exec", self.pid, "supervisorctl", "status"],
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+        # supervisorctl status exits with code 1 whenever any process is not
+        # RUNNING (e.g. STOPPED after a graceful stop).  The output is still
+        # valid program-list output, so parse it regardless of returncode.
+        # Only bail out if stdout is completely empty (podman exec failed).
+        if not res.stdout.strip():
+            return set()
+        programs = {
+            line.split()[0]
+            for line in res.stdout.splitlines()
+            if line.strip() and ":" not in line.split()[0]
+        }
+        if programs:
+            self._cached_supervisor_programs = programs
+        return programs
+
+    def _scylla_service_name(self):
+        programs = self._supervisor_program_names()
+        if "scylla" in programs:
+            return "scylla"
+        return "scylla-server"
+
+    def _jmx_service_name(self):
+        programs = self._supervisor_program_names()
+        if "scylla-jmx" in programs:
+            return "scylla-jmx"
+        return None
+
+    @property
+    def has_jmx(self):
+        return self._jmx_service_name() is not None
+
+    def nodetool(self, cmd, capture_output=True, wait=True, timeout=None, verbose=True):
+        """Run nodetool inside the podman container via 'podman exec'."""
+        if self.pid is None:
+            raise RuntimeError(
+                f"Cannot run nodetool on {self.name}: no running container"
+            )
+        nodetool = ["podman", "exec", self.pid, "scylla", "nodetool"]
+        # Check if the command is supported by the native nodetool
+        command = next(
+            (arg for arg in cmd.split() if not arg.startswith("-")), None
+        )
+        if command is None:
+            raise RuntimeError(f"Could not determine nodetool subcommand from: {cmd!r}")
+        cache = getattr(self, "_cached_nodetool_support", None)
+        if cache is None:
+            cache = {}
+            self._cached_nodetool_support = cache
+        if command not in cache:
+            try:
+                subprocess.check_call(
+                    nodetool + [command, "--help"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.STDOUT,
+                )
+                cache[command] = True
+            except subprocess.CalledProcessError:
+                cache[command] = False
+        if cache[command]:
+            nodetool.extend(["-h", "localhost", "-p", str(self.api_port)])
+            nodetool.extend(cmd.split())
+            return self._do_run_nodetool(
+                nodetool, capture_output, wait, timeout, verbose
+            )
+
+        if not self.has_jmx:
+            raise RuntimeError(
+                f"Node {self.name}: native nodetool does not support '{cmd}' "
+                f"and JMX is not available for fallback"
+            )
+        # Fall back to java nodetool via JMX (running inside the container)
+        jmx_nodetool = [
+            "podman",
+            "exec",
+            self.pid,
+            "nodetool",
+            f"-Dcom.scylladb.apiPort={self.api_port}",
+        ] + cmd.split()
+        return self._do_run_nodetool(
+            jmx_nodetool, capture_output, wait, timeout, verbose
+        )
+
+    def _prepare_bind_mounts(self):
+        _make_path_container_writable(self.local_yaml_path)
+        runtime_user = _get_image_runtime_user(self.cluster.podman_image)
+        for host_path in [
+            os.path.join(self.get_path(), directory)
+            for directory in self.share_directories
+        ]:
+            _make_path_container_writable(host_path)
+            if runtime_user is not None:
+                uid, gid = runtime_user
+                _chown_path_for_container(host_path, uid, gid)
+                # After handing ownership to the container user via podman unshare,
+                # the host user (uid != container subuid) can no longer write into
+                # these directories.  Run chmod a+rwX inside the same user-namespace
+                # so that both the container user AND the host user retain write
+                # access.  This is critical for the logs/ directory: PodmanLogger
+                # opens logs/system.log from the host side after the container has
+                # taken ownership of the directory.
+                res = run(
+                    ["podman", "unshare", "chmod", "-R", "a+rwX", host_path],
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    text=True,
+                )
+                if res.returncode != 0:
+                    LOGGER.warning(
+                        f"Failed to chmod {host_path} to a+rwX via podman unshare: {res.stderr}"
+                    )
+                _make_path_container_writable(host_path)
+
+    def _get_directories(self):
+        dirs = {}
+        for dir_name in self.share_directories + ["conf"]:
+            dirs[dir_name] = os.path.join(self.get_path(), dir_name)
+        return dirs
+
+    def is_scylla(self):
+        return True
+
+    @staticmethod
+    def is_docker():
+        return True
+
+    @staticmethod
+    def is_podman():
+        return True
+
+    def read_scylla_yaml(self):
+        conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
+        with open(conf_file, "r") as f:
+            return YAML().load(f)
+
+    def update_yaml(self):
+        """Extract config from image if needed, then update scylla.yaml with podman-specific settings."""
+        if not os.path.exists(os.path.join(self.local_yaml_path, "scylla.yaml")):
+            # Extract /etc/scylla from the image using a temporary container
+            res = run(
+                [
+                    "podman",
+                    "run",
+                    "-d",
+                    "--label",
+                    f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}",
+                    self.cluster.podman_image,
+                    "tail",
+                    "-f",
+                    "/dev/null",
+                ],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+            )
+            if res.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to start temp container for config extraction: {res.stderr}"
+                )
+            container_id = res.stdout.strip()
+            try:
+                # Copy /etc/scylla/ contents from the container
+                cp_res = run(
+                    [
+                        "podman",
+                        "container",
+                        "cp",
+                        "-a",
+                        f"{container_id}:/etc/scylla/",
+                        "-",
+                    ],
+                    stdout=PIPE,
+                    stderr=PIPE,
+                )
+                if cp_res.returncode == 0:
+                    # Extract the tar archive into the local yaml path
+                    # Use --skip-old-files instead of --keep-old-files to avoid
+                    # spurious warnings about existing files
+                    tar_res = run(
+                        [
+                            "tar",
+                            "--skip-old-files",
+                            "-x",
+                            "--strip-components=1",
+                            "-C",
+                            self.local_yaml_path,
+                        ],
+                        input=cp_res.stdout,
+                        stderr=PIPE,
+                    )
+                    if tar_res.returncode != 0:
+                        LOGGER.warning(
+                            f"Failed to extract scylla config: {tar_res.stderr}"
+                        )
+                else:
+                    LOGGER.warning(
+                        f"Failed to copy config from container: {cp_res.stderr}"
+                    )
+            finally:
+                run(
+                    ["podman", "rm", "-f", container_id],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                )
+        super(ScyllaPodmanNode, self).update_yaml()
+
+        conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
+        data = self.read_scylla_yaml()
+
+        # Get the node's rack IP from the network topology
+        node_ip = self._get_rack_ip()
+
+        # ScyllaDB addresses
+        data["listen_address"] = node_ip
+        data["broadcast_address"] = node_ip
+        data["rpc_address"] = "0.0.0.0"
+        data["broadcast_rpc_address"] = node_ip
+        data["api_address"] = "0.0.0.0"
+
+        if "alternator_port" in data or "alternator_https_port" in data:
+            data["alternator_address"] = "0.0.0.0"
+
+        # Data directories inside the container
+        data["data_file_directories"] = [os.path.join(self.base_data_path, "data")]
+        data["commitlog_directory"] = os.path.join(self.base_data_path, "commitlogs")
+        for directory in ["hints", "view_hints", "saved_caches"]:
+            data[f"{directory}_directory"] = os.path.join(
+                self.base_data_path, directory
+            )
+
+        # Handle server encryption options
+        server_encryption_options = data.get("server_encryption_options", {})
+        if server_encryption_options:
+            keys_dir_path = os.path.join(self.get_path(), "keys")
+            for key, file_path in list(server_encryption_options.items()):
+                if os.path.isfile(file_path):
+                    file_name = os.path.split(file_path)[1]
+                    copyfile(src=file_path, dst=os.path.join(keys_dir_path, file_name))
+                    server_encryption_options[key] = os.path.join(
+                        self.base_data_path, "keys", file_name
+                    )
+
+        with open(conf_file, "w") as f:
+            YAML().dump(data, f)
+
+    def _get_rack_ip(self):
+        """Get this node's IP from the cluster's network topology."""
+        if self.cluster.network_topology:
+            return self.cluster.network_topology.get_node_ip(self.name)
+        # Fallback
+        return self.network_interfaces["storage"][0]
+
+    def create_container(self, args):
+        """Create and start the podman container for this node.
+
+        The container is connected to its rack network with a static IP.
+        After creation, IP routes and tc rules are set up.
+        """
+        if self.pid:
+            return
+
+        if not self.cluster.network_topology:
+            raise RuntimeError(
+                f"Cannot create container for {self.name}: "
+                f"cluster network topology is not initialized"
+            )
+
+        node_ip = self._get_rack_ip()
+        network_name = self.cluster.network_topology.get_node_network(self.name)
+
+        # Build seed list
+        node1 = self.cluster.nodelist()[0]
+        seed_args = []
+        if self.name != node1.name:
+            seed_args = ["--seeds", node1.network_interfaces["storage"][0]]
+
+        scylla_yaml = self.read_scylla_yaml()
+        port_args = []
+        if "alternator_port" in scylla_yaml:
+            port_args.extend(["-p", str(scylla_yaml["alternator_port"])])
+        if "alternator_https_port" in scylla_yaml:
+            port_args.extend(["-p", str(scylla_yaml["alternator_https_port"])])
+
+        self._prepare_bind_mounts()
+
+        # Volume mounts
+        # Use :z for SELinux relabeling so rootless podman can read the config
+        mount_args = [
+            "-v",
+            f"{self.local_yaml_path}:/etc/scylla:z",
+            "-v",
+            "/tmp:/tmp",
+        ]
+        for d in self.share_directories:
+            mount_args.extend(
+                [
+                    "-v",
+                    f"{os.path.join(self.get_path(), d)}:{os.path.join(self.base_data_path, d)}:z",
+                ]
+            )
+
+        # Run the container on its rack network
+        cmd = [
+            "podman",
+            "run",
+            *port_args,
+            *mount_args,
+            "--name",
+            self.podman_name,
+            "--network",
+            network_name,
+            "--ip",
+            node_ip,
+            "--label",
+            f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}",
+            "--cap-add",
+            "NET_ADMIN",
+            "-d",
+            self.cluster.podman_image,
+            *seed_args,
+            *args,
+        ]
+        res = run(cmd, stdout=PIPE, stderr=PIPE, text=True)
+
+        if res.returncode != 0:
+            LOGGER.error(res)
+            raise RuntimeError(
+                f"Failed to create podman container {self.podman_name}: {res.stderr}"
+            )
+
+        self.pid = res.stdout.strip()
+
+        try:
+            # Start log streaming (stop any previous logger first for restart case)
+            if self.log_thread:
+                self.log_thread.stop()
+            self.log_thread = PodmanLogger(
+                self, os.path.join(self.get_path(), "logs", "system.log")
+            )
+            self.log_thread.start()
+
+            # TODO: Replace this supervisord-specific readiness check with a runtime-
+            # agnostic container startup probe once the image no longer uses supervisord.
+            def is_container_runtime_ready():
+                res = run(
+                    ["podman", "exec", self.pid, "supervisorctl", "status"],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                )
+                return res.returncode == 0
+
+            if not common.wait_for(
+                func=is_container_runtime_ready, timeout=30, step=0.2
+            ):
+                raise TimeoutError(
+                    f"Container runtime for {self.name} did not become ready within 30 seconds"
+                )
+
+            # Stop scylla so that _start_scylla() can do a controlled
+            # start after routes and tc rules are in place.  We do NOT
+            # modify supervisord config files inside the container —
+            # supervisorctl stop/start is sufficient for lifecycle
+            # control.  The image's default autorestart=true is
+            # harmless: supervisorctl stop sets the desired state to
+            # STOPPED, and supervisord will not auto-restart a process
+            # that was explicitly stopped.  For ungraceful stops
+            # (kill -9), do_stop() calls supervisorctl stop immediately
+            # after the kill to prevent an auto-restart.
+            scylla_service = self._scylla_service_name()
+            self.service_stop(scylla_service)
+            jmx_service = self._jmx_service_name()
+            if jmx_service:
+                self.service_stop(jmx_service)
+
+            # Update network interfaces with the actual rack IP
+            self.network_interfaces = {
+                k: (node_ip, v[1]) for k, v in list(self.network_interfaces.items())
+            }
+
+            # Set up routes to other rack subnets (for cross-rack/DC communication).
+            # Routes and tc rules are applied via nsenter from the host, using
+            # the host's ip/tc binaries — no tools need to be installed inside
+            # the container.
+            self._setup_routes()
+
+            # tc/netem rules are applied later by the cluster's
+            # start_nodes() method — after all nodes are running — so that
+            # artificial latency does not slow down Raft topology bootstrap.
+        except Exception:
+            LOGGER.error(
+                f"Container setup failed for {self.name}, cleaning up container {self.pid}"
+            )
+            if self.log_thread:
+                self.log_thread.stop()
+                self.log_thread = None
+            run(
+                ["podman", "rm", "--volumes", "-f", self.pid],
+                stdout=DEVNULL,
+                stderr=DEVNULL,
+            )
+            self.pid = None
+            raise
+
+    def _setup_routes(self):
+        """Add IP routes inside the container for cross-rack connectivity.
+
+        Uses ``nsenter`` to run the host's ``ip`` binary in the container's
+        network namespace, avoiding any dependency on tools inside the image.
+        """
+        if not self.cluster.network_topology:
+            return
+
+        routes = self.cluster.network_topology.get_routes_for_node(self.name)
+        for dest_subnet, gateway in routes:
+            res = _nsenter_net_run(
+                self.pid,
+                ["ip", "route", "add", dest_subnet, "via", gateway],
+            )
+            if res.returncode != 0:
+                LOGGER.warning(
+                    f"Failed to add route {dest_subnet} via {gateway} "
+                    f"in {self.name}: {res.stderr}"
+                )
+
+    def _apply_tc_rules(self):
+        """Apply tc/netem rules for latency simulation.
+
+        Uses ``nsenter`` to run the host's ``tc`` binary in the container's
+        network namespace.  This avoids requiring ``iproute-tc`` inside the
+        container image.
+        """
+        if not self.cluster.network_topology:
+            return
+
+        tc_commands = self.cluster.network_topology.build_tc_commands(self.name)
+        for cmd in tc_commands:
+            res = _nsenter_net_run(self.pid, ["sh", "-c", cmd])
+            if res.returncode != 0:
+                LOGGER.warning(
+                    f"Failed to apply tc rule in {self.name}: "
+                    f"cmd={cmd} stderr={res.stderr}"
+                )
+
+    def service_start(self, service_name):
+        # Clear any FATAL/EXITED state so supervisord will accept the start
+        # command.  After an ungraceful stop (kill -9) the process lands in
+        # FATAL and supervisorctl refuses a plain "start" until cleared.
+        status = self.service_status(service_name)
+        if status and status.upper() in ("FATAL", "EXITED", "BACKOFF"):
+            run(
+                ["podman", "exec", self.pid, "supervisorctl", "clear", service_name],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+            )
+        res = run(
+            [
+                "podman",
+                "exec",
+                self.pid,
+                "supervisorctl",
+                "start",
+                service_name,
+            ],
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+        if res.returncode != 0:
+            LOGGER.debug(res.stdout)
+            raise RuntimeError(
+                f"service {service_name} failed to start in {self.name}: {res.stderr}"
+            )
+
+    def service_stop(self, service_name):
+        res = run(
+            ["podman", "exec", self.pid, "supervisorctl", "stop", service_name],
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+        if res.returncode != 0:
+            LOGGER.debug(res.stdout)
+            LOGGER.error(f"service {service_name} failed to stop: {res.stderr}")
+
+    def service_status(self, service_name):
+        if self.pid is None:
+            return "DOWN"
+        res = run(
+            ["podman", "exec", self.pid, "supervisorctl", "status", service_name],
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+        # supervisorctl status <name> exits with 1 when the process exists but
+        # is not RUNNING (e.g. STOPPED/EXITED/FATAL).  The second token on
+        # stdout is still the status string we need.  Only fall back to DOWN
+        # when podman exec itself failed (empty stdout).
+        parts = res.stdout.split()
+        if len(parts) > 1:
+            return parts[1]
+        LOGGER.debug(f"service {service_name} failed to get status: {res.stderr}")
+        return "DOWN"
+
+    def wait_for_binary_interface(self, **kwargs):
+        timeout = kwargs.get("timeout", 420)
+        process = kwargs.get("process")
+        from_mark = kwargs.get("from_mark")
+
+        if self.cluster.version() and self.cluster.version() >= "1.2":
+            self.watch_log_for(
+                "Starting listening for CQL clients",
+                from_mark=from_mark,
+                process=process,
+                timeout=timeout,
+            )
+
+        binary_itf = self.network_interfaces["binary"]
+
+        def is_binary_interface_listening():
+            if process is not None:
+                if process.poll() is not None:
+                    raise NodeError(
+                        f"Container {self.name} exited (rc={process.returncode}) "
+                        f"before CQL interface became ready"
+                    )
+            res = run(
+                [
+                    "podman",
+                    "exec",
+                    self.pid,
+                    "python3",
+                    "-c",
+                    "import socket; "
+                    "sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM); "
+                    "sock.settimeout(1.0); "
+                    f"sock.connect(('{binary_itf[0]}', {binary_itf[1]})); "
+                    "sock.close()",
+                ],
+                stdout=DEVNULL,
+                stderr=DEVNULL,
+            )
+            return res.returncode == 0
+
+        if not common.wait_for(
+            func=is_binary_interface_listening, timeout=timeout, step=0.2
+        ):
+            raise TimeoutError(
+                f"Binary interface {binary_itf[0]}:{binary_itf[1]} did not start listening within {timeout} seconds"
+            )
+
+    def show(self, only_status=False, show_cluster=True):
+        self._update_podman_status()
+        indent = " " * (len(self.name) + 2)
+        print(f"{self.name}: {self.__get_status_string()}")
+        if not only_status:
+            if show_cluster:
+                print(f"{indent}cluster={self.cluster.name}")
+            print(f"{indent}auto_bootstrap={self.auto_bootstrap}")
+            if self.network_interfaces["binary"] is not None:
+                print(f"{indent}binary={self.network_interfaces['binary']}")
+            print(f"{indent}storage={self.network_interfaces['storage']}")
+            print(f"{indent}jmx_port={self.jmx_port}")
+            print(f"{indent}remote_debug_port={self.remote_debug_port}")
+            print(f"{indent}initial_token={self.initial_token}")
+            if self.data_center:
+                print(f"{indent}data_center={self.data_center}")
+            if self.rack:
+                print(f"{indent}rack={self.rack}")
+            if self.pid:
+                print(f"{indent}pid={self.pid}")
+
+    def __get_status_string(self):
+        if self.status == Status.UNINITIALIZED:
+            return f"{Status.DOWN} (Not initialized)"
+        return self.status
+
+    def _update_config(self):
+        dir_name = self.get_path()
+        if not os.path.exists(dir_name):
+            return
+        filename = os.path.join(dir_name, "node.conf")
+        values = {
+            "name": self.name,
+            "status": self.status,
+            "auto_bootstrap": self.auto_bootstrap,
+            "interfaces": self.network_interfaces,
+            "jmx_port": self.jmx_port,
+            "docker_id": self.pid,  # reuse docker_id key for compat
+            "podman_id": self.pid,
+            "podman_name": self.podman_name,
+            "install_dir": "",
+        }
+        if self.initial_token:
+            values["initial_token"] = self.initial_token
+        if self.remote_debug_port:
+            values["remote_debug_port"] = self.remote_debug_port
+        if self.data_center:
+            values["data_center"] = self.data_center
+        if self.rack:
+            values["rack"] = self.rack
+        if self.workload is not None:
+            values["workload"] = self.workload
+        with open(filename, "w") as f:
+            YAML().dump(values, f)
+
+    @staticmethod
+    def filter_args(args):
+        """Filter command-line args for podman container compatibility.
+
+        The incoming args list from ScyllaNode.start() begins with
+        ``[launch_bin, '--options-file', options_file, ...]``.  We skip
+        everything before the first recognised ``--flag`` so the grouper
+        pairs flags with their values correctly.
+        """
+        # Work on a copy to avoid mutating the caller's list
+        args = list(args)
+        cleaned_args = []
+        if "--overprovisioned" in args:
+            args.remove("--overprovisioned")
+            args += ["--overprovisioned", "1"]
+
+        # Find the start of flag arguments (skip the launch binary and
+        # --options-file <path> preamble by looking for the first element
+        # that starts with '--').
+        flag_start = 0
+        for i, a in enumerate(args):
+            if a.startswith("--"):
+                flag_start = i
+                break
+
+        for arg, value in common.grouper(2, args[flag_start:], padvalue=""):
+            if arg == "--developer-mode" and value == "true":
+                value = "1"
+            if arg in ["--log-to-stdout", "--default-log-level", "--options-file"]:
+                continue
+            if arg in [
+                "--experimental",
+                "--seeds",
+                "--cpuset",
+                "--smp",
+                "--memory",
+                "--reserve-memory",
+                "--overprovisioned",
+                "--io-setup",
+                "--developer-mode",
+                "--listen-address",
+                "--rpc-address",
+                "--broadcast-address",
+                "--broadcast-rpc-address",
+                "--api-address",
+                "--alternator-address",
+                "--alternator-port",
+                "--alternator-https-port",
+                "--alternator-write-isolation",
+                "--disable-version-check",
+                "--authenticator",
+                "--authorizer",
+                "--cluster-name",
+                "--endpoint-snitch",
+                "--replace-address-first-boot",
+                "--replace-node-first-boot",
+                "--blocked-reactor-notify-ms",
+                "--prometheus-address",
+                "--unsafe-bypass-fsync",
+            ]:
+                cleaned_args.append(arg)
+                cleaned_args.append(value)
+        return cleaned_args
+
+    def _start_scylla(
+        self,
+        args,
+        marks,
+        update_pid,
+        wait_other_notice,
+        wait_normal_token_owner,
+        wait_for_binary_proto,
+        ext_env,
+    ):
+        args = self.filter_args(args)
+        if ext_env:
+            LOGGER.warning(
+                "ext_env (SCYLLA_EXT_ENV) is not supported for podman clusters; "
+                "environment settings will be ignored"
+            )
+        self.create_container(args)
+
+        # Restart the log streamer if it was stopped (e.g. after do_stop)
+        if not self.log_thread and self.pid:
+            self.log_thread = PodmanLogger(
+                self, os.path.join(self.get_path(), "logs", "system.log")
+            )
+            self.log_thread.start()
+
+        scylla_status = self.service_status(self._scylla_service_name())
+        if scylla_status and scylla_status.upper() != "RUNNING":
+            self.service_start(self._scylla_service_name())
+
+        if wait_other_notice:
+            for node, mark in marks:
+                node.watch_log_for_alive(self, from_mark=mark)
+
+        if wait_for_binary_proto:
+            podman_process = PodmanProcess(self.pid)
+            self.wait_for_binary_interface(
+                from_mark=self.mark, process=podman_process, timeout=300
+            )
+
+        return PodmanProcess(self.pid)
+
+    def do_stop(self, gently=True):
+        # Stop the log streamer so it doesn't become orphaned
+        if self.log_thread:
+            self.log_thread.stop()
+            self.log_thread = None
+
+        if not self.pid:
+            return
+
+        if gently:
+            jmx_service = self._jmx_service_name()
+            if jmx_service:
+                self.service_stop(jmx_service)
+            self.service_stop(self._scylla_service_name())
+        else:
+            jmx_service = self._jmx_service_name()
+            scylla_service = self._scylla_service_name()
+            # Get the PID of the scylla service, then kill -9 via bash
+            pid_res = run(
+                [
+                    "podman",
+                    "exec",
+                    self.pid,
+                    "supervisorctl",
+                    "pid",
+                    scylla_service,
+                ],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+            )
+            if pid_res.returncode == 0 and pid_res.stdout.strip():
+                _pid = pid_res.stdout.strip()
+                if not _pid.isdigit():
+                    LOGGER.warning(
+                        f"Unexpected PID value from supervisorctl for {scylla_service} "
+                        f"in {self.name}: {_pid!r}"
+                    )
+                else:
+                    run(
+                        [
+                            "podman",
+                            "exec",
+                            self.pid,
+                            "bash",
+                            "-c",
+                            f"kill -9 {_pid}",
+                        ],
+                        stdout=PIPE,
+                        stderr=PIPE,
+                    )
+            # Tell supervisord the service is stopped so autorestart
+            # does not kick in after the kill -9.
+            self.service_stop(scylla_service)
+            if jmx_service:
+                jmx_pid_res = run(
+                    [
+                        "podman",
+                        "exec",
+                        self.pid,
+                        "supervisorctl",
+                        "pid",
+                        jmx_service,
+                    ],
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    text=True,
+                )
+                if jmx_pid_res.returncode == 0 and jmx_pid_res.stdout.strip():
+                    _jmx_pid = jmx_pid_res.stdout.strip()
+                    if not _jmx_pid.isdigit():
+                        LOGGER.warning(
+                            f"Unexpected PID value from supervisorctl for {jmx_service} "
+                            f"in {self.name}: {_jmx_pid!r}"
+                        )
+                    else:
+                        run(
+                            [
+                                "podman",
+                                "exec",
+                                self.pid,
+                                "bash",
+                                "-c",
+                                f"kill -9 {_jmx_pid}",
+                            ],
+                            stdout=PIPE,
+                            stderr=PIPE,
+                        )
+                self.service_stop(jmx_service)
+
+    def wait_until_stopped(self, wait_seconds=None, marks=None, dump_core=True):
+        """Wait until the Scylla service inside the container is no longer running.
+
+        Overrides the parent implementation because self.pid is a container ID
+        string (not an OS pid), so os.kill() would crash.  The container itself
+        stays alive — only the Scylla process inside supervisord is stopped.
+        """
+        marks = marks or []
+        if wait_seconds is None:
+            wait_seconds = 127
+
+        if self.is_running():
+            if not common.wait_for(
+                func=lambda: not self.is_running(),
+                timeout=wait_seconds,
+                step=0.5,
+            ):
+                raise NodeError(f"Problem stopping node {self.name}")
+
+        for node, mark in marks:
+            if node != self:
+                node.watch_log_for_death(self, from_mark=mark)
+
+    def clear(self, *args, **kwargs):
+        # Reclaim ownership of container-written files so the host user can
+        # delete them.  775 is sufficient — data is about to be removed.
+        run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "-v",
+                f"{self.get_path()}:/node",
+                "busybox",
+                "chmod",
+                "-R",
+                "775",
+                "/node",
+            ],
+            stdout=DEVNULL,
+            stderr=DEVNULL,
+        )
+        super(ScyllaPodmanNode, self).clear(*args, **kwargs)
+
+    def remove(self):
+        if self.log_thread:
+            self.log_thread.stop()
+            self.log_thread = None
+        container_id = self.pid
+        # Clear pid first so that any subsequent is_running()/service_status()
+        # calls (e.g. from the parent stop() during teardown) take the early
+        # return path in __update_status instead of exec-ing into a removed
+        # container.
+        self.pid = None
+        # Try to remove by container ID first, then by deterministic podman
+        # name as a fallback.  Log and warn on failures — silent swallowing
+        # of podman rm errors leads to leaked containers.
+        targets = []
+        if container_id:
+            targets.append(str(container_id))
+        if hasattr(self, "podman_name") and self.podman_name:
+            targets.append(self.podman_name)
+        removed = False
+        for target in targets:
+            res = run(
+                ["podman", "rm", "--volumes", "-f", target],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+            )
+            if res.returncode == 0:
+                removed = True
+                break
+            LOGGER.warning(
+                "podman rm -f %s failed (rc=%d): %s",
+                target,
+                res.returncode,
+                res.stderr.strip(),
+            )
+        if not removed and targets:
+            LOGGER.error(
+                "Failed to remove container for %s using targets %s",
+                self.name,
+                targets,
+            )
+
+    def _start_jmx(self, data):
+        jmx_service = self._jmx_service_name()
+        if not jmx_service:
+            return
+        jmx_status = self.service_status(jmx_service)
+        if jmx_status and jmx_status.upper() != "RUNNING":
+            self.service_start(jmx_service)
+
+    def is_running(self):
+        self._update_podman_status()
+        return self.status == Status.UP or self.status == Status.DECOMMISSIONED
+
+    def is_live(self):
+        self._update_podman_status()
+        return self.status == Status.UP
+
+    def _update_podman_status(self):
+        if self.pid is None:
+            if self.status == Status.UP or self.status == Status.DECOMMISSIONED:
+                self.status = Status.DOWN
+                self._update_config()
+            return
+
+        scylla_status = self.service_status(self._scylla_service_name())
+        new_status = Status.UP if (scylla_status and scylla_status.upper() == "RUNNING") else Status.DOWN
+        if new_status != self.status:
+            self.status = new_status
+            self._update_config()
+
+    def _wait_java_up(self, ip_addr, jmx_port):
+        return True
+
+    def _update_pid(self, process):
+        pass
+
+    def get_tool(self, toolname):
+        return ["podman", "exec", "-i", f"{self.pid}", f"{toolname}"]
+
+    def _find_cmd(self, command_name):
+        return self.get_tool(command_name)
+
+    def get_sstables(self, *args, **kwargs):
+        files = super(ScyllaPodmanNode, self).get_sstables(*args, **kwargs)
+        return [f.replace(self.get_path(), "/usr/lib/scylla") for f in files]
+
+    def get_env(self):
+        return os.environ.copy()
+
+    def copy_config_files(self):
+        pass
+
+    def import_config_files(self):
+        self.update_yaml()
+
+    def kill(self, __signal):
+        if self.pid is None:
+            return
+        service_name = self._scylla_service_name()
+        # Get the PID of the service first, then send the signal via bash
+        # (kill is a shell builtin, not a binary in the Scylla container).
+        pid_res = run(
+            [
+                "podman",
+                "exec",
+                self.pid,
+                "supervisorctl",
+                "pid",
+                service_name,
+            ],
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+        if pid_res.returncode != 0 or not pid_res.stdout.strip():
+            LOGGER.debug(
+                f"Failed to get pid of {service_name} in {self.name}: {pid_res.stderr}"
+            )
+            return
+        _pid = pid_res.stdout.strip()
+        if not _pid.isdigit():
+            LOGGER.warning(
+                f"Unexpected PID value from supervisorctl for {service_name} "
+                f"in {self.name}: {_pid!r}"
+            )
+            return
+        run(
+            [
+                "podman",
+                "exec",
+                self.pid,
+                "bash",
+                "-c",
+                f"kill -{__signal} {_pid}",
+            ],
+            stdout=PIPE,
+            stderr=PIPE,
+        )
+
+    def unlink(self, file_path):
+        run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "-v",
+                f"{file_path}:{file_path}",
+                "busybox",
+                "rm",
+                file_path,
+            ],
+            stdout=DEVNULL,
+            stderr=DEVNULL,
+        )
+
+    def chmod(self, file_path, permissions):
+        path_inside = file_path.replace(self.get_path(), self.base_data_path)
+        run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "-v",
+                f"{file_path}:{path_inside}",
+                "busybox",
+                "chmod",
+                "-R",
+                permissions,
+                path_inside,
+            ],
+            stdout=DEVNULL,
+            stderr=DEVNULL,
+        )
+
+    def rmtree(self, path):
+        run(
+            [
+                "podman",
+                "run",
+                "--rm",
+                "-v",
+                f"{self.get_path()}:/node",
+                "busybox",
+                "chmod",
+                "-R",
+                "777",
+                "/node",
+            ],
+            stdout=DEVNULL,
+            stderr=DEVNULL,
+        )
+        super(ScyllaPodmanNode, self).rmtree(path)
+
+
+class PodmanLogger:
+    """Streams podman container logs to a local file.
+
+    Uses subprocess.Popen so the process can be tracked and stopped cleanly.
+    """
+
+    def __init__(self, node, target_log_file: str):
+        self._node = node
+        self._target_log_file = target_log_file
+        self._process = None
+        self._log_file = None
+
+    def start(self):
+        """Start streaming container logs to the target file.
+
+        Uses a background thread that reads from ``podman logs -f`` and writes
+        each line to the log file with an explicit flush.  This ensures that
+        ``watch_log_for`` sees new lines promptly, regardless of OS-level
+        write buffering on the pipe-to-file path.
+        """
+        self.stop()  # Clean up any previous process
+        self._log_file = open(self._target_log_file, "a", encoding="utf-8")
+        try:
+            self._process = Popen(
+                ["podman", "logs", "-f", self._node.pid],
+                stdout=PIPE,
+                stderr=STDOUT,
+            )
+            self._reader_thread = threading.Thread(
+                target=self._reader_loop, daemon=True
+            )
+            self._reader_thread.start()
+        except Exception:
+            self._log_file.close()
+            self._log_file = None
+            raise
+
+    def _reader_loop(self):
+        """Read lines from the podman logs process and write them with flush."""
+        try:
+            for line in self._process.stdout:
+                if self._log_file is None:
+                    break
+                try:
+                    self._log_file.write(line.decode("utf-8", errors="replace"))
+                    self._log_file.flush()
+                except Exception:
+                    LOGGER.debug(
+                        "Podman log writer stopped for %s",
+                        self._node.name,
+                        exc_info=True,
+                    )
+                    break
+        except Exception:
+            LOGGER.debug(
+                "Podman log reader stopped for %s", self._node.name, exc_info=True
+            )
+
+    def stop(self):
+        """Stop the log streaming process and close the file handle."""
+        if self._process is not None:
+            try:
+                self._process.terminate()
+                self._process.wait(timeout=5)
+            except Exception:
+                try:
+                    self._process.kill()
+                except Exception:
+                    pass
+            self._process = None
+        if hasattr(self, "_log_file") and self._log_file is not None:
+            try:
+                self._log_file.close()
+            except Exception:
+                pass
+            self._log_file = None

--- a/ccmlib/scylla_podman_cluster.py
+++ b/ccmlib/scylla_podman_cluster.py
@@ -1,15 +1,18 @@
 # ccm podman-based scylla cluster with network topology support
 
 import ipaddress
+import hashlib
 import json
 import logging
 import os
 import re
 import subprocess
 import threading
+import time
 import warnings
 from collections import OrderedDict
-from shutil import copyfile
+from multiprocessing import cpu_count as host_cpu_count
+from shutil import copy2, copyfile, which
 from subprocess import run, PIPE, DEVNULL, STDOUT, Popen
 
 from ruamel.yaml import YAML
@@ -21,6 +24,7 @@ from ccmlib.node import (
 )
 from ccmlib.scylla_cluster import ScyllaCluster
 from ccmlib.scylla_node import ScyllaNode
+from ccmlib.utils.version import parse_version
 
 LOGGER = logging.getLogger("ccm")
 
@@ -33,9 +37,257 @@ DEFAULT_RACK_SUBNET_PREFIX = "10.89"
 RACK_GATEWAY_HOST = 254
 CLIENT_CONTAINER_HOST = 100
 SUBNET_PREFIX_ENV = "CCM_PODMAN_SUBNET_PREFIX"
+CONTAINER_NET_INTERFACE = os.environ.get("CCM_PODMAN_NET_INTERFACE", "eth0")
+if not re.fullmatch(r"[a-zA-Z0-9._-]{1,15}", CONTAINER_NET_INTERFACE):
+    raise ValueError(
+        f"Invalid CCM_PODMAN_NET_INTERFACE value {CONTAINER_NET_INTERFACE!r}: "
+        "must be 1-15 alphanumeric, dot, hyphen, or underscore characters"
+    )
 PODMAN_RESOURCE_OWNER_LABEL = "org.scylladb.ccm-owner-pid"
+BUSYBOX_IMAGE = os.environ.get("CCM_PODMAN_BUSYBOX_IMAGE", "busybox")
 _IMAGE_RUNTIME_USER_CACHE = {}
-_CACHE_NEGATIVE = object()  # sentinel for caching failed lookups
+_RUNNING_CONTAINER_STATES = frozenset(("running", "created", "paused"))
+
+
+def _busybox_chmod(host_path, container_path, permissions, description="busybox chmod"):
+    """Run busybox chmod inside podman, logging a warning on failure."""
+    res = run(
+        [
+            "podman", "run", "--rm",
+            "-v", f"{host_path}:{container_path}",
+            BUSYBOX_IMAGE,
+            "chmod", "-R", permissions, container_path,
+        ],
+        stdout=DEVNULL,
+        stderr=PIPE,
+        text=True,
+    )
+    if res.returncode != 0:
+        LOGGER.warning(
+            "%s on %s failed (rc=%d): %s",
+            description, host_path, res.returncode, res.stderr.strip(),
+        )
+
+
+def _extract_image_conf(image, dest_dir):
+    """Extract /etc/scylla from *image* into *dest_dir* using a throw-away container.
+
+    This is a one-time-per-cluster operation. All nodes share the same base
+    image so the extracted config is identical for every node.  The cluster
+    caches the result in ``_image_conf_cache/`` and each node copies from
+    there, avoiding O(N) container spawns during ``populate()``.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+    res = run(
+        [
+            "podman", "run", "-d",
+            "--label", f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}",
+            image,
+            "tail", "-f", "/dev/null",
+        ],
+        stdout=PIPE, stderr=PIPE, text=True,
+    )
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"Failed to start temp container for config extraction: {res.stderr}"
+        )
+    container_id = res.stdout.strip()
+    try:
+        cp_res = run(
+            ["podman", "container", "cp", "-a", f"{container_id}:/etc/scylla/", "-"],
+            stdout=PIPE, stderr=PIPE,
+        )
+        if cp_res.returncode != 0:
+            stderr_text = cp_res.stderr.decode("utf-8", errors="replace") if isinstance(cp_res.stderr, bytes) else cp_res.stderr
+            raise RuntimeError(
+                f"Failed to copy /etc/scylla from {image} (container {container_id}): {stderr_text}"
+            )
+        tar_res = run(
+            ["tar", "--skip-old-files", "-x", "--strip-components=1", "-C", dest_dir],
+            input=cp_res.stdout,
+            stderr=PIPE,
+        )
+        if tar_res.returncode != 0:
+            stderr_text = tar_res.stderr.decode("utf-8", errors="replace") if isinstance(tar_res.stderr, bytes) else tar_res.stderr
+            raise RuntimeError(
+                f"Failed to extract scylla config from {image}: {stderr_text}"
+            )
+    finally:
+        run(["podman", "rm", "-f", container_id], stdout=DEVNULL, stderr=DEVNULL)
+
+    # Belt-and-suspenders: verify the sentinel was written.  Guards against
+    # silent edge cases (e.g. the image has no /etc/scylla/scylla.yaml) that
+    # would leave the cache empty and cause every subsequent node to re-enter
+    # the extraction path, silently regressing to O(N) container spawns.
+    yaml_sentinel = os.path.join(dest_dir, "scylla.yaml")
+    if not os.path.exists(yaml_sentinel):
+        raise RuntimeError(
+            f"Config extraction from {image} succeeded but scylla.yaml was not "
+            f"found in {dest_dir}; the image may be missing /etc/scylla/scylla.yaml"
+        )
+
+
+def _copy_conf_dir(src_dir, dst_dir):
+    """Copy files from *src_dir* into *dst_dir*, skipping files that already exist.
+
+    Copies regular files and recurses into subdirectories.  Symlinks (valid or
+    dangling) are recreated as symlinks at the destination — they are not
+    dereferenced — matching ``tar``'s default behaviour.  Files already present
+    at the destination are skipped (``tar --skip-old-files`` semantics).
+    """
+    os.makedirs(dst_dir, exist_ok=True)
+    for item in os.listdir(src_dir):
+        src = os.path.join(src_dir, item)
+        dst = os.path.join(dst_dir, item)
+        if os.path.islink(src):
+            # Recreate symlinks verbatim; use lexists so a pre-existing broken
+            # symlink at dst is also counted as "already present".
+            if not os.path.lexists(dst):
+                os.symlink(os.readlink(src), dst)
+        elif os.path.isdir(src):
+            _copy_conf_dir(src, dst)
+        elif not os.path.exists(dst):
+            copy2(src, dst)
+
+
+def _sanitize_podman_name(name):
+    """Return a podman-safe name component with a stable fallback."""
+
+    original = str(name)
+    sanitized = re.sub(r"-+", "-", re.sub(r"[^a-z0-9-]", "-", original.lower())).strip(
+        "-"
+    )
+    if sanitized:
+        return sanitized
+    return f"unnamed-{hashlib.sha1(original.encode('utf-8'), usedforsecurity=False).hexdigest()[:8]}"
+
+
+def _pid_is_alive(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _resource_owner_pid(labels):
+    if not isinstance(labels, dict):
+        return None
+    owner_pid = labels.get(PODMAN_RESOURCE_OWNER_LABEL)
+    if owner_pid is None:
+        return None
+    try:
+        return int(owner_pid)
+    except (TypeError, ValueError):
+        return None
+
+
+def _inspect_podman_json(command):
+    res = run(command, stdout=PIPE, stderr=DEVNULL, text=True)
+    if res.returncode != 0 or not res.stdout.strip():
+        return None
+    try:
+        payload = json.loads(res.stdout)
+    except json.JSONDecodeError:
+        LOGGER.warning("Failed to parse podman inspect output for %r", command)
+        return None
+    if isinstance(payload, list):
+        return payload[0] if payload else None
+    return payload
+
+
+def _inspect_container(name_or_id):
+    return _inspect_podman_json(["podman", "inspect", name_or_id])
+
+
+def _inspect_network(name):
+    return _inspect_podman_json(["podman", "network", "inspect", name])
+
+
+def _container_owner_labels(container_info):
+    if not isinstance(container_info, dict):
+        return {}
+    config = container_info.get("Config", {})
+    if not isinstance(config, dict):
+        return {}
+    labels = config.get("Labels", {})
+    return labels if isinstance(labels, dict) else {}
+
+
+def _network_owner_labels(network_info):
+    if not isinstance(network_info, dict):
+        return {}
+    labels = network_info.get("labels", {})
+    return labels if isinstance(labels, dict) else {}
+
+
+def _network_attached_container_names(network_info):
+    if not isinstance(network_info, dict):
+        return set()
+    containers = network_info.get("containers", {})
+    if not isinstance(containers, dict):
+        return set()
+    return {
+        details.get("name")
+        for details in containers.values()
+        if isinstance(details, dict) and details.get("name")
+    }
+
+
+def _remove_named_container_if_safe(
+    container_name,
+    allow_reuse_current_running=False,
+    allow_remove_current_running=False,
+):
+    """Safely handle an existing deterministic-name container.
+
+    Returns the inspected container info when ``allow_reuse_current_running`` is
+    True and a current-process running container is reused. Otherwise returns
+    ``None`` after removing a stale container or when no container exists.
+    """
+    container_info = _inspect_container(container_name)
+    if container_info is None:
+        return None
+
+    owner_pid = _resource_owner_pid(_container_owner_labels(container_info))
+    state = container_info.get("State", {}).get("Status", "unknown")
+    is_running = state in _RUNNING_CONTAINER_STATES
+    if owner_pid is None:
+        raise RuntimeError(
+            f"Refusing to remove existing container {container_name}: "
+            f"missing {PODMAN_RESOURCE_OWNER_LABEL} label"
+        )
+    owned_by_current = owner_pid == os.getpid()
+    # Never remove a running container based on creator-PID liveness alone:
+    # a "ccm create -s" process legitimately exits right after starting the
+    # daemon, leaving a live container owned by an already-dead PID.
+    if is_running and not owned_by_current:
+        raise RuntimeError(
+            f"Refusing to remove running container {container_name}: "
+            f"owned by process {owner_pid} and currently running"
+        )
+    if owned_by_current and is_running:
+        if allow_reuse_current_running:
+            return container_info
+        if not allow_remove_current_running:
+            raise RuntimeError(
+                f"Refusing to remove existing running container {container_name}: "
+                "it is already owned by this process"
+            )
+
+    res = run(
+        ["podman", "rm", "--volumes", "-f", container_name],
+        stdout=PIPE,
+        stderr=PIPE,
+        text=True,
+    )
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"Failed to remove existing container {container_name}: {res.stderr}"
+        )
+    return None
 
 
 class PodmanProcess:
@@ -74,8 +326,19 @@ class PodmanProcess:
             output = res.stdout.strip()
             if ":" in output:
                 status, exit_code = output.rsplit(":", 1)
-                if status not in ("running", "created"):
-                    self.returncode = int(exit_code)
+                if status not in _RUNNING_CONTAINER_STATES:
+                    try:
+                        self.returncode = int(exit_code)
+                    except ValueError:
+                        LOGGER.warning(
+                            "Unexpected exit code %r for container %s",
+                            exit_code,
+                            self.pid,
+                        )
+                        self.returncode = -1
+        except FileNotFoundError:
+            LOGGER.warning("podman not found; marking container %s as dead", self.pid)
+            self.returncode = -1
         except Exception:
             LOGGER.debug("poll() failed for container %s", self.pid, exc_info=True)
         return self.returncode
@@ -101,7 +364,12 @@ def _get_container_host_pid(container_id):
     pid = res.stdout.strip()
     if not pid or pid == "0":
         raise RuntimeError(f"Container {container_id} is not running (host PID={pid})")
-    return int(pid)
+    try:
+        return int(pid)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Unexpected host PID value for container {container_id}: {pid!r}"
+        ) from exc
 
 
 def _nsenter_net_run(container_id, command, check=False):
@@ -122,7 +390,16 @@ def _nsenter_net_run(container_id, command, check=False):
     """
     host_pid = _get_container_host_pid(container_id)
     full_cmd = ["nsenter", "-t", str(host_pid), "--user", "--net"] + list(command)
-    res = run(full_cmd, stdout=PIPE, stderr=PIPE, text=True)
+    try:
+        res = run(full_cmd, stdout=PIPE, stderr=PIPE, text=True)
+    except FileNotFoundError as exc:
+        # nsenter (from util-linux) or the command itself (e.g. ip, tc
+        # from iproute2) is not installed on the host.
+        raise RuntimeError(
+            f"Host binary not found while running {full_cmd!r}: {exc}. "
+            f"Ensure 'nsenter' (util-linux) and 'ip'/'tc' (iproute2) "
+            f"are installed on the host."
+        ) from exc
     if check and res.returncode != 0:
         raise RuntimeError(
             f"nsenter command failed (container={container_id}): "
@@ -145,7 +422,7 @@ def _make_path_container_writable(path):
         try:
             os.chmod(target_path, mode)
         except OSError as exc:
-            LOGGER.warning(f"Failed to chmod {target_path} to {oct(mode)}: {exc}")
+            LOGGER.warning("Failed to chmod %s to %s: %s", target_path, oct(mode), exc)
 
     if os.path.isdir(path):
         chmod_if_possible(path, 0o775)
@@ -161,7 +438,7 @@ def _make_path_container_writable(path):
 def _get_image_runtime_user(image_name):
     cached = _IMAGE_RUNTIME_USER_CACHE.get(image_name)
     if cached is not None:
-        return None if cached is _CACHE_NEGATIVE else cached
+        return cached
 
     res = run(
         [
@@ -180,26 +457,26 @@ def _get_image_runtime_user(image_name):
     )
     if res.returncode != 0:
         LOGGER.warning(
-            f"Failed to determine runtime user for image {image_name}: {res.stderr}"
+            "Failed to determine runtime user for image %s: %s",
+            image_name, res.stderr,
         )
-        _IMAGE_RUNTIME_USER_CACHE[image_name] = _CACHE_NEGATIVE
         return None
 
     lines = [line.strip() for line in res.stdout.splitlines() if line.strip()]
     if len(lines) < 2:
         LOGGER.warning(
-            f"Unexpected runtime user output for image {image_name}: {res.stdout}"
+            "Unexpected runtime user output for image %s: %s",
+            image_name, res.stdout,
         )
-        _IMAGE_RUNTIME_USER_CACHE[image_name] = _CACHE_NEGATIVE
         return None
 
     try:
         runtime_user = (int(lines[0]), int(lines[1]))
     except ValueError:
         LOGGER.warning(
-            f"Invalid runtime user output for image {image_name}: {res.stdout}"
+            "Invalid runtime user output for image %s: %s",
+            image_name, res.stdout,
         )
-        _IMAGE_RUNTIME_USER_CACHE[image_name] = _CACHE_NEGATIVE
         return None
 
     _IMAGE_RUNTIME_USER_CACHE[image_name] = runtime_user
@@ -215,7 +492,8 @@ def _chown_path_for_container(path, uid, gid):
     )
     if res.returncode != 0:
         LOGGER.warning(
-            f"Failed to chown {path} to {uid}:{gid} for container access: {res.stderr}"
+            "Failed to chown %s to %s:%s for container access: %s",
+            path, uid, gid, res.stderr,
         )
         return False
     return True
@@ -230,7 +508,7 @@ def _list_podman_ipv4_networks():
         text=True,
     )
     if res.returncode != 0:
-        LOGGER.warning(f"Failed to list podman networks: {res.stderr}")
+        LOGGER.warning("Failed to list podman networks: %s", res.stderr)
         return []
 
     try:
@@ -278,6 +556,19 @@ def _find_available_subnet_prefix(exclude_prefixes=None):
                 f"{SUBNET_PREFIX_ENV}={env_prefix!r} is invalid; "
                 f"second octet must be 0-255, got {second}"
             )
+        # Check for conflicts with existing podman networks even when an
+        # explicit prefix is given — the user may not be aware of collisions.
+        used_subnets = _list_podman_ipv4_networks()
+        candidate = ipaddress.ip_network(f"{env_prefix}.0.0/16")
+        for used in used_subnets:
+            if candidate.overlaps(used):
+                LOGGER.warning(
+                    "%s=%s overlaps existing podman network %s — using anyway",
+                    SUBNET_PREFIX_ENV,
+                    env_prefix,
+                    used,
+                )
+                break
         return env_prefix
 
     used_subnets = _list_podman_ipv4_networks()
@@ -407,10 +698,18 @@ class PodmanNetworkTopology:
                     }
             self.dc_subnets[dc] = dc_rack_subnets
 
-        # Validate that the first rack can fit the client container IP
+        # Validate that the first rack can fit the client container IP and
+        # has at least one node.  The CQL client container sits on the first
+        # rack network and ``start_client_container()`` computes routes from
+        # the perspective of the first node (assumed to be on this rack).
         if self.rack_networks:
             first_rack_key = list(self.rack_networks.keys())[0]
             first_rack_nodes = self.topology[first_rack_key[0]][first_rack_key[1]]
+            if first_rack_nodes < 1:
+                raise ValueError(
+                    f"First rack ({first_rack_key[0]}/{first_rack_key[1]}) must "
+                    f"have at least 1 node (client container shares its network)"
+                )
             if first_rack_nodes >= CLIENT_CONTAINER_HOST:
                 raise ValueError(
                     f"Too many nodes ({first_rack_nodes}) in first rack: "
@@ -425,17 +724,9 @@ class PodmanNetworkTopology:
         same network name (e.g. "a_b" and "a-b" both becoming "a-b").
         """
 
-        # Sanitize names for podman (alphanumeric + hyphens only)
-        def sanitize(name):
-            # Replace any non-alphanumeric character with a hyphen, then collapse
-            # multiple hyphens and strip leading/trailing hyphens
-            return re.sub(r"-+", "-", re.sub(r"[^a-z0-9-]", "-", name.lower())).strip(
-                "-"
-            )
-
-        safe_cluster = sanitize(self.cluster_name)
-        safe_dc = sanitize(dc)
-        safe_rack = sanitize(rack)
+        safe_cluster = _sanitize_podman_name(self.cluster_name)
+        safe_dc = _sanitize_podman_name(dc)
+        safe_rack = _sanitize_podman_name(rack)
         name = f"ccm-{safe_cluster}-{safe_dc}-{safe_rack}"
 
         source = (dc, rack)
@@ -449,21 +740,57 @@ class PodmanNetworkTopology:
         self._network_name_sources[name] = source
         return name
 
-    def reassign_subnet_prefix(self, subnet_prefix):
-        self.subnet_prefix = subnet_prefix
-        self.rack_networks = OrderedDict()
-        self.node_assignments = OrderedDict()
-        self.dc_subnets = {}
-        self._build_assignments()
-
     def create_networks(self):
         """Create all podman networks for the topology."""
         for (dc, rack), info in self.rack_networks.items():
             name = info["network_name"]
             subnet = info["subnet"]
             gateway = info["gateway"]
-            # Remove existing network if present (idempotent)
-            run(["podman", "network", "rm", "-f", name], stdout=DEVNULL, stderr=DEVNULL)
+            network_info = _inspect_network(name)
+            if network_info is not None:
+                owner_pid = _resource_owner_pid(_network_owner_labels(network_info))
+                attached_names = _network_attached_container_names(network_info)
+                subnets = network_info.get("subnets", [])
+                network_subnet = None
+                network_gateway = None
+                if isinstance(subnets, list) and subnets:
+                    first_subnet = subnets[0]
+                    if isinstance(first_subnet, dict):
+                        network_subnet = first_subnet.get("subnet")
+                        network_gateway = first_subnet.get("gateway")
+                if owner_pid is None:
+                    raise RuntimeError(
+                        f"Refusing to remove existing network {name}: "
+                        f"missing {PODMAN_RESOURCE_OWNER_LABEL} label"
+                    )
+                owned_by_current = owner_pid == os.getpid()
+                # Attached-container state, not creator-PID liveness, decides
+                # safety: a "ccm create -s" process exits right after start
+                # while the network is still legitimately in use.
+                if attached_names and not owned_by_current:
+                    raise RuntimeError(
+                        f"Refusing to remove existing network {name}: "
+                        f"containers still attached: {sorted(attached_names)}"
+                    )
+                if owned_by_current:
+                    if network_subnet == subnet and network_gateway == gateway:
+                        LOGGER.debug("Reusing existing podman network %s (%s)", name, subnet)
+                        continue
+                    if attached_names:
+                        raise RuntimeError(
+                            f"Refusing to recreate in-use network {name}: "
+                            f"containers still attached: {sorted(attached_names)}"
+                        )
+                rm_res = run(
+                    ["podman", "network", "rm", "-f", name],
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    text=True,
+                )
+                if rm_res.returncode != 0:
+                    raise RuntimeError(
+                        f"Failed to remove existing podman network {name}: {rm_res.stderr}"
+                    )
             res = run(
                 [
                     "podman",
@@ -485,14 +812,42 @@ class PodmanNetworkTopology:
                 raise RuntimeError(
                     f"Failed to create podman network {name}: {res.stderr}"
                 )
-            LOGGER.debug(f"Created podman network {name} ({subnet})")
+            LOGGER.debug("Created podman network %s (%s)", name, subnet)
 
     def destroy_networks(self):
         """Remove all podman networks for this topology."""
         for (dc, rack), info in self.rack_networks.items():
             name = info["network_name"]
-            run(["podman", "network", "rm", "-f", name], stdout=DEVNULL, stderr=DEVNULL)
-            LOGGER.debug(f"Removed podman network {name}")
+            network_info = _inspect_network(name)
+            if network_info is None:
+                continue
+            owner_pid = _resource_owner_pid(_network_owner_labels(network_info))
+            attached_names = _network_attached_container_names(network_info)
+            owned_by_current = owner_pid is not None and owner_pid == os.getpid()
+            # Attachment state, not creator-PID liveness, decides safety here:
+            # a "ccm create -s" process exits right after start while the
+            # network is still legitimately in use.
+            if attached_names and not owned_by_current:
+                LOGGER.warning(
+                    "Skipping removal of network %s: containers still attached: %s",
+                    name,
+                    sorted(attached_names),
+                )
+                continue
+            res = run(
+                ["podman", "network", "rm", "-f", name],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+            )
+            if res.returncode != 0:
+                LOGGER.warning(
+                    "Failed to remove podman network %s: %s",
+                    name,
+                    res.stderr.strip(),
+                )
+            else:
+                LOGGER.debug("Removed podman network %s", name)
 
     def get_node_ip(self, node_name):
         """Get the assigned rack IP for a node."""
@@ -557,36 +912,39 @@ class PodmanNetworkTopology:
         foreign = self.get_foreign_subnets(node_name)
         commands = []
 
+        iface = CONTAINER_NET_INTERFACE
         # Root qdisc: prio with 4 bands, all traffic defaults to band 1 (no delay)
         commands.append(
-            "tc qdisc add dev eth0 root handle 1: prio bands 4 "
+            f"tc qdisc add dev {iface} root handle 1: prio bands 4 "
             "priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
         )
 
         # Band 2: inter-rack same DC
         if foreign["inter_rack"] and self.inter_rack_delay_ms > 0:
             commands.append(
-                f"tc qdisc add dev eth0 parent 1:2 handle 20: "
+                f"tc qdisc add dev {iface} parent 1:2 handle 20: "
                 f"netem delay {self.inter_rack_delay_ms}ms"
             )
             for subnet in foreign["inter_rack"]:
                 commands.append(
-                    f"tc filter add dev eth0 parent 1:0 protocol ip u32 "
+                    f"tc filter add dev {iface} parent 1:0 protocol ip u32 "
                     f"match ip dst {subnet} flowid 1:2"
                 )
 
         # Band 3: inter-DC
-        if foreign["inter_dc"] and self.inter_dc_delay_ms > 0:
-            loss_str = ""
+        if foreign["inter_dc"] and (self.inter_dc_delay_ms > 0 or self.packet_loss_percent > 0):
+            netem_parts = []
+            if self.inter_dc_delay_ms > 0:
+                netem_parts.append(f"delay {self.inter_dc_delay_ms}ms")
             if self.packet_loss_percent > 0:
-                loss_str = f" loss {self.packet_loss_percent}%"
+                netem_parts.append(f"loss {self.packet_loss_percent}%")
             commands.append(
-                f"tc qdisc add dev eth0 parent 1:3 handle 30: "
-                f"netem delay {self.inter_dc_delay_ms}ms{loss_str}"
+                f"tc qdisc add dev {iface} parent 1:3 handle 30: "
+                f"netem {' '.join(netem_parts)}"
             )
             for subnet in foreign["inter_dc"]:
                 commands.append(
-                    f"tc filter add dev eth0 parent 1:0 protocol ip u32 "
+                    f"tc filter add dev {iface} parent 1:0 protocol ip u32 "
                     f"match ip dst {subnet} flowid 1:3"
                 )
 
@@ -594,14 +952,18 @@ class PodmanNetworkTopology:
 
     def get_client_ip(self):
         """Return the IP address for the CQL client container (on Rack1 network)."""
+        if not self.rack_networks:
+            raise RuntimeError("No rack networks have been created")
         # Client sits on the first rack network
-        first_rack_key = list(self.rack_networks.keys())[0]
+        first_rack_key = next(iter(self.rack_networks))
         rack_idx = self.rack_networks[first_rack_key]["rack_idx"]
         return f"{self.subnet_prefix}.{rack_idx}.{CLIENT_CONTAINER_HOST}"
 
     def get_client_network(self):
         """Return the podman network name for the CQL client container."""
-        first_rack_key = list(self.rack_networks.keys())[0]
+        if not self.rack_networks:
+            raise RuntimeError("No rack networks have been created")
+        first_rack_key = next(iter(self.rack_networks))
         return self.rack_networks[first_rack_key]["network_name"]
 
     def to_dict(self):
@@ -610,6 +972,10 @@ class PodmanNetworkTopology:
         Only the topology and delay parameters are persisted. node_assignments
         and rack_networks are deterministically recomputed from the topology
         by _build_assignments() on load.
+
+        Note: ``topology`` is an ``OrderedDict`` but we convert to plain
+        ``dict`` here.  This is intentional — ``ruamel.yaml`` preserves
+        insertion order for mappings, so the round-trip is order-stable.
         """
         return {
             "topology": {dc: dict(racks) for dc, racks in self.topology.items()},
@@ -657,11 +1023,39 @@ class ScyllaPodmanCluster(ScyllaCluster):
         self.inter_rack_delay_ms = kwargs.pop("inter_rack_delay_ms", 1)
         self.inter_dc_delay_ms = kwargs.pop("inter_dc_delay_ms", 50)
         self.packet_loss_percent = kwargs.pop("packet_loss_percent", 0.0)
+        self.pinning = kwargs.pop("pinning", False)
         self.network_topology = None
         self._client_container_id = None
+        self._cpu_assignments = {}
+        self._cpu_assignments_lock = threading.Lock()
+        # Lock protecting the one-time image config extraction (see _get_image_conf_cache_dir).
+        self._image_conf_cache_lock = threading.Lock()
         # Pass docker_image to parent so it skips install_dir validation
         kwargs["docker_image"] = self.podman_image
         super(ScyllaPodmanCluster, self).__init__(*args, **kwargs)
+
+    def _get_image_conf_cache_dir(self):
+        """Return a directory containing /etc/scylla extracted from the image.
+
+        The extraction runs exactly once per cluster (on first call).  Every
+        subsequent call — including calls from different nodes during populate()
+        — just returns the cached directory.  A threading lock prevents a
+        double-extraction if populate() is ever parallelised.
+        """
+        cache_dir = os.path.join(self.get_path(), "_image_conf_cache")
+        # Fast path: cache already populated (check without the lock).
+        if os.path.exists(os.path.join(cache_dir, "scylla.yaml")):
+            return cache_dir
+        with self._image_conf_cache_lock:
+            # Re-check inside the lock to handle concurrent callers.
+            if os.path.exists(os.path.join(cache_dir, "scylla.yaml")):
+                return cache_dir
+            LOGGER.info(
+                "Extracting image config from %s into cluster cache (one-time per cluster)",
+                self.podman_image,
+            )
+            _extract_image_conf(self.podman_image, cache_dir)
+        return cache_dir
 
     def get_install_dir(self):
         return None
@@ -716,7 +1110,8 @@ class ScyllaPodmanCluster(ScyllaCluster):
                 ):
                     raise
                 LOGGER.warning(
-                    f"Podman subnet prefix {subnet_prefix} is already in use; retrying with another prefix"
+                    "Podman subnet prefix %s is already in use; retrying with another prefix",
+                    subnet_prefix,
                 )
         else:
             raise RuntimeError(
@@ -748,7 +1143,7 @@ class ScyllaPodmanCluster(ScyllaCluster):
                 raise common.ArgumentError(f"Cannot create existing node node{i}")
 
         if tokens is None and not use_vnodes:
-            if dcs is None or len(dcs) <= 1:
+            if len(dcs) <= 1:
                 tokens = self.balanced_tokens(node_count)
             else:
                 tokens = self.balanced_tokens_across_dcs(node_locations)
@@ -781,7 +1176,93 @@ class ScyllaPodmanCluster(ScyllaCluster):
             raise
 
         self.cluster_cleanup()
+        if self.pinning:
+            self._refresh_cpu_assignments()
+
+        # Scale wait_for_binary_proto with cluster size.  Container creation
+        # is serialised (one at a time) so N nodes take roughly N × 20 s to
+        # reach the controlled start; add a 120 s base to cover bootstrapping.
+        # The minimum (420 s) matches ScyllaCluster's release-mode default.
+        self.default_wait_for_binary_proto = max(
+            420, 120 + 20 * node_count
+        )
+        LOGGER.debug(
+            "default_wait_for_binary_proto set to %d s for %d nodes",
+            self.default_wait_for_binary_proto, node_count,
+        )
         return self
+
+    def _compute_cpu_assignments(self):
+        """Compute non-overlapping CPU assignments for each node.
+
+        When pinning is enabled and there are enough host CPUs, each
+        node is assigned a contiguous block of CPUs sized to that
+        node's ``smp()`` value. If there are not enough host CPUs,
+        pinning is disabled with a warning.
+
+        The assignments are stored in ``self._cpu_assignments`` as
+        ``{node_name: [cpu_id, ...]}``. The map is intentionally NOT
+        persisted in cluster.conf -- it is recomputed on populate and
+        before node starts so that a cluster loaded on a different
+        machine (or after a CPU hotplug) gets a valid assignment.
+        """
+        nodes = list(self.nodes.values())
+        if not nodes:
+            self._cpu_assignments = {}
+            return
+
+        node_cpu_counts = [(node, int(node.smp())) for node in nodes]
+        total_cores_needed = sum(node_smp for _, node_smp in node_cpu_counts)
+        try:
+            available = host_cpu_count()
+        except NotImplementedError:
+            LOGGER.warning("Cannot determine host CPU count; disabling CPU pinning")
+            self.pinning = False
+            self._cpu_assignments = {}
+            return
+
+        if total_cores_needed > available:
+            LOGGER.warning(
+                "CPU pinning requires %d cores across %d node(s) but host "
+                "has only %d; disabling CPU pinning for this cluster",
+                total_cores_needed,
+                len(nodes),
+                available,
+            )
+            self.pinning = False
+            self._cpu_assignments = {}
+            return
+
+        LOGGER.info(
+            "CPU pinning enabled: %d node(s) require %d cores (host has %d)",
+            len(nodes),
+            total_cores_needed,
+            available,
+        )
+        assignments = {}
+        cpu_offset = 0
+        for node, node_smp in node_cpu_counts:
+            core_list = list(range(cpu_offset, cpu_offset + node_smp))
+            assignments[node.name] = core_list
+            cpu_offset += node_smp
+        self._cpu_assignments = assignments
+
+    def _refresh_cpu_assignments(self):
+        """Recompute CPU pinning from current node state when enabled.
+
+        Guarded by a lock: node starts triggered concurrently (outside of
+        start_nodes(), which freezes one shared map before kicking off
+        parallel starts) must not race computing overlapping CPU sets.
+        """
+        if not self.pinning:
+            self._cpu_assignments = {}
+            return
+
+        with self._cpu_assignments_lock:
+            previous_pinning = self.pinning
+            self._compute_cpu_assignments()
+            if self.pinning != previous_pinning:
+                self._update_config()
 
     def _parse_topology(self, nodes):
         """Parse the nodes argument into an OrderedDict topology, same as base class."""
@@ -860,8 +1341,13 @@ class ScyllaPodmanCluster(ScyllaCluster):
         client_ip = self.network_topology.get_client_ip()
         client_network = self.network_topology.get_client_network()
 
-        # Remove if already exists
-        run(["podman", "rm", "-f", client_name], stdout=DEVNULL, stderr=DEVNULL)
+        existing_container = _remove_named_container_if_safe(
+            client_name, allow_reuse_current_running=True
+        )
+        if existing_container is not None:
+            self._client_container_id = existing_container.get("Id", client_name)
+            LOGGER.debug("Reusing existing CQL client container %s", client_name)
+            return
 
         # Use the Scylla image so cqlsh is available in the client container.
         res = run(
@@ -894,27 +1380,56 @@ class ScyllaPodmanCluster(ScyllaCluster):
             raise RuntimeError(f"Failed to start CQL client container: {res.stderr}")
 
         self._client_container_id = res.stdout.strip()
-        LOGGER.debug(f"Started CQL client container {client_name} at {client_ip}")
+        LOGGER.debug("Started CQL client container %s at %s", client_name, client_ip)
 
-        # Set up routes to other rack subnets.
-        # Routes and tc rules use nsenter (host's ip/tc binaries), so no tools
-        # need to be installed inside the client container.
-        first_node_name = next(iter(self.network_topology.node_assignments))
-        self._setup_container_routes(client_name, first_node_name)
+        try:
+            # Set up routes to other rack subnets.
+            # Routes and tc rules use nsenter (host's ip/tc binaries), so no tools
+            # need to be installed inside the client container.
+            if not self.network_topology.node_assignments:
+                raise RuntimeError(
+                    "Cannot set up client container routes: no nodes have been assigned"
+                )
+            first_node_name = next(iter(self.network_topology.node_assignments))
+            self._setup_container_routes(client_name, first_node_name)
 
-        # Apply tc rules (client is on Rack1, so same rules as a Rack1 node)
-        tc_commands = self.network_topology.build_tc_commands(first_node_name)
-        for cmd in tc_commands:
-            _nsenter_net_run(self._client_container_id, ["sh", "-c", cmd])
+            # Apply tc rules (client is on Rack1, so same rules as a Rack1 node)
+            tc_commands = self.network_topology.build_tc_commands(first_node_name)
+            for cmd in tc_commands:
+                res = _nsenter_net_run(self._client_container_id, ["sh", "-c", cmd])
+                if res.returncode != 0:
+                    LOGGER.warning(
+                        "Failed to apply tc rule on client container: "
+                        "cmd=%s stderr=%s",
+                        cmd, res.stderr,
+                    )
+        except Exception:
+            LOGGER.error(
+                "Client container setup failed, cleaning up container %s",
+                client_name,
+            )
+            self.stop_client_container()
+            raise
 
     def stop_client_container(self):
         """Stop and remove the CQL client container."""
         client_name = self._client_container_name()
-        run(["podman", "rm", "-f", client_name], stdout=DEVNULL, stderr=DEVNULL)
+        container_info = _inspect_container(client_name)
+        if container_info is not None:
+            # Running/attachment state (checked inside), not creator-PID
+            # liveness, decides whether removal is safe.
+            try:
+                _remove_named_container_if_safe(
+                    client_name,
+                    allow_remove_current_running=True,
+                )
+            except RuntimeError as exc:
+                LOGGER.warning("Skipping removal of client container %s: %s", client_name, exc)
         self._client_container_id = None
 
     def _client_container_name(self):
-        return f"ccm-{self.name}-client"
+        dir_name = os.path.basename(os.path.dirname(self.get_path())).lstrip(".")
+        return f"ccm-{_sanitize_podman_name(dir_name)}-{_sanitize_podman_name(self.name)}-client"
 
     def get_client_contact_points(self):
         """Return (host, port) list for CQL clients to connect to from the client container.
@@ -943,7 +1458,12 @@ class ScyllaPodmanCluster(ScyllaCluster):
             raise RuntimeError("Client container did not start correctly")
 
         if node is None:
-            node = self.nodelist()[0]
+            nodes = self.nodelist()
+            if not nodes:
+                raise RuntimeError("No nodes available to run CQL against")
+            node = next((candidate for candidate in nodes if candidate.is_running()), None)
+            if node is None:
+                raise RuntimeError("No running nodes available to run CQL against")
 
         ip = node.network_interfaces["binary"][0]
         port = node.network_interfaces["binary"][1]
@@ -963,6 +1483,11 @@ class ScyllaPodmanCluster(ScyllaCluster):
             stderr=PIPE,
             text=True,
         )
+        if res.returncode != 0:
+            LOGGER.warning(
+                "cqlsh on client container returned non-zero exit code %d: %s",
+                res.returncode, res.stderr.strip(),
+            )
         return res.stdout, res.stderr
 
     def _setup_container_routes(self, container_name_or_id, node_name):
@@ -974,6 +1499,7 @@ class ScyllaPodmanCluster(ScyllaCluster):
         if not self.network_topology:
             return
 
+        failed_routes = []
         routes = self.network_topology.get_routes_for_node(node_name)
         for dest_subnet, gateway in routes:
             res = _nsenter_net_run(
@@ -981,10 +1507,14 @@ class ScyllaPodmanCluster(ScyllaCluster):
                 ["ip", "route", "add", dest_subnet, "via", gateway],
             )
             if res.returncode != 0:
-                LOGGER.warning(
-                    f"Failed to add route {dest_subnet} via {gateway} "
-                    f"in {container_name_or_id}: {res.stderr}"
+                failed_routes.append(
+                    f"{dest_subnet} via {gateway}: {res.stderr.strip()}"
                 )
+        if failed_routes:
+            raise RuntimeError(
+                "Failed to add %d route(s) in %s: %s"
+                % (len(failed_routes), container_name_or_id, "; ".join(failed_routes))
+            )
 
     def start_nodes(
         self,
@@ -1005,6 +1535,9 @@ class ScyllaPodmanCluster(ScyllaCluster):
         Raft topology bootstrap being slowed by artificial inter-DC latency,
         which can cause joins to exceed the wait timeout.
         """
+        if self.pinning:
+            self._refresh_cpu_assignments()
+
         started = super().start_nodes(
             nodes=nodes,
             no_wait=no_wait,
@@ -1018,20 +1551,31 @@ class ScyllaPodmanCluster(ScyllaCluster):
         )
         # Apply tc/netem rules now that all nodes are running
         if self.network_topology:
+            skipped = []
             for node in self.nodelist():
                 if node.is_running() and node.pid:
                     node._apply_tc_rules()
+                else:
+                    skipped.append(node.name)
+            if skipped:
+                LOGGER.warning(
+                    "Skipped tc/netem rules for %d node(s) that are not running: %s",
+                    len(skipped), ", ".join(skipped),
+                )
         return started
 
     def clear(self):
-        """Remove all containers and networks, then wipe node data directories.
+        """Remove all containers, then wipe node data directories.
 
         Overrides Cluster.clear() because the base implementation only stops
         the Scylla process inside containers via supervisorctl, leaving the
         containers themselves running. This override force-removes containers
-        and cleans up podman networks before wiping data, ensuring no leaks.
+        before wiping data, while preserving the current topology so the
+        cluster can be started again in the same process.
         """
-        # Force-stop and remove all node containers (podman rm -f handles running containers)
+        # Force-stop and remove all node containers (podman rm -f handles running containers).
+        # Keep the topology in memory so `cluster.start()` can recreate the
+        # containers and reuse the same rack networks in this process.
         try:
             self.stop_client_container()
         except Exception:
@@ -1047,15 +1591,6 @@ class ScyllaPodmanCluster(ScyllaCluster):
                     n.name,
                     exc_info=True,
                 )
-        # Destroy podman networks
-        if self.network_topology:
-            try:
-                self.network_topology.destroy_networks()
-            except Exception:
-                LOGGER.warning(
-                    "Failed to destroy podman networks during clear()", exc_info=True
-                )
-            self.network_topology = None
         # Wipe node data directories (node.pid is None after remove() so no container access)
         for n in list(self.nodes.values()):
             try:
@@ -1072,14 +1607,17 @@ class ScyllaPodmanCluster(ScyllaCluster):
     ):
         """Remove the cluster or a single node: stop containers, remove networks."""
         if node is not None:
-            # Single-node removal: remove only that node's container
-            node.remove()
+            # Let the base class do orderly teardown first (removes from
+            # self.nodes, honours wait_other_notice, calls node.stop()).
+            # Only then force-remove the container to clean up any
+            # residual process/volumes.
             super(ScyllaPodmanCluster, self).remove(
                 node=node,
                 wait_other_notice=wait_other_notice,
                 other_nodes=other_nodes,
                 remove_node_dir=remove_node_dir,
             )
+            node.remove()
         else:
             # Full cluster removal: remove all containers, client, and networks.
             # Wrap each step in try/except to ensure we always attempt network
@@ -1135,31 +1673,17 @@ class ScyllaPodmanCluster(ScyllaCluster):
             "id": self.id,
             "ipprefix": self.ipprefix,
             "docker_image": self.podman_image,
+            "pinning": self.pinning,
         }
         if self.network_topology:
             cluster_config["network_topology"] = self.network_topology.to_dict()
 
-        with open(filename, "w") as f:
+        with open(filename, "w", encoding="utf-8") as f:
             YAML().dump(cluster_config, f)
 
     def remove_dir_with_retry(self, path):
         """Use podman to fix permissions before removing directories."""
-        run(
-            [
-                "podman",
-                "run",
-                "--rm",
-                "-v",
-                f"{path}:/node",
-                "busybox",
-                "chmod",
-                "-R",
-                "777",
-                "/node",
-            ],
-            stdout=DEVNULL,
-            stderr=DEVNULL,
-        )
+        _busybox_chmod(path, "/node", "777", "remove_dir_with_retry chmod")
         super(ScyllaPodmanCluster, self).remove_dir_with_retry(path)
 
     @staticmethod
@@ -1190,26 +1714,31 @@ class ScyllaPodmanNode(ScyllaNode):
             "saved_caches",
             "keys",
             "logs",
+            "workdir",  # bind-mounted so scylla user can write cql.m maintenance socket
         ]
         super(ScyllaPodmanNode, self).__init__(*args, **kwargs)
         self.base_data_path = "/usr/lib/scylla"
         self.local_base_data_path = os.path.join(self.get_path(), "data")
         self.local_yaml_path = os.path.join(self.get_path(), "conf")
         dir_name = os.path.basename(os.path.dirname(self.cluster.get_path())).lstrip(".")
-        self.podman_name = f"{dir_name}-{self.cluster.name}-{self.name}"
+        self.podman_name = "-".join(
+            [
+                _sanitize_podman_name(dir_name),
+                _sanitize_podman_name(self.cluster.name),
+                _sanitize_podman_name(self.name),
+            ]
+        )
         self.jmx_port = "7199"
         self.log_thread = None
         self._cached_nodetool_support = {}
+        self._cached_supervisor_programs = None
 
     def _supervisor_program_names(self):
         if self.pid is None:
             return set()
         # Return cached result if available (program names don't change
         # during the lifetime of a container).
-        if (
-            hasattr(self, "_cached_supervisor_programs")
-            and self._cached_supervisor_programs
-        ):
+        if self._cached_supervisor_programs is not None:
             return self._cached_supervisor_programs
         res = run(
             ["podman", "exec", self.pid, "supervisorctl", "status"],
@@ -1271,9 +1800,10 @@ class ScyllaPodmanNode(ScyllaNode):
                     nodetool + [command, "--help"],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.STDOUT,
+                    timeout=30,
                 )
                 cache[command] = True
-            except subprocess.CalledProcessError:
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
                 cache[command] = False
         if cache[command]:
             nodetool.extend(["-h", "localhost", "-p", str(self.api_port)])
@@ -1325,9 +1855,124 @@ class ScyllaPodmanNode(ScyllaNode):
                 )
                 if res.returncode != 0:
                     LOGGER.warning(
-                        f"Failed to chmod {host_path} to a+rwX via podman unshare: {res.stderr}"
+                        "Failed to chmod %s to a+rwX via podman unshare: %s",
+                        host_path, res.stderr,
                     )
-                _make_path_container_writable(host_path)
+                # Do NOT call _make_path_container_writable() here a second time.
+                # After podman unshare chown, the host user no longer owns these
+                # directories and os.chmod() would fail with EPERM.  The
+                # podman unshare chmod -R a+rwX above already grants both the
+                # container user and the host user write access.
+
+    def _pinning_container_args(self):
+        """Return podman run flags for CPU pinning, or empty list if not pinned."""
+        assignments = getattr(self.cluster, "_cpu_assignments", {})
+        cpus = assignments.get(self.name)
+        if not cpus:
+            return []
+        cpuset_str = ",".join(str(c) for c in cpus)
+        return ["--cpuset-cpus", cpuset_str]
+
+    def _pinning_scylla_args(self, args):
+        """Adjust Scylla command-line args for CPU pinning.
+
+        When pinning is active for this node:
+        - Inject ``--cpuset`` so Scylla binds to the assigned cores.
+        - Remove ``--overprovisioned`` (the whole point of pinning is
+          dedicated cores, so overprovisioned mode is wrong).
+        - Add ``--io-setup 0`` to skip iotune and provide an
+          ``io_properties.yaml`` file with tuning appropriate for the
+          number of pinned cores.
+
+        Returns a new args list (the original is not mutated).
+        """
+        assignments = getattr(self.cluster, "_cpu_assignments", {})
+        cpus = assignments.get(self.name)
+        if not cpus:
+            return args
+
+        args = list(args)  # don't mutate caller
+
+        # Strip any pre-existing --cpuset (space- or '='-separated, e.g. from
+        # SCYLLA_EXT_OPTS) so it can't conflict with the computed pinning.
+        cleaned_args = []
+        skip_next = False
+        for arg in args:
+            if skip_next:
+                skip_next = False
+                continue
+            if arg == "--cpuset":
+                skip_next = True
+                continue
+            if arg.startswith("--cpuset="):
+                continue
+            cleaned_args.append(arg)
+        args = cleaned_args
+
+        cpuset_str = ",".join(str(c) for c in cpus)
+        args.extend(["--cpuset", cpuset_str])
+
+        # Remove --overprovisioned (may appear as "--overprovisioned 1"
+        # after filter_args conversion)
+        while "--overprovisioned" in args:
+            idx = args.index("--overprovisioned")
+            # Remove flag and its value if the next element looks like
+            # a value (not a flag)
+            if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+                del args[idx : idx + 2]
+            else:
+                del args[idx]
+
+        # Write io_properties.yaml and tell Scylla to use it
+        self._write_io_properties(len(cpus))
+        # Replace any existing --io-setup value or add it
+        if "--io-setup" in args:
+            idx = args.index("--io-setup")
+            if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+                args[idx + 1] = "0"
+            else:
+                args.insert(idx + 1, "0")
+        else:
+            args.extend(["--io-setup", "0"])
+
+        # Add --io-properties-file pointing to our generated file.
+        # The file sits in the bind-mounted /etc/scylla inside the container.
+        if "--io-properties-file" not in args:
+            args.extend(["--io-properties-file", "/etc/scylla/io_properties.yaml"])
+
+        return args
+
+    def _write_io_properties(self, num_cpus):
+        """Write an io_properties.yaml tuned for *num_cpus* pinned cores.
+
+        The file is written into the node's conf directory which is
+        bind-mounted to ``/etc/scylla`` inside the container.  The
+        values are deliberately generous so that Scylla does not
+        throttle itself unnecessarily in a test/dev environment.
+
+        Returns the host-side path to the file.
+        """
+        # Use generous values: 100k IOPS per core, 1 GB/s bandwidth per core.
+        # These are intentionally high to prevent Scylla from throttling I/O
+        # in a test environment where we want maximum throughput.
+        mountpoint = getattr(self, "base_data_path", "/usr/lib/scylla")
+        io_props = {
+            "disks": [
+                {
+                    "mountpoint": mountpoint,
+                    "read_iops": 100000 * num_cpus,
+                    "read_bandwidth": 1073741824 * num_cpus,
+                    "write_iops": 100000 * num_cpus,
+                    "write_bandwidth": 1073741824 * num_cpus,
+                }
+            ]
+        }
+        io_props_path = os.path.join(self.local_yaml_path, "io_properties.yaml")
+        yaml = YAML()
+        yaml.default_flow_style = False
+        with open(io_props_path, "w", encoding="utf-8") as f:
+            yaml.dump(io_props, f)
+        return io_props_path
 
     def _get_directories(self):
         dirs = {}
@@ -1348,78 +1993,21 @@ class ScyllaPodmanNode(ScyllaNode):
 
     def read_scylla_yaml(self):
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
-        with open(conf_file, "r") as f:
+        with open(conf_file, "r", encoding="utf-8") as f:
             return YAML().load(f)
 
     def update_yaml(self):
-        """Extract config from image if needed, then update scylla.yaml with podman-specific settings."""
+        """Copy image config from the cluster cache, then apply podman-specific settings.
+
+        The cluster-level cache (``_image_conf_cache/``) is populated on first
+        use via a single throw-away container (see
+        ``ScyllaPodmanCluster._get_image_conf_cache_dir``).  Subsequent nodes
+        copy from that cache directory instead of spawning their own container,
+        reducing O(N) container spawns to O(1).
+        """
         if not os.path.exists(os.path.join(self.local_yaml_path, "scylla.yaml")):
-            # Extract /etc/scylla from the image using a temporary container
-            res = run(
-                [
-                    "podman",
-                    "run",
-                    "-d",
-                    "--label",
-                    f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}",
-                    self.cluster.podman_image,
-                    "tail",
-                    "-f",
-                    "/dev/null",
-                ],
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True,
-            )
-            if res.returncode != 0:
-                raise RuntimeError(
-                    f"Failed to start temp container for config extraction: {res.stderr}"
-                )
-            container_id = res.stdout.strip()
-            try:
-                # Copy /etc/scylla/ contents from the container
-                cp_res = run(
-                    [
-                        "podman",
-                        "container",
-                        "cp",
-                        "-a",
-                        f"{container_id}:/etc/scylla/",
-                        "-",
-                    ],
-                    stdout=PIPE,
-                    stderr=PIPE,
-                )
-                if cp_res.returncode == 0:
-                    # Extract the tar archive into the local yaml path
-                    # Use --skip-old-files instead of --keep-old-files to avoid
-                    # spurious warnings about existing files
-                    tar_res = run(
-                        [
-                            "tar",
-                            "--skip-old-files",
-                            "-x",
-                            "--strip-components=1",
-                            "-C",
-                            self.local_yaml_path,
-                        ],
-                        input=cp_res.stdout,
-                        stderr=PIPE,
-                    )
-                    if tar_res.returncode != 0:
-                        LOGGER.warning(
-                            f"Failed to extract scylla config: {tar_res.stderr}"
-                        )
-                else:
-                    LOGGER.warning(
-                        f"Failed to copy config from container: {cp_res.stderr}"
-                    )
-            finally:
-                run(
-                    ["podman", "rm", "-f", container_id],
-                    stdout=DEVNULL,
-                    stderr=DEVNULL,
-                )
+            cache_dir = self.cluster._get_image_conf_cache_dir()
+            _copy_conf_dir(cache_dir, self.local_yaml_path)
         super(ScyllaPodmanNode, self).update_yaml()
 
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
@@ -1446,19 +2034,30 @@ class ScyllaPodmanNode(ScyllaNode):
                 self.base_data_path, directory
             )
 
+        # Override workdir to a container-internal path that the scylla user
+        # can write to.  The parent update_yaml() sets workdir,W to the
+        # host-side node directory (which doesn't exist in the container).
+        # We can't use base_data_path itself (/usr/lib/scylla) because it is
+        # owned by root:root 0755 inside the image — the scylla user cannot
+        # create the cql.m maintenance socket there.  Instead, use the
+        # dedicated "workdir/" subdirectory which is bind-mounted from the
+        # host and chowned to the scylla user by _prepare_bind_mounts.
+        data["workdir,W"] = os.path.join(self.base_data_path, "workdir")
+
         # Handle server encryption options
         server_encryption_options = data.get("server_encryption_options", {})
         if server_encryption_options:
             keys_dir_path = os.path.join(self.get_path(), "keys")
+            os.makedirs(keys_dir_path, exist_ok=True)
             for key, file_path in list(server_encryption_options.items()):
-                if os.path.isfile(file_path):
+                if isinstance(file_path, str) and os.path.isfile(file_path):
                     file_name = os.path.split(file_path)[1]
                     copyfile(src=file_path, dst=os.path.join(keys_dir_path, file_name))
                     server_encryption_options[key] = os.path.join(
                         self.base_data_path, "keys", file_name
                     )
 
-        with open(conf_file, "w") as f:
+        with open(conf_file, "w", encoding="utf-8") as f:
             YAML().dump(data, f)
 
     def _get_rack_ip(self):
@@ -1475,7 +2074,29 @@ class ScyllaPodmanNode(ScyllaNode):
         After creation, IP routes and tc rules are set up.
         """
         if self.pid:
-            return
+            # Verify the container is still alive.  If it was killed
+            # externally (OOM, ``podman stop``, etc.) we need to clear
+            # the stale pid so a fresh container can be created.
+            res = run(
+                ["podman", "inspect", "--format", "{{.State.Status}}", self.pid],
+                stdout=PIPE, stderr=DEVNULL, text=True,
+            )
+            if res.returncode == 0 and res.stdout.strip() in ("running", "created", "paused"):
+                return
+            LOGGER.warning(
+                "Container %s for node %s is no longer running (status: %s); "
+                "will recreate",
+                self.pid,
+                self.name,
+                res.stdout.strip() if res.returncode == 0 else "not found",
+            )
+            # Clean up the dead container
+            run(["podman", "rm", "-f", self.pid], stdout=DEVNULL, stderr=DEVNULL)
+            self.pid = None
+            self._cached_supervisor_programs = None
+            if self.log_thread:
+                self.log_thread.stop()
+                self.log_thread = None
 
         if not self.cluster.network_topology:
             raise RuntimeError(
@@ -1483,21 +2104,26 @@ class ScyllaPodmanNode(ScyllaNode):
                 f"cluster network topology is not initialized"
             )
 
+        self.cluster.network_topology.create_networks()
+
         node_ip = self._get_rack_ip()
         network_name = self.cluster.network_topology.get_node_network(self.name)
 
-        # Build seed list
+        # All configuration is already in place on the host before this point:
+        # update_yaml() wrote scylla.yaml (addresses, seeds, rack/DC) during
+        # populate().  The bind mount below makes it visible inside the
+        # container.  Supervisord starts Scylla automatically; no
+        # stop/start cycle is needed.
         node1 = self.cluster.nodelist()[0]
         seed_args = []
         if self.name != node1.name:
             seed_args = ["--seeds", node1.network_interfaces["storage"][0]]
 
         scylla_yaml = self.read_scylla_yaml()
+        # Do not publish Alternator to fixed host ports. Each node already has a
+        # stable per-rack container IP; host-port publishing would collide when
+        # multiple nodes enable Alternator in the same cluster.
         port_args = []
-        if "alternator_port" in scylla_yaml:
-            port_args.extend(["-p", str(scylla_yaml["alternator_port"])])
-        if "alternator_https_port" in scylla_yaml:
-            port_args.extend(["-p", str(scylla_yaml["alternator_https_port"])])
 
         self._prepare_bind_mounts()
 
@@ -1517,7 +2143,18 @@ class ScyllaPodmanNode(ScyllaNode):
                 ]
             )
 
-        # Run the container on its rack network
+        existing_container = _remove_named_container_if_safe(
+            self.podman_name, allow_reuse_current_running=True
+        )
+        if existing_container is not None:
+            self.pid = existing_container.get("Id", self.podman_name)
+            self.network_interfaces = {
+                k: (node_ip, v[1]) for k, v in list(self.network_interfaces.items())
+            }
+            return
+
+        # Start the container.  All configuration is bind-mounted; supervisord
+        # starts Scylla with the correct settings immediately.
         cmd = [
             "podman",
             "run",
@@ -1533,6 +2170,7 @@ class ScyllaPodmanNode(ScyllaNode):
             f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}",
             "--cap-add",
             "NET_ADMIN",
+            *self._pinning_container_args(),
             "-d",
             self.cluster.podman_image,
             *seed_args,
@@ -1549,7 +2187,7 @@ class ScyllaPodmanNode(ScyllaNode):
         self.pid = res.stdout.strip()
 
         try:
-            # Start log streaming (stop any previous logger first for restart case)
+            # Start log streaming immediately so startup logs are captured.
             if self.log_thread:
                 self.log_thread.stop()
             self.log_thread = PodmanLogger(
@@ -1557,66 +2195,54 @@ class ScyllaPodmanNode(ScyllaNode):
             )
             self.log_thread.start()
 
-            # TODO: Replace this supervisord-specific readiness check with a runtime-
-            # agnostic container startup probe once the image no longer uses supervisord.
-            def is_container_runtime_ready():
-                res = run(
-                    ["podman", "exec", self.pid, "supervisorctl", "status"],
-                    stdout=DEVNULL,
-                    stderr=DEVNULL,
-                )
-                return res.returncode == 0
-
-            if not common.wait_for(
-                func=is_container_runtime_ready, timeout=30, step=0.2
-            ):
-                raise TimeoutError(
-                    f"Container runtime for {self.name} did not become ready within 30 seconds"
-                )
-
-            # Stop scylla so that _start_scylla() can do a controlled
-            # start after routes and tc rules are in place.  We do NOT
-            # modify supervisord config files inside the container —
-            # supervisorctl stop/start is sufficient for lifecycle
-            # control.  The image's default autorestart=true is
-            # harmless: supervisorctl stop sets the desired state to
-            # STOPPED, and supervisord will not auto-restart a process
-            # that was explicitly stopped.  For ungraceful stops
-            # (kill -9), do_stop() calls supervisorctl stop immediately
-            # after the kill to prevent an auto-restart.
-            scylla_service = self._scylla_service_name()
-            self.service_stop(scylla_service)
-            jmx_service = self._jmx_service_name()
-            if jmx_service:
-                self.service_stop(jmx_service)
-
-            # Update network interfaces with the actual rack IP
+            # Update network interfaces with the actual rack IP.
             self.network_interfaces = {
                 k: (node_ip, v[1]) for k, v in list(self.network_interfaces.items())
             }
 
-            # Set up routes to other rack subnets (for cross-rack/DC communication).
-            # Routes and tc rules are applied via nsenter from the host, using
-            # the host's ip/tc binaries — no tools need to be installed inside
-            # the container.
+            # Set up cross-rack routes as soon as the container's network
+            # namespace is available — before Scylla's first gossip attempt
+            # (~0.3 s after start).  Scylla retries gossip if the route is not
+            # ready on the very first attempt, so the exact ordering is not
+            # critical, but setting routes early minimises unnecessary retries.
             self._setup_routes()
 
-            # tc/netem rules are applied later by the cluster's
-            # start_nodes() method — after all nodes are running — so that
-            # artificial latency does not slow down Raft topology bootstrap.
+            # Wait for supervisord to be accepting commands before returning.
+            # This ensures that _start_scylla() can immediately call
+            # service_status() / _supervisor_program_names() to determine the
+            # correct service name and whether service_start() is needed.
+            # Exit code 0 (all programs RUNNING) or 1 (some not yet RUNNING) are
+            # both acceptable — we just need supervisord to be reachable.
+            def is_supervisord_ready():
+                r = run(
+                    ["podman", "exec", self.pid, "supervisorctl", "status"],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                )
+                return r.returncode in (0, 1)
+
+            if not common.wait_for(func=is_supervisord_ready, timeout=30, step=0.1):
+                raise TimeoutError(
+                    f"Supervisord for {self.name} did not become ready within 30 seconds"
+                )
+
         except Exception:
             LOGGER.error(
-                f"Container setup failed for {self.name}, cleaning up container {self.pid}"
+                "Container setup failed for %s, cleaning up container %s",
+                self.name, self.pid,
             )
+            self._cached_supervisor_programs = None
+            self._cached_nodetool_support = {}
             if self.log_thread:
                 self.log_thread.stop()
                 self.log_thread = None
-            run(
-                ["podman", "rm", "--volumes", "-f", self.pid],
-                stdout=DEVNULL,
-                stderr=DEVNULL,
-            )
-            self.pid = None
+            if self.pid:
+                run(
+                    ["podman", "rm", "--volumes", "-f", self.pid],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                )
+                self.pid = None
             raise
 
     def _setup_routes(self):
@@ -1628,6 +2254,7 @@ class ScyllaPodmanNode(ScyllaNode):
         if not self.cluster.network_topology:
             return
 
+        failed_routes = []
         routes = self.cluster.network_topology.get_routes_for_node(self.name)
         for dest_subnet, gateway in routes:
             res = _nsenter_net_run(
@@ -1635,10 +2262,14 @@ class ScyllaPodmanNode(ScyllaNode):
                 ["ip", "route", "add", dest_subnet, "via", gateway],
             )
             if res.returncode != 0:
-                LOGGER.warning(
-                    f"Failed to add route {dest_subnet} via {gateway} "
-                    f"in {self.name}: {res.stderr}"
+                failed_routes.append(
+                    f"{dest_subnet} via {gateway}: {res.stderr.strip()}"
                 )
+        if failed_routes:
+            raise RuntimeError(
+                "Failed to add %d route(s) in %s: %s"
+                % (len(failed_routes), self.name, "; ".join(failed_routes))
+            )
 
     def _apply_tc_rules(self):
         """Apply tc/netem rules for latency simulation.
@@ -1646,17 +2277,28 @@ class ScyllaPodmanNode(ScyllaNode):
         Uses ``nsenter`` to run the host's ``tc`` binary in the container's
         network namespace.  This avoids requiring ``iproute-tc`` inside the
         container image.
+
+        On restart (container still alive from previous start), the old rules
+        are removed first so the new rules can be applied cleanly.
         """
         if not self.cluster.network_topology:
             return
 
         tc_commands = self.cluster.network_topology.build_tc_commands(self.name)
+        if not tc_commands:
+            return
+
+        # Remove any existing root qdisc so we can re-apply rules cleanly
+        # (e.g. on restart when the container was not recreated).
+        # Failure is expected on first start (no qdisc to delete).
+        _nsenter_net_run(self.pid, ["sh", "-c", f"tc qdisc del dev {CONTAINER_NET_INTERFACE} root 2>/dev/null || true"])
+
         for cmd in tc_commands:
             res = _nsenter_net_run(self.pid, ["sh", "-c", cmd])
             if res.returncode != 0:
                 LOGGER.warning(
-                    f"Failed to apply tc rule in {self.name}: "
-                    f"cmd={cmd} stderr={res.stderr}"
+                    "Failed to apply tc rule in %s: cmd=%s stderr=%s",
+                    self.name, cmd, res.stderr,
                 )
 
     def service_start(self, service_name):
@@ -1691,6 +2333,15 @@ class ScyllaPodmanNode(ScyllaNode):
             )
 
     def service_stop(self, service_name):
+        # Pre-check: if the service is already stopped/exited/fatal, return
+        # early to make stop idempotent.
+        current_status = self.service_status(service_name)
+        if current_status.upper() in ("STOPPED", "EXITED", "FATAL", "DOWN"):
+            LOGGER.debug(
+                "service %s in %s already %s; skipping stop",
+                service_name, self.name, current_status,
+            )
+            return
         res = run(
             ["podman", "exec", self.pid, "supervisorctl", "stop", service_name],
             stdout=PIPE,
@@ -1699,7 +2350,9 @@ class ScyllaPodmanNode(ScyllaNode):
         )
         if res.returncode != 0:
             LOGGER.debug(res.stdout)
-            LOGGER.error(f"service {service_name} failed to stop: {res.stderr}")
+            raise RuntimeError(
+                f"service {service_name} failed to stop in {self.name}: {res.stderr}"
+            )
 
     def service_status(self, service_name):
         if self.pid is None:
@@ -1717,23 +2370,28 @@ class ScyllaPodmanNode(ScyllaNode):
         parts = res.stdout.split()
         if len(parts) > 1:
             return parts[1]
-        LOGGER.debug(f"service {service_name} failed to get status: {res.stderr}")
+        LOGGER.debug("service %s failed to get status in %s: %s", service_name, self.name, res.stderr)
         return "DOWN"
 
     def wait_for_binary_interface(self, **kwargs):
         timeout = kwargs.get("timeout", 420)
         process = kwargs.get("process")
         from_mark = kwargs.get("from_mark")
+        start = time.time()
 
-        if self.cluster.version() and self.cluster.version() >= "1.2":
+        def remaining_timeout():
+            return max(0.0, timeout - (time.time() - start))
+
+        if self.cluster.version() and parse_version(self.cluster.version()) >= parse_version("1.2"):
             self.watch_log_for(
                 "Starting listening for CQL clients",
                 from_mark=from_mark,
                 process=process,
-                timeout=timeout,
+                timeout=remaining_timeout(),
             )
 
         binary_itf = self.network_interfaces["binary"]
+        container_id = self.pid
 
         def is_binary_interface_listening():
             if process is not None:
@@ -1742,27 +2400,24 @@ class ScyllaPodmanNode(ScyllaNode):
                         f"Container {self.name} exited (rc={process.returncode}) "
                         f"before CQL interface became ready"
                     )
+            if container_id is None:
+                return False
             res = run(
                 [
                     "podman",
                     "exec",
-                    self.pid,
-                    "python3",
+                    container_id,
+                    "bash",
                     "-c",
-                    "import socket; "
-                    "sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM); "
-                    "sock.settimeout(1.0); "
-                    f"sock.connect(('{binary_itf[0]}', {binary_itf[1]})); "
-                    "sock.close()",
+                    f"echo > /dev/tcp/{binary_itf[0]}/{binary_itf[1]}",
                 ],
                 stdout=DEVNULL,
                 stderr=DEVNULL,
             )
             return res.returncode == 0
 
-        if not common.wait_for(
-            func=is_binary_interface_listening, timeout=timeout, step=0.2
-        ):
+        remaining = remaining_timeout()
+        if not common.wait_for(func=is_binary_interface_listening, timeout=remaining, step=0.2):
             raise TimeoutError(
                 f"Binary interface {binary_itf[0]}:{binary_itf[1]} did not start listening within {timeout} seconds"
             )
@@ -1808,8 +2463,9 @@ class ScyllaPodmanNode(ScyllaNode):
             "podman_id": self.pid,
             "podman_name": self.podman_name,
             "install_dir": "",
+            "config_options": getattr(self, "_Node__config_options", {}),
         }
-        if self.initial_token:
+        if self.initial_token is not None:
             values["initial_token"] = self.initial_token
         if self.remote_debug_port:
             values["remote_debug_port"] = self.remote_debug_port
@@ -1819,7 +2475,7 @@ class ScyllaPodmanNode(ScyllaNode):
             values["rack"] = self.rack
         if self.workload is not None:
             values["workload"] = self.workload
-        with open(filename, "w") as f:
+        with open(filename, "w", encoding="utf-8") as f:
             YAML().dump(values, f)
 
     @staticmethod
@@ -1828,15 +2484,48 @@ class ScyllaPodmanNode(ScyllaNode):
 
         The incoming args list from ScyllaNode.start() begins with
         ``[launch_bin, '--options-file', options_file, ...]``.  We skip
-        everything before the first recognised ``--flag`` so the grouper
-        pairs flags with their values correctly.
+        the launcher preamble and keep the remaining Scylla flags intact,
+        except for a tiny set of known launcher-only/incompatible options.
+
+        ``--io-setup 0`` is always injected (or kept) so the entrypoint
+        never runs ``scylla_io_setup`` / iotune.  I/O benchmarking is
+        inappropriate in a CCM cluster: the data directories are bind-mounted
+        from the host, there may be many concurrent nodes, and the results
+        would be discarded anyway when the container is removed.
         """
         # Work on a copy to avoid mutating the caller's list
         args = list(args)
         cleaned_args = []
-        if "--overprovisioned" in args:
-            args.remove("--overprovisioned")
+        boolean_args = {"--experimental", "--disable-version-check"}
+        drop_flags = {
+            "--log-to-stdout",
+            "--default-log-level",
+            "--options-file",
+        }
+        if "--overprovisioned" in args or any(a.startswith("--overprovisioned=") for a in args):
+            # Handle both "--overprovisioned VALUE" and "--overprovisioned=VALUE"
+            for idx in range(len(args) - 1, -1, -1):
+                if args[idx] == "--overprovisioned":
+                    if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+                        del args[idx : idx + 2]
+                    else:
+                        del args[idx]
+                elif args[idx].startswith("--overprovisioned="):
+                    del args[idx]
             args += ["--overprovisioned", "1"]
+
+        # Always disable the entrypoint's I/O benchmark (iotune / scylla_io_setup).
+        # Normalise any existing --io-setup value to 0, or inject it if absent.
+        for idx in range(len(args) - 1, -1, -1):
+            if args[idx] == "--io-setup":
+                # Remove flag and its (optional) value so we can re-add cleanly.
+                if idx + 1 < len(args) and not args[idx + 1].startswith("--"):
+                    del args[idx : idx + 2]
+                else:
+                    del args[idx]
+            elif args[idx].startswith("--io-setup="):
+                del args[idx]
+        args += ["--io-setup", "0"]
 
         # Find the start of flag arguments (skip the launch binary and
         # --options-file <path> preamble by looking for the first element
@@ -1847,43 +2536,36 @@ class ScyllaPodmanNode(ScyllaNode):
                 flag_start = i
                 break
 
-        for arg, value in common.grouper(2, args[flag_start:], padvalue=""):
-            if arg == "--developer-mode" and value == "true":
-                value = "1"
-            if arg in ["--log-to-stdout", "--default-log-level", "--options-file"]:
+        i = flag_start
+        while i < len(args):
+            arg = args[i]
+            if not arg.startswith("--"):
+                i += 1
                 continue
-            if arg in [
-                "--experimental",
-                "--seeds",
-                "--cpuset",
-                "--smp",
-                "--memory",
-                "--reserve-memory",
-                "--overprovisioned",
-                "--io-setup",
-                "--developer-mode",
-                "--listen-address",
-                "--rpc-address",
-                "--broadcast-address",
-                "--broadcast-rpc-address",
-                "--api-address",
-                "--alternator-address",
-                "--alternator-port",
-                "--alternator-https-port",
-                "--alternator-write-isolation",
-                "--disable-version-check",
-                "--authenticator",
-                "--authorizer",
-                "--cluster-name",
-                "--endpoint-snitch",
-                "--replace-address-first-boot",
-                "--replace-node-first-boot",
-                "--blocked-reactor-notify-ms",
-                "--prometheus-address",
-                "--unsafe-bypass-fsync",
-            ]:
-                cleaned_args.append(arg)
-                cleaned_args.append(value)
+            # Handle --flag=value syntax by splitting on the first '='
+            if "=" in arg:
+                flag_name, value = arg.split("=", 1)
+                i += 1
+            elif arg in boolean_args:
+                flag_name = arg
+                value = ""
+                i += 1
+            elif i + 1 < len(args) and not args[i + 1].startswith("--"):
+                flag_name = arg
+                value = args[i + 1]
+                i += 2
+            else:
+                flag_name = arg
+                value = ""
+                i += 1
+            if flag_name == "--developer-mode" and value == "true":
+                value = "1"
+            if flag_name in drop_flags:
+                continue
+            if flag_name.startswith("--"):
+                cleaned_args.append(flag_name)
+                if value:
+                    cleaned_args.append(value)
         return cleaned_args
 
     def _start_scylla(
@@ -1896,7 +2578,11 @@ class ScyllaPodmanNode(ScyllaNode):
         wait_for_binary_proto,
         ext_env,
     ):
+        if getattr(self.cluster, "pinning", False):
+            self.cluster._refresh_cpu_assignments()
+
         args = self.filter_args(args)
+        args = self._pinning_scylla_args(args)
         if ext_env:
             LOGGER.warning(
                 "ext_env (SCYLLA_EXT_ENV) is not supported for podman clusters; "
@@ -1911,21 +2597,32 @@ class ScyllaPodmanNode(ScyllaNode):
             )
             self.log_thread.start()
 
+        # For a fresh container supervisord auto-starts Scylla; no explicit
+        # service_start is needed.  For a restarted container (after do_stop)
+        # Scylla is STOPPED and must be started explicitly.
         scylla_status = self.service_status(self._scylla_service_name())
-        if scylla_status and scylla_status.upper() != "RUNNING":
+        if scylla_status and scylla_status.upper() not in ("RUNNING", "STARTING"):
             self.service_start(self._scylla_service_name())
 
         if wait_other_notice:
             for node, mark in marks:
                 node.watch_log_for_alive(self, from_mark=mark)
 
+        # Reset cached host ID so it is re-fetched after restart.
+        self.node_hostid = None
+
         if wait_for_binary_proto:
             podman_process = PodmanProcess(self.pid)
             self.wait_for_binary_interface(
-                from_mark=self.mark, process=podman_process, timeout=300
+                from_mark=self.mark, process=podman_process,
+                timeout=self.cluster.default_wait_for_binary_proto,
             )
 
-        return PodmanProcess(self.pid)
+        # Store the process adapter so the parent start_nodes() can pass it
+        # to watch_log_for() for early death detection between sequential
+        # node starts (ScyllaCluster.start_nodes line 143).
+        self._process_scylla = PodmanProcess(self.pid)
+        return self._process_scylla
 
     def do_stop(self, gently=True):
         # Stop the log streamer so it doesn't become orphaned
@@ -1960,10 +2657,11 @@ class ScyllaPodmanNode(ScyllaNode):
             )
             if pid_res.returncode == 0 and pid_res.stdout.strip():
                 _pid = pid_res.stdout.strip()
-                if not _pid.isdigit():
+                if not _pid.isdigit() or _pid == "0":
                     LOGGER.warning(
-                        f"Unexpected PID value from supervisorctl for {scylla_service} "
-                        f"in {self.name}: {_pid!r}"
+                        "Unexpected PID value from supervisorctl for %s "
+                        "in %s: %r",
+                        scylla_service, self.name, _pid,
                     )
                 else:
                     run(
@@ -1997,10 +2695,11 @@ class ScyllaPodmanNode(ScyllaNode):
                 )
                 if jmx_pid_res.returncode == 0 and jmx_pid_res.stdout.strip():
                     _jmx_pid = jmx_pid_res.stdout.strip()
-                    if not _jmx_pid.isdigit():
+                    if not _jmx_pid.isdigit() or _jmx_pid == "0":
                         LOGGER.warning(
-                            f"Unexpected PID value from supervisorctl for {jmx_service} "
-                            f"in {self.name}: {_jmx_pid!r}"
+                            "Unexpected PID value from supervisorctl for %s "
+                            "in %s: %r",
+                            jmx_service, self.name, _jmx_pid,
                         )
                     else:
                         run(
@@ -2043,32 +2742,21 @@ class ScyllaPodmanNode(ScyllaNode):
     def clear(self, *args, **kwargs):
         # Reclaim ownership of container-written files so the host user can
         # delete them.  775 is sufficient — data is about to be removed.
-        run(
-            [
-                "podman",
-                "run",
-                "--rm",
-                "-v",
-                f"{self.get_path()}:/node",
-                "busybox",
-                "chmod",
-                "-R",
-                "775",
-                "/node",
-            ],
-            stdout=DEVNULL,
-            stderr=DEVNULL,
-        )
+        _busybox_chmod(self.get_path(), "/node", "775", f"clear chmod for {self.name}")
         super(ScyllaPodmanNode, self).clear(*args, **kwargs)
 
     def remove(self):
         if self.log_thread:
             self.log_thread.stop()
             self.log_thread = None
+        # Invalidate caches tied to the container — a new container may have
+        # different supervisor programs or nodetool support.
+        self._cached_supervisor_programs = None
+        self._cached_nodetool_support = {}
         container_id = self.pid
         # Clear pid first so that any subsequent is_running()/service_status()
         # calls (e.g. from the parent stop() during teardown) take the early
-        # return path in __update_status instead of exec-ing into a removed
+        # return path in _update_podman_status instead of exec-ing into a removed
         # container.
         self.pid = None
         # Try to remove by container ID first, then by deterministic podman
@@ -2127,7 +2815,14 @@ class ScyllaPodmanNode(ScyllaNode):
             return
 
         scylla_status = self.service_status(self._scylla_service_name())
-        new_status = Status.UP if (scylla_status and scylla_status.upper() == "RUNNING") else Status.DOWN
+        if scylla_status and scylla_status.upper() == "RUNNING":
+            new_status = Status.UP
+        elif self.status == Status.DECOMMISSIONED:
+            # Preserve DECOMMISSIONED — a decommissioned node whose scylla
+            # process has stopped is still decommissioned, not merely DOWN.
+            return
+        else:
+            new_status = Status.DOWN
         if new_status != self.status:
             self.status = new_status
             self._update_config()
@@ -2139,14 +2834,21 @@ class ScyllaPodmanNode(ScyllaNode):
         pass
 
     def get_tool(self, toolname):
-        return ["podman", "exec", "-i", f"{self.pid}", f"{toolname}"]
+        if self.pid is None:
+            raise RuntimeError(f"Cannot run {toolname} on {self.name}: no running container")
+        podman_bin = which("podman") or "podman"
+        return [podman_bin, "exec", "-i", f"{self.pid}", f"{toolname}"]
 
     def _find_cmd(self, command_name):
         return self.get_tool(command_name)
 
     def get_sstables(self, *args, **kwargs):
         files = super(ScyllaPodmanNode, self).get_sstables(*args, **kwargs)
-        return [f.replace(self.get_path(), "/usr/lib/scylla") for f in files]
+        prefix = self.get_path()
+        return [
+            "/usr/lib/scylla" + f[len(prefix):] if f.startswith(prefix) else f
+            for f in files
+        ]
 
     def get_env(self):
         return os.environ.copy()
@@ -2178,14 +2880,16 @@ class ScyllaPodmanNode(ScyllaNode):
         )
         if pid_res.returncode != 0 or not pid_res.stdout.strip():
             LOGGER.debug(
-                f"Failed to get pid of {service_name} in {self.name}: {pid_res.stderr}"
+                "Failed to get pid of %s in %s: %s",
+                service_name, self.name, pid_res.stderr,
             )
             return
         _pid = pid_res.stdout.strip()
-        if not _pid.isdigit():
+        if not _pid.isdigit() or _pid == "0":
             LOGGER.warning(
-                f"Unexpected PID value from supervisorctl for {service_name} "
-                f"in {self.name}: {_pid!r}"
+                "Unexpected PID value from supervisorctl for %s "
+                "in %s: %r",
+                service_name, self.name, _pid,
             )
             return
         run(
@@ -2195,64 +2899,120 @@ class ScyllaPodmanNode(ScyllaNode):
                 self.pid,
                 "bash",
                 "-c",
-                f"kill -{__signal} {_pid}",
+                f"kill -{int(__signal)} {_pid}",
             ],
             stdout=PIPE,
             stderr=PIPE,
         )
 
-    def unlink(self, file_path):
+    def pause(self):
+        """Pause the Scylla process inside the container using SIGSTOP.
+
+        Overrides the base Node.pause() because self.pid is a container ID
+        string — not an OS-level integer PID — so os.kill() / psutil.Process()
+        would crash with TypeError.
+        """
+        if self.pid is None:
+            return
+        service_name = self._scylla_service_name()
+        pid_res = run(
+            ["podman", "exec", self.pid, "supervisorctl", "pid", service_name],
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+        if pid_res.returncode != 0 or not pid_res.stdout.strip():
+            LOGGER.warning(
+                "Cannot pause %s: failed to get Scylla PID from supervisorctl",
+                self.name,
+            )
+            return
+        _pid = pid_res.stdout.strip()
+        if not _pid.isdigit() or _pid == "0":
+            LOGGER.warning(
+                "Cannot pause %s: unexpected PID value %r from supervisorctl",
+                self.name,
+                _pid,
+            )
+            return
         run(
+            ["podman", "exec", self.pid, "bash", "-c", f"kill -STOP {_pid}"],
+            stdout=PIPE,
+            stderr=PIPE,
+        )
+
+    def resume(self):
+        """Resume the Scylla process inside the container using SIGCONT.
+
+        Overrides the base Node.resume() for the same reason as pause().
+        """
+        if self.pid is None:
+            return
+        service_name = self._scylla_service_name()
+        pid_res = run(
+            ["podman", "exec", self.pid, "supervisorctl", "pid", service_name],
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+        if pid_res.returncode != 0 or not pid_res.stdout.strip():
+            LOGGER.warning(
+                "Cannot resume %s: failed to get Scylla PID from supervisorctl",
+                self.name,
+            )
+            return
+        _pid = pid_res.stdout.strip()
+        if not _pid.isdigit() or _pid == "0":
+            LOGGER.warning(
+                "Cannot resume %s: unexpected PID value %r from supervisorctl",
+                self.name,
+                _pid,
+            )
+            return
+        run(
+            ["podman", "exec", self.pid, "bash", "-c", f"kill -CONT {_pid}"],
+            stdout=PIPE,
+            stderr=PIPE,
+        )
+
+    def unlink(self, file_path):
+        if not os.path.exists(file_path):
+            return
+        # Mount the parent directory (not the file itself) because a bind-
+        # mounted file IS the mount point — ``rm`` inside the container would
+        # fail with EBUSY if we mounted the file directly.
+        parent_dir = os.path.dirname(os.path.abspath(file_path))
+        res = run(
             [
                 "podman",
                 "run",
                 "--rm",
                 "-v",
-                f"{file_path}:{file_path}",
-                "busybox",
+                f"{parent_dir}:{parent_dir}",
+                BUSYBOX_IMAGE,
                 "rm",
-                file_path,
+                os.path.abspath(file_path),
             ],
             stdout=DEVNULL,
-            stderr=DEVNULL,
+            stderr=PIPE,
+            text=True,
         )
+        if res.returncode != 0:
+            LOGGER.warning(
+                "unlink %s via busybox failed (rc=%d): %s",
+                file_path, res.returncode, res.stderr.strip(),
+            )
 
     def chmod(self, file_path, permissions):
-        path_inside = file_path.replace(self.get_path(), self.base_data_path)
-        run(
-            [
-                "podman",
-                "run",
-                "--rm",
-                "-v",
-                f"{file_path}:{path_inside}",
-                "busybox",
-                "chmod",
-                "-R",
-                permissions,
-                path_inside,
-            ],
-            stdout=DEVNULL,
-            stderr=DEVNULL,
-        )
+        prefix = self.get_path()
+        if file_path.startswith(prefix):
+            path_inside = self.base_data_path + file_path[len(prefix):]
+        else:
+            path_inside = file_path
+        _busybox_chmod(file_path, path_inside, permissions, f"chmod {permissions} for {self.name}")
 
     def rmtree(self, path):
-        run(
-            [
-                "podman",
-                "run",
-                "--rm",
-                "-v",
-                f"{self.get_path()}:/node",
-                "busybox",
-                "chmod",
-                "-R",
-                "777",
-                "/node",
-            ],
-            stdout=DEVNULL,
-            stderr=DEVNULL,
-        )
+        _busybox_chmod(self.get_path(), "/node", "777", f"rmtree chmod for {self.name}")
         super(ScyllaPodmanNode, self).rmtree(path)
 
 
@@ -2267,6 +3027,8 @@ class PodmanLogger:
         self._target_log_file = target_log_file
         self._process = None
         self._log_file = None
+        self._reader_thread = None
+        self._stop_event = threading.Event()
 
     def start(self):
         """Start streaming container logs to the target file.
@@ -2277,6 +3039,7 @@ class PodmanLogger:
         write buffering on the pipe-to-file path.
         """
         self.stop()  # Clean up any previous process
+        self._stop_event.clear()
         self._log_file = open(self._target_log_file, "a", encoding="utf-8")
         try:
             self._process = Popen(
@@ -2289,33 +3052,44 @@ class PodmanLogger:
             )
             self._reader_thread.start()
         except Exception:
+            if self._process is not None:
+                try:
+                    self._process.kill()
+                    self._process.wait(timeout=5)
+                except Exception:
+                    pass
+                self._process = None
             self._log_file.close()
             self._log_file = None
             raise
 
     def _reader_loop(self):
         """Read lines from the podman logs process and write them with flush."""
+        log_file = self._log_file
+        if log_file is None:
+            return
         try:
             for line in self._process.stdout:
-                if self._log_file is None:
+                if self._stop_event.is_set():
                     break
                 try:
-                    self._log_file.write(line.decode("utf-8", errors="replace"))
-                    self._log_file.flush()
+                    log_file.write(line.decode("utf-8", errors="replace"))
+                    log_file.flush()
                 except Exception:
                     LOGGER.debug(
-                        "Podman log writer stopped for %s",
+                        "Podman log writer error for %s (skipping line)",
                         self._node.name,
                         exc_info=True,
                     )
-                    break
+                    continue
         except Exception:
             LOGGER.debug(
                 "Podman log reader stopped for %s", self._node.name, exc_info=True
             )
 
     def stop(self):
-        """Stop the log streaming process and close the file handle."""
+        """Stop the log streaming process, join the reader thread, and close the file handle."""
+        self._stop_event.set()
         if self._process is not None:
             try:
                 self._process.terminate()
@@ -2323,10 +3097,17 @@ class PodmanLogger:
             except Exception:
                 try:
                     self._process.kill()
+                    self._process.wait(timeout=5)
                 except Exception:
                     pass
             self._process = None
-        if hasattr(self, "_log_file") and self._log_file is not None:
+        # Join the reader thread to ensure it has finished writing before we
+        # close the file handle.  This prevents a race where start() reopens
+        # the file while the old thread is still flushing.
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=5)
+            self._reader_thread = None
+        if self._log_file is not None:
             try:
                 self._log_file.close()
             except Exception:

--- a/ccmlib/scylla_podman_cluster.py
+++ b/ccmlib/scylla_podman_cluster.py
@@ -1592,25 +1592,90 @@ class ScyllaPodmanCluster(ScyllaCluster):
     ):
         """Start nodes, then apply tc/netem rules for latency simulation.
 
-        Overrides ScyllaCluster.start_nodes() to defer tc rule application
-        until after all nodes have their CQL interface ready.  This avoids
-        Raft topology bootstrap being slowed by artificial inter-DC latency,
-        which can cause joins to exceed the wait timeout.
+        Overrides ScyllaCluster.start_nodes() to skip ``watch_log_for``
+        calls (the parent's ``start_nodes`` waits for ``system.log``
+        patterns).  Podman containers always run with ``--log-to-stdout 1``
+        (hard-coded in the image's ``scylla-server.sh``), so ``system.log``
+        is never written to the bind-mounted logs directory, causing
+        ``watch_log_for`` to hang indefinitely.
+
+        CQL readiness is verified by the podman override of
+        ``wait_for_binary_interface()``, which checks the CQL port directly
+        via ``podman exec`` inside each ``node.start()`` call.
         """
+
+        if wait_for_binary_proto is None:
+            wait_for_binary_proto = self.force_wait_for_cluster_start
+        if wait_other_notice is None:
+            wait_other_notice = self.force_wait_for_cluster_start
+        if wait_normal_token_owner is None and wait_other_notice:
+            wait_normal_token_owner = True
+        self.debug(
+            f"start_nodes: no_wait={no_wait} "
+            f"wait_for_binary_proto={wait_for_binary_proto} "
+            f"wait_other_notice={wait_other_notice} "
+            f"wait_normal_token_owner={wait_normal_token_owner} "
+            f"force_wait_for_cluster_start={self.force_wait_for_cluster_start}"
+        )
+        self.started = True
+
         if self.pinning:
             self._refresh_cpu_assignments()
 
-        started = super().start_nodes(
-            nodes=nodes,
-            no_wait=no_wait,
-            verbose=verbose,
-            wait_for_binary_proto=wait_for_binary_proto,
-            wait_other_notice=wait_other_notice,
-            wait_normal_token_owner=wait_normal_token_owner,
-            jvm_args=jvm_args,
-            profile_options=profile_options,
-            quiet_start=quiet_start,
-        )
+        if jvm_args is None:
+            jvm_args = []
+
+        marks = []
+        if wait_other_notice:
+            marks = [
+                (node, node.mark_log())
+                for node in list(self.nodes.values())
+                if node.is_running()
+            ]
+
+        if nodes is None:
+            nodes = list(self.nodes.values())
+        elif isinstance(nodes, ScyllaNode):
+            nodes = [nodes]
+
+        started = []
+        for node in nodes:
+            if not node.is_running():
+                # Skip the parent's watch_log_for — CQL readiness is verified
+                # via podman exec inside node.start().
+                p = node.start(
+                    update_pid=False,
+                    jvm_args=jvm_args,
+                    profile_options=profile_options,
+                    no_wait=no_wait,
+                    wait_for_binary_proto=wait_for_binary_proto,
+                    wait_other_notice=wait_other_notice,
+                    wait_normal_token_owner=False,
+                )
+                mark = 0
+                if os.path.exists(node.logfilename()):
+                    mark = node.mark_log()
+                started.append((node, p, mark))
+                marks.append((node, mark))
+
+        # Skip __update_pids (parent stores _process_scylla reference) and
+        # the is_running() check — podman nodes set their own pid and
+        # _process_scylla during _start_scylla().
+
+        if wait_other_notice:
+            for old_node, mark in marks:
+                for node, _, _ in started:
+                    if old_node is not node:
+                        old_node.watch_log_for_alive(
+                            node, from_mark=mark,
+                            timeout=self.default_wait_other_notice_timeout,
+                        )
+                        old_node.watch_rest_for_alive(
+                            node,
+                            timeout=self.default_wait_other_notice_timeout,
+                            wait_normal_token_owner=wait_normal_token_owner,
+                        )
+
         # Apply tc/netem rules now that all nodes are running
         if self.network_topology:
             skipped = []
@@ -2016,6 +2081,7 @@ class ScyllaPodmanNode(ScyllaNode):
         # Data directories inside the container
         data["data_file_directories"] = [os.path.join(self.base_data_path, "data")]
         data["commitlog_directory"] = os.path.join(self.base_data_path, "commitlogs")
+        data["log_directory"] = os.path.join(self.base_data_path, "logs")
         for directory in ["hints", "view_hints", "saved_caches"]:
             data[f"{directory}_directory"] = os.path.join(
                 self.base_data_path, directory

--- a/ccmlib/scylla_podman_cluster.py
+++ b/ccmlib/scylla_podman_cluster.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import subprocess
 import threading
 import time
@@ -296,51 +297,49 @@ class PodmanProcess:
     The parent ScyllaNode.start() expects _start_scylla() to return a Popen-like
     object with a .pid attribute. This adapter wraps a podman container ID to
     satisfy that interface.
+
+    ``poll()`` checks liveness via ``/proc/<host_pid>`` after resolving the
+    container's host PID once on the first throttled call.  This avoids any
+    ``podman`` subprocess calls during hot polling (which previously caused
+    ~75k ``podman inspect`` processes / ~3400 s of CPU for a 45-node cluster
+    and contended the podman database lock under concurrent log streaming).
     """
+
+    _POLL_CACHE_TTL = 0.5
 
     def __init__(self, container_id):
         self.pid = container_id
         self.returncode = None
+        self._last_poll_ts = 0.0
+        self._host_pid = None
 
     def poll(self):
-        """Check if the container is still running; update returncode if it exited."""
+        """Check if the container is still running; update returncode if it exited.
+
+        Throttled: at most one liveness check per ``_POLL_CACHE_TTL`` seconds.
+        After the container exits the cached returncode is returned immediately.
+        """
         if self.returncode is not None:
             return self.returncode
-        try:
-            res = run(
-                [
-                    "podman",
-                    "inspect",
-                    "--format",
-                    "{{.State.Status}}:{{.State.ExitCode}}",
-                    self.pid,
-                ],
-                stdout=PIPE,
-                stderr=DEVNULL,
-                text=True,
-            )
-            if res.returncode != 0:
-                # Container doesn't exist anymore
+        now = time.time()
+        if now - self._last_poll_ts < self._POLL_CACHE_TTL:
+            return self.returncode
+        self._last_poll_ts = now
+
+        # Resolve the host PID once.  This requires a single `podman inspect`
+        # — typically completes in <50 ms and avoids repeated podman calls.
+        # If the container is already gone the inspect fails and we mark it dead.
+        if self._host_pid is None:
+            try:
+                self._host_pid = _get_container_host_pid(self.pid)
+            except RuntimeError:
                 self.returncode = -1
                 return self.returncode
-            output = res.stdout.strip()
-            if ":" in output:
-                status, exit_code = output.rsplit(":", 1)
-                if status not in _RUNNING_CONTAINER_STATES:
-                    try:
-                        self.returncode = int(exit_code)
-                    except ValueError:
-                        LOGGER.warning(
-                            "Unexpected exit code %r for container %s",
-                            exit_code,
-                            self.pid,
-                        )
-                        self.returncode = -1
-        except FileNotFoundError:
-            LOGGER.warning("podman not found; marking container %s as dead", self.pid)
+
+        # Instant liveness check — no subprocess, no podman lock contention.
+        if not os.path.isdir(f"/proc/{self._host_pid}"):
             self.returncode = -1
-        except Exception:
-            LOGGER.debug("poll() failed for container %s", self.pid, exc_info=True)
+
         return self.returncode
 
 
@@ -1704,6 +1703,8 @@ class ScyllaPodmanNode(ScyllaNode):
           gossip ring settling with --seeds handshake, or iproute install latency.
     """
 
+    _STATUS_CACHE_TTL = 5
+
     def __init__(self, *args, **kwargs):
         kwargs["save"] = False
         self.share_directories = [
@@ -1730,6 +1731,9 @@ class ScyllaPodmanNode(ScyllaNode):
         )
         self.jmx_port = "7199"
         self.log_thread = None
+        self._host_pid = None
+        self._fresh_container = False
+        self._last_status_check = 0.0
         self._cached_nodetool_support = {}
         self._cached_supervisor_programs = None
 
@@ -2185,6 +2189,7 @@ class ScyllaPodmanNode(ScyllaNode):
             )
 
         self.pid = res.stdout.strip()
+        self._fresh_container = True
 
         try:
             # Start log streaming immediately so startup logs are captured.
@@ -2206,25 +2211,6 @@ class ScyllaPodmanNode(ScyllaNode):
             # ready on the very first attempt, so the exact ordering is not
             # critical, but setting routes early minimises unnecessary retries.
             self._setup_routes()
-
-            # Wait for supervisord to be accepting commands before returning.
-            # This ensures that _start_scylla() can immediately call
-            # service_status() / _supervisor_program_names() to determine the
-            # correct service name and whether service_start() is needed.
-            # Exit code 0 (all programs RUNNING) or 1 (some not yet RUNNING) are
-            # both acceptable — we just need supervisord to be reachable.
-            def is_supervisord_ready():
-                r = run(
-                    ["podman", "exec", self.pid, "supervisorctl", "status"],
-                    stdout=DEVNULL,
-                    stderr=DEVNULL,
-                )
-                return r.returncode in (0, 1)
-
-            if not common.wait_for(func=is_supervisord_ready, timeout=30, step=0.1):
-                raise TimeoutError(
-                    f"Supervisord for {self.name} did not become ready within 30 seconds"
-                )
 
         except Exception:
             LOGGER.error(
@@ -2248,27 +2234,43 @@ class ScyllaPodmanNode(ScyllaNode):
     def _setup_routes(self):
         """Add IP routes inside the container for cross-rack connectivity.
 
-        Uses ``nsenter`` to run the host's ``ip`` binary in the container's
-        network namespace, avoiding any dependency on tools inside the image.
+        All routes are added in a single ``nsenter`` + ``sh -c`` call (instead
+        of one ``nsenter`` per route) to minimise subprocess overhead.
         """
         if not self.cluster.network_topology:
             return
 
-        failed_routes = []
         routes = self.cluster.network_topology.get_routes_for_node(self.name)
-        for dest_subnet, gateway in routes:
-            res = _nsenter_net_run(
-                self.pid,
-                ["ip", "route", "add", dest_subnet, "via", gateway],
+        if not routes:
+            return
+
+        # Resolve the host PID with retries — the container's init-process
+        # PID may not be assigned immediately after podman run -d returns.
+        host_pid = None
+        for _ in range(10):
+            try:
+                host_pid = _get_container_host_pid(self.pid)
+                break
+            except RuntimeError:
+                time.sleep(0.5)
+        if host_pid is None:
+            raise RuntimeError(
+                f"Container {self.pid} did not become ready within 5s"
             )
-            if res.returncode != 0:
-                failed_routes.append(
-                    f"{dest_subnet} via {gateway}: {res.stderr.strip()}"
-                )
-        if failed_routes:
+        self._host_pid = int(host_pid)
+
+        route_script = "; ".join(
+            f"ip route add {shlex.quote(dest)} via {shlex.quote(gw)}" for dest, gw in routes
+        )
+        full_cmd = [
+            "nsenter", "-t", str(host_pid), "--user", "--net",
+            "sh", "-c", route_script,
+        ]
+        res = run(full_cmd, stdout=PIPE, stderr=PIPE, text=True)
+        if res.returncode != 0:
             raise RuntimeError(
                 "Failed to add %d route(s) in %s: %s"
-                % (len(failed_routes), self.name, "; ".join(failed_routes))
+                % (len(routes), self.name, res.stderr.strip())
             )
 
     def _apply_tc_rules(self):
@@ -2313,24 +2315,30 @@ class ScyllaPodmanNode(ScyllaNode):
                 stderr=PIPE,
                 text=True,
             )
-        res = run(
-            [
-                "podman",
-                "exec",
-                self.pid,
-                "supervisorctl",
-                "start",
-                service_name,
-            ],
-            stdout=PIPE,
-            stderr=PIPE,
-            text=True,
-        )
-        if res.returncode != 0:
-            LOGGER.debug(res.stdout)
-            raise RuntimeError(
-                f"service {service_name} failed to start in {self.name}: {res.stderr}"
+        # Retry up to 30s in case supervisord isn't ready yet (fresh
+        # container just started by podman run -d).
+        for attempt in range(30):
+            res = run(
+                [
+                    "podman",
+                    "exec",
+                    self.pid,
+                    "supervisorctl",
+                    "start",
+                    service_name,
+                ],
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
             )
+            if res.returncode == 0:
+                return
+            if attempt == 29:
+                LOGGER.debug(res.stdout)
+                raise RuntimeError(
+                    f"service {service_name} failed to start in {self.name}: {res.stderr}"
+                )
+            time.sleep(1)
 
     def service_stop(self, service_name):
         # Pre-check: if the service is already stopped/exited/fatal, return
@@ -2383,11 +2391,15 @@ class ScyllaPodmanNode(ScyllaNode):
             return max(0.0, timeout - (time.time() - start))
 
         if self.cluster.version() and parse_version(self.cluster.version()) >= parse_version("1.2"):
+            # 0.2 s log polling instead of the 10 ms default.  This wait can
+            # last minutes during Raft topology bootstrap; 10 ms spinning
+            # wastes CPU that the joining Scylla shards need.
             self.watch_log_for(
                 "Starting listening for CQL clients",
                 from_mark=from_mark,
                 process=process,
                 timeout=remaining_timeout(),
+                polling_interval=0.2,
             )
 
         binary_itf = self.network_interfaces["binary"]
@@ -2597,12 +2609,14 @@ class ScyllaPodmanNode(ScyllaNode):
             )
             self.log_thread.start()
 
-        # For a fresh container supervisord auto-starts Scylla; no explicit
-        # service_start is needed.  For a restarted container (after do_stop)
-        # Scylla is STOPPED and must be started explicitly.
-        scylla_status = self.service_status(self._scylla_service_name())
-        if scylla_status and scylla_status.upper() not in ("RUNNING", "STARTING"):
-            self.service_start(self._scylla_service_name())
+        # supervisord auto-starts Scylla in fresh containers, so no explicit
+        # service_start is needed here.  Only restarted containers (after
+        # do_stop) need manual start.
+        if not self._fresh_container:
+            scylla_status = self.service_status(self._scylla_service_name())
+            if scylla_status and scylla_status.upper() not in ("RUNNING", "STARTING"):
+                self.service_start(self._scylla_service_name())
+        self._fresh_container = False
 
         if wait_other_notice:
             for node, mark in marks:
@@ -2808,6 +2822,15 @@ class ScyllaPodmanNode(ScyllaNode):
         return self.status == Status.UP
 
     def _update_podman_status(self):
+        # Cache UP status for _STATUS_CACHE_TTL seconds to avoid podman DB
+        # lock contention when many threads poll concurrently during the
+        # final is_running() wait in start().  Still detects process death
+        # within the TTL window, unlike permanent caching.
+        now = time.time()
+        if self.status == Status.UP and now - self._last_status_check < self._STATUS_CACHE_TTL:
+            return
+        self._last_status_check = now
+
         if self.pid is None:
             if self.status == Status.UP or self.status == Status.DECOMMISSIONED:
                 self.status = Status.DOWN
@@ -2818,8 +2841,6 @@ class ScyllaPodmanNode(ScyllaNode):
         if scylla_status and scylla_status.upper() == "RUNNING":
             new_status = Status.UP
         elif self.status == Status.DECOMMISSIONED:
-            # Preserve DECOMMISSIONED — a decommissioned node whose scylla
-            # process has stopped is still decommissioned, not merely DOWN.
             return
         else:
             new_status = Status.DOWN
@@ -2832,6 +2853,12 @@ class ScyllaPodmanNode(ScyllaNode):
 
     def _update_pid(self, process):
         pass
+
+    def nodetool(self, cmd, capture_output=True, wait=True, timeout=None, verbose=True):
+        nodetool = self.get_tool('nodetool')
+        nodetool.extend(['-h', 'localhost', '-p', str(self.api_port)])
+        nodetool.extend(cmd.split())
+        return self._do_run_nodetool(nodetool, capture_output, wait, timeout, verbose)
 
     def get_tool(self, toolname):
         if self.pid is None:

--- a/ccmlib/scylla_podman_cluster.py
+++ b/ccmlib/scylla_podman_cluster.py
@@ -2123,18 +2123,25 @@ class ScyllaPodmanNode(ScyllaNode):
         # host and chowned to the scylla user by _prepare_bind_mounts.
         data["workdir,W"] = os.path.join(self.base_data_path, "workdir")
 
-        # Handle server encryption options
-        server_encryption_options = data.get("server_encryption_options", {})
-        if server_encryption_options:
+        # Cert/key paths in server_encryption_options and client_encryption_options
+        # are written as cluster-level host paths (see enable_ssl() /
+        # enable_internode_ssl()), which live outside anything bind-mounted
+        # into this node's container. Copy the referenced files into this
+        # node's own keys/ dir (which IS mounted) and rewrite the paths to
+        # the container-internal location.
+        def _remap_cert_paths_for_container(options):
+            if not options:
+                return
             keys_dir_path = os.path.join(self.get_path(), "keys")
             os.makedirs(keys_dir_path, exist_ok=True)
-            for key, file_path in list(server_encryption_options.items()):
+            for key, file_path in list(options.items()):
                 if isinstance(file_path, str) and os.path.isfile(file_path):
                     file_name = os.path.split(file_path)[1]
                     copyfile(src=file_path, dst=os.path.join(keys_dir_path, file_name))
-                    server_encryption_options[key] = os.path.join(
-                        self.base_data_path, "keys", file_name
-                    )
+                    options[key] = os.path.join(self.base_data_path, "keys", file_name)
+
+        _remap_cert_paths_for_container(data.get("server_encryption_options", {}))
+        _remap_cert_paths_for_container(data.get("client_encryption_options", {}))
 
         with open(conf_file, "w", encoding="utf-8") as f:
             YAML().dump(data, f)

--- a/ccmlib/scylla_podman_cluster.py
+++ b/ccmlib/scylla_podman_cluster.py
@@ -8,18 +8,23 @@ import logging
 import os
 import re
 import shlex
-import subprocess
 import threading
 import time
+import uuid
 import warnings
 from collections import OrderedDict
 from multiprocessing import cpu_count as host_cpu_count
-from shutil import copy2, copyfile, which
-from subprocess import run, PIPE, DEVNULL, STDOUT, Popen
+from shutil import copy2, copyfile
+from subprocess import run, PIPE, DEVNULL, Popen, TimeoutExpired
 
 from ruamel.yaml import YAML
 
 from ccmlib import common
+from ccmlib.container_client import (
+    ContainerClientError,
+    ContainerLogManager,
+    PodmanClient,
+)
 from ccmlib.node import (
     NodeError,
     Status,
@@ -30,6 +35,27 @@ from ccmlib.scylla_node import ScyllaNode
 from ccmlib.utils.version import parse_version
 
 LOGGER = logging.getLogger("ccm")
+
+_PODMAN_CLIENT = None
+_PODMAN_CLIENT_LOCK = threading.Lock()
+
+
+def _get_podman_client():
+    """Return a process-wide singleton PodmanClient.
+
+    All podman container/network operations go through this shared
+    `ContainerClient` instead of ad-hoc subprocess calls, so the low-level
+    runtime code isn't duplicated between the Docker and Podman clusters.
+
+    Double-checked locking since concurrent node starts race here; harmless
+    (PodmanClient is stateless) but wastes a `podman version` call per race.
+    """
+    global _PODMAN_CLIENT
+    if _PODMAN_CLIENT is None:
+        with _PODMAN_CLIENT_LOCK:
+            if _PODMAN_CLIENT is None:
+                _PODMAN_CLIENT = PodmanClient()
+    return _PODMAN_CLIENT
 
 # Subnet allocation scheme:
 #   Rack networks:  10.{prefix_octet}.{rack_idx}.0/24  (rack_idx starts at 1)
@@ -47,29 +73,48 @@ if not re.fullmatch(r"[a-zA-Z0-9._-]{1,15}", CONTAINER_NET_INTERFACE):
         "must be 1-15 alphanumeric, dot, hyphen, or underscore characters"
     )
 PODMAN_RESOURCE_OWNER_LABEL = "org.scylladb.ccm-owner-pid"
+# Set by test suites (see tests/conftest.py) to mark every container/network
+# they create as belonging to a test session. This lets test-session cleanup
+# scope itself to resources it (or a previous test session) actually created,
+# instead of pruning any dead-owner-PID "ccm-"-named resource on the host --
+# which would also catch containers from a normal interactive
+# `ccm create ... -s` CLI invocation (whose creating process exits right
+# after startup while the cluster keeps running).
+PODMAN_TEST_SESSION_LABEL = "org.scylladb.ccm-test-session"
+PODMAN_TEST_SESSION_ENV = "CCM_PODMAN_TEST_SESSION"
 BUSYBOX_IMAGE = os.environ.get("CCM_PODMAN_BUSYBOX_IMAGE", "busybox")
 _IMAGE_RUNTIME_USER_CACHE = {}
 _RUNNING_CONTAINER_STATES = frozenset(("running", "created", "paused"))
 
 
+def _resource_labels():
+    """Return the labels applied to every container/network CCM creates.
+
+    Always includes the owning-PID label. When running under a test session
+    (``CCM_PODMAN_TEST_SESSION`` set -- see tests/conftest.py), also tags the
+    resource so test-session cleanup can be scoped to test-created resources.
+    """
+    labels = {PODMAN_RESOURCE_OWNER_LABEL: str(os.getpid())}
+    test_session = os.environ.get(PODMAN_TEST_SESSION_ENV)
+    if test_session:
+        labels[PODMAN_TEST_SESSION_LABEL] = test_session
+    return labels
+
+
 def _busybox_chmod(host_path, container_path, permissions, description="busybox chmod"):
     """Run busybox chmod inside podman, logging a warning on failure."""
-    res = run(
-        [
-            "podman", "run", "--rm",
-            "-v", f"{host_path}:{container_path}",
-            BUSYBOX_IMAGE,
-            "chmod", "-R", permissions, container_path,
-        ],
-        stdout=DEVNULL,
-        stderr=PIPE,
-        text=True,
-    )
-    if res.returncode != 0:
-        LOGGER.warning(
-            "%s on %s failed (rc=%d): %s",
-            description, host_path, res.returncode, res.stderr.strip(),
+    client = _get_podman_client()
+    try:
+        client.run_container(
+            image=BUSYBOX_IMAGE,
+            name=f"ccm-chmod-{uuid.uuid4().hex[:12]}",
+            volumes={host_path: container_path},
+            command=["chmod", "-R", permissions, container_path],
+            detach=False,
+            remove=True,
         )
+    except ContainerClientError as exc:
+        LOGGER.warning("%s on %s failed: %s", description, host_path, exc)
 
 
 def _extract_image_conf(image, dest_dir):
@@ -81,33 +126,28 @@ def _extract_image_conf(image, dest_dir):
     there, avoiding O(N) container spawns during ``populate()``.
     """
     os.makedirs(dest_dir, exist_ok=True)
-    res = run(
-        [
-            "podman", "run", "-d",
-            "--label", f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}",
-            image,
-            "tail", "-f", "/dev/null",
-        ],
-        stdout=PIPE, stderr=PIPE, text=True,
-    )
-    if res.returncode != 0:
-        raise RuntimeError(
-            f"Failed to start temp container for config extraction: {res.stderr}"
-        )
-    container_id = res.stdout.strip()
+    client = _get_podman_client()
     try:
-        cp_res = run(
-            ["podman", "container", "cp", "-a", f"{container_id}:/etc/scylla/", "-"],
-            stdout=PIPE, stderr=PIPE,
+        container_id = client.run_container(
+            image=image,
+            name=f"ccm-extract-conf-{uuid.uuid4().hex[:12]}",
+            labels=_resource_labels(),
+            command=["tail", "-f", "/dev/null"],
         )
-        if cp_res.returncode != 0:
-            stderr_text = cp_res.stderr.decode("utf-8", errors="replace") if isinstance(cp_res.stderr, bytes) else cp_res.stderr
+    except ContainerClientError as exc:
+        raise RuntimeError(
+            f"Failed to start temp container for config extraction: {exc}"
+        )
+    try:
+        try:
+            tar_bytes = client.copy_from_container(container_id, "/etc/scylla/")
+        except ContainerClientError as exc:
             raise RuntimeError(
-                f"Failed to copy /etc/scylla from {image} (container {container_id}): {stderr_text}"
+                f"Failed to copy /etc/scylla from {image} (container {container_id}): {exc}"
             )
         tar_res = run(
             ["tar", "--skip-old-files", "-x", "--strip-components=1", "-C", dest_dir],
-            input=cp_res.stdout,
+            input=tar_bytes,
             stderr=PIPE,
         )
         if tar_res.returncode != 0:
@@ -116,7 +156,7 @@ def _extract_image_conf(image, dest_dir):
                 f"Failed to extract scylla config from {image}: {stderr_text}"
             )
     finally:
-        run(["podman", "rm", "-f", container_id], stdout=DEVNULL, stderr=DEVNULL)
+        client.remove_container(container_id, force=True)
 
     # Belt-and-suspenders: verify the sentinel was written.  Guards against
     # silent edge cases (e.g. the image has no /etc/scylla/scylla.yaml) that
@@ -187,26 +227,12 @@ def _resource_owner_pid(labels):
         return None
 
 
-def _inspect_podman_json(command):
-    res = run(command, stdout=PIPE, stderr=DEVNULL, text=True)
-    if res.returncode != 0 or not res.stdout.strip():
-        return None
-    try:
-        payload = json.loads(res.stdout)
-    except json.JSONDecodeError:
-        LOGGER.warning("Failed to parse podman inspect output for %r", command)
-        return None
-    if isinstance(payload, list):
-        return payload[0] if payload else None
-    return payload
-
-
 def _inspect_container(name_or_id):
-    return _inspect_podman_json(["podman", "inspect", name_or_id])
+    return _get_podman_client().inspect_container(name_or_id)
 
 
 def _inspect_network(name):
-    return _inspect_podman_json(["podman", "network", "inspect", name])
+    return _get_podman_client().inspect_network(name)
 
 
 def _container_owner_labels(container_info):
@@ -280,15 +306,13 @@ def _remove_named_container_if_safe(
                 "it is already owned by this process"
             )
 
-    res = run(
-        ["podman", "rm", "--volumes", "-f", container_name],
-        stdout=PIPE,
-        stderr=PIPE,
-        text=True,
-    )
-    if res.returncode != 0:
+    try:
+        _get_podman_client().remove_container(
+            container_name, force=True, volumes=True, check=True
+        )
+    except ContainerClientError as exc:
         raise RuntimeError(
-            f"Failed to remove existing container {container_name}: {res.stderr}"
+            f"Failed to remove existing container {container_name}: {exc}"
         )
     return None
 
@@ -352,25 +376,10 @@ def _get_container_host_pid(container_id):
     from the host, allowing us to run ``ip`` and ``tc`` commands using the host's
     binaries rather than requiring them inside the container.
     """
-    res = run(
-        ["podman", "inspect", "--format", "{{.State.Pid}}", container_id],
-        stdout=PIPE,
-        stderr=PIPE,
-        text=True,
-    )
-    if res.returncode != 0:
-        raise RuntimeError(
-            f"Failed to get host PID for container {container_id}: {res.stderr}"
-        )
-    pid = res.stdout.strip()
-    if not pid or pid == "0":
-        raise RuntimeError(f"Container {container_id} is not running (host PID={pid})")
-    try:
-        return int(pid)
-    except ValueError as exc:
-        raise RuntimeError(
-            f"Unexpected host PID value for container {container_id}: {pid!r}"
-        ) from exc
+    pid = _get_podman_client().get_container_pid(container_id)
+    if pid is None:
+        raise RuntimeError(f"Container {container_id} is not running or was not found")
+    return pid
 
 
 def _nsenter_net_run(container_id, command, check=False, host_pid=None):
@@ -443,33 +452,28 @@ def _get_image_runtime_user(image_name):
     if cached is not None:
         return cached
 
-    res = run(
-        [
-            "podman",
-            "run",
-            "--rm",
-            "--entrypoint",
-            "sh",
-            image_name,
-            "-lc",
-            "id -u; id -g",
-        ],
-        stdout=PIPE,
-        stderr=PIPE,
-        text=True,
-    )
-    if res.returncode != 0:
+    client = _get_podman_client()
+    try:
+        output = client.run_container(
+            image=image_name,
+            name=f"ccm-runtime-user-{uuid.uuid4().hex[:12]}",
+            entrypoint="sh",
+            command=["-lc", "id -u; id -g"],
+            detach=False,
+            remove=True,
+        )
+    except ContainerClientError as exc:
         LOGGER.warning(
             "Failed to determine runtime user for image %s: %s",
-            image_name, res.stderr,
+            image_name, exc,
         )
         return None
 
-    lines = [line.strip() for line in res.stdout.splitlines() if line.strip()]
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
     if len(lines) < 2:
         LOGGER.warning(
             "Unexpected runtime user output for image %s: %s",
-            image_name, res.stdout,
+            image_name, output,
         )
         return None
 
@@ -478,7 +482,7 @@ def _get_image_runtime_user(image_name):
     except ValueError:
         LOGGER.warning(
             "Invalid runtime user output for image %s: %s",
-            image_name, res.stdout,
+            image_name, output,
         )
         return None
 
@@ -486,39 +490,9 @@ def _get_image_runtime_user(image_name):
     return runtime_user
 
 
-def _chown_path_for_container(path, uid, gid):
-    res = run(
-        ["podman", "unshare", "chown", "-R", f"{uid}:{gid}", path],
-        stdout=PIPE,
-        stderr=PIPE,
-        text=True,
-    )
-    if res.returncode != 0:
-        LOGGER.warning(
-            "Failed to chown %s to %s:%s for container access: %s",
-            path, uid, gid, res.stderr,
-        )
-        return False
-    return True
-
-
 def _list_podman_ipv4_networks():
     """Return all IPv4 podman network subnets visible to the local podman daemon."""
-    res = run(
-        ["podman", "network", "ls", "--format", "json"],
-        stdout=PIPE,
-        stderr=PIPE,
-        text=True,
-    )
-    if res.returncode != 0:
-        LOGGER.warning("Failed to list podman networks: %s", res.stderr)
-        return []
-
-    try:
-        networks = json.loads(res.stdout)
-    except json.JSONDecodeError:
-        LOGGER.warning("Failed to parse podman network ls output as JSON")
-        return []
+    networks = _get_podman_client().list_networks()
 
     subnets = []
     for network in networks:
@@ -745,6 +719,7 @@ class PodmanNetworkTopology:
 
     def create_networks(self):
         """Create all podman networks for the topology."""
+        client = _get_podman_client()
         for (dc, rack), info in self.rack_networks.items():
             name = info["network_name"]
             subnet = info["subnet"]
@@ -784,52 +759,46 @@ class PodmanNetworkTopology:
                             f"Refusing to recreate in-use network {name}: "
                             f"containers still attached: {sorted(attached_names)}"
                         )
-                rm_res = run(
-                    ["podman", "network", "rm", "-f", name],
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    text=True,
-                )
-                if rm_res.returncode != 0:
+                try:
+                    client.remove_network(name, force=True, check=True)
+                except ContainerClientError as exc:
                     raise RuntimeError(
-                        f"Failed to remove existing podman network {name}: {rm_res.stderr}"
+                        f"Failed to remove existing podman network {name}: {exc}"
                     )
-            res = run(
-                [
-                    "podman",
-                    "network",
-                    "create",
-                    "--label",
-                    f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}",
-                    "--subnet",
-                    subnet,
-                    "--gateway",
-                    gateway,
+            try:
+                client.create_network(
                     name,
-                ],
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True,
-            )
-            if res.returncode != 0:
-                raise RuntimeError(
-                    f"Failed to create podman network {name}: {res.stderr}"
+                    subnet=subnet,
+                    gateway=gateway,
+                    labels=_resource_labels(),
                 )
+            except ContainerClientError as exc:
+                raise RuntimeError(f"Failed to create podman network {name}: {exc}")
             LOGGER.debug("Created podman network %s (%s)", name, subnet)
 
     def destroy_networks(self):
         """Remove all podman networks for this topology."""
+        client = _get_podman_client()
         for (dc, rack), info in self.rack_networks.items():
             name = info["network_name"]
             network_info = _inspect_network(name)
             if network_info is None:
                 continue
             owner_pid = _resource_owner_pid(_network_owner_labels(network_info))
+            if owner_pid is None:
+                # Mirrors create_networks(): a network with this deterministic
+                # name exists but wasn't created by us (no ownership label).
+                # Never force-remove a resource we don't own.
+                LOGGER.warning(
+                    "Skipping removal of network %s: missing %s label "
+                    "(not created by this process)",
+                    name,
+                    PODMAN_RESOURCE_OWNER_LABEL,
+                )
+                continue
             attached_names = _network_attached_container_names(network_info)
-            owned_by_current = owner_pid is not None and owner_pid == os.getpid()
-            # Attachment state, not creator-PID liveness, decides safety here:
-            # a "ccm create -s" process exits right after start while the
-            # network is still legitimately in use.
+            owned_by_current = owner_pid == os.getpid()
+            # Attachment state, not creator-PID liveness, decides safety here too.
             if attached_names and not owned_by_current:
                 LOGGER.warning(
                     "Skipping removal of network %s: containers still attached: %s",
@@ -837,20 +806,7 @@ class PodmanNetworkTopology:
                     sorted(attached_names),
                 )
                 continue
-            res = run(
-                ["podman", "network", "rm", "-f", name],
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True,
-            )
-            if res.returncode != 0:
-                LOGGER.warning(
-                    "Failed to remove podman network %s: %s",
-                    name,
-                    res.stderr.strip(),
-                )
-            else:
-                LOGGER.debug("Removed podman network %s", name)
+            client.remove_network(name, force=True)
 
     def get_node_ip(self, node_name):
         """Get the assigned rack IP for a node."""
@@ -951,6 +907,9 @@ class PodmanNetworkTopology:
                     f"match ip dst {subnet} flowid 1:3"
                 )
 
+        # only the root qdisc: no delay/loss configured, nothing to shape
+        if len(commands) == 1:
+            return []
         return commands
 
     def get_client_ip(self):
@@ -1073,8 +1032,20 @@ class ScyllaPodmanCluster(ScyllaCluster):
         # PodmanEventMonitor.register) so read-only commands on a loaded
         # cluster don't spawn a `podman events --stream` subprocess.
         if self._log_manager is None:
-            self._log_manager = PodmanLogManager()
+            self._log_manager = ContainerLogManager(self.get_container_client())
             self._event_monitor = PodmanEventMonitor(self._log_manager)
+
+    def _ensure_image_pulled(self):
+        """Pull the image if it is not present locally."""
+        client = _get_podman_client()
+        if not client.image_exists(self.podman_image):
+            LOGGER.info("Pulling image %s (not present locally)...", self.podman_image)
+            if not client.pull_image(self.podman_image):
+                raise RuntimeError(f"Failed to pull podman image {self.podman_image}")
+
+    def get_container_client(self):
+        """Return the shared PodmanClient used for all container operations."""
+        return _get_podman_client()
 
     def populate(
         self,
@@ -1094,6 +1065,8 @@ class ScyllaPodmanCluster(ScyllaCluster):
             LOGGER.warning(
                 "ipformat is ignored for podman clusters (IPs come from network topology)"
             )
+
+        self._ensure_image_pulled()
 
         # Parse the topology exactly like the base class does
         topology = self._parse_topology(nodes)
@@ -1236,23 +1209,28 @@ class ScyllaPodmanCluster(ScyllaCluster):
             )
             return
         uid, gid = runtime_user
-        for node in self.nodelist():
-            for directory in node.share_directories:
-                host_path = os.path.join(node.get_path(), directory)
-                if not os.path.exists(host_path):
-                    continue
-                _chown_path_for_container(host_path, uid, gid)
-                res = run(
-                    ["podman", "unshare", "chmod", "-R", "a+rwX", host_path],
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    text=True,
-                )
-                if res.returncode != 0:
-                    LOGGER.warning(
-                        "Failed to chmod %s to a+rwX via podman unshare: %s",
-                        host_path, res.stderr,
-                    )
+        client = _get_podman_client()
+        paths = [
+            host_path
+            for node in self.nodelist()
+            for directory in node.share_directories
+            if os.path.exists(host_path := os.path.join(node.get_path(), directory))
+        ]
+        if not paths:
+            return
+        # batch all paths into two unshare calls
+        returncode, stdout, stderr = client.unshare(["chown", "-R", f"{uid}:{gid}", *paths])
+        if returncode != 0:
+            LOGGER.warning(
+                "Failed to chown node directories to %s:%s via podman unshare: %s",
+                uid, gid, stderr,
+            )
+        returncode, stdout, stderr = client.unshare(["chmod", "-R", "a+rwX", *paths])
+        if returncode != 0:
+            LOGGER.warning(
+                "Failed to chmod node directories to a+rwX via podman unshare: %s",
+                stderr,
+            )
 
     def _compute_cpu_assignments(self):
         """Compute non-overlapping CPU assignments for each node.
@@ -1412,36 +1390,21 @@ class ScyllaPodmanCluster(ScyllaCluster):
             return
 
         # Use the Scylla image so cqlsh is available in the client container.
-        res = run(
-            [
-                "podman",
-                "run",
-                "-d",
-                "--name",
-                client_name,
-                "--network",
-                client_network,
-                "--ip",
-                client_ip,
-                "--label",
-                f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}",
-                "--cap-add",
-                "NET_ADMIN",
-                "--entrypoint",
-                "sh",
-                self.podman_image,
-                "-lc",
-                "sleep infinity",
-            ],
-            stdout=PIPE,
-            stderr=PIPE,
-            text=True,
-        )
+        client = _get_podman_client()
+        try:
+            self._client_container_id = client.run_container(
+                image=self.podman_image,
+                name=client_name,
+                network=client_network,
+                ip=client_ip,
+                labels=_resource_labels(),
+                cap_add=["NET_ADMIN"],
+                entrypoint="sh",
+                command=["-lc", "sleep infinity"],
+            )
+        except ContainerClientError as exc:
+            raise RuntimeError(f"Failed to start CQL client container: {exc}")
 
-        if res.returncode != 0:
-            raise RuntimeError(f"Failed to start CQL client container: {res.stderr}")
-
-        self._client_container_id = res.stdout.strip()
         LOGGER.debug("Started CQL client container %s at %s", client_name, client_ip)
 
         try:
@@ -1530,27 +1493,16 @@ class ScyllaPodmanCluster(ScyllaCluster):
         ip = node.network_interfaces["binary"][0]
         port = node.network_interfaces["binary"][1]
 
-        res = run(
-            [
-                "podman",
-                "exec",
-                self._client_container_id,
-                "cqlsh",
-                ip,
-                str(port),
-                "-e",
-                cql_command,
-            ],
-            stdout=PIPE,
-            stderr=PIPE,
-            text=True,
+        returncode, stdout, stderr = _get_podman_client().exec_command(
+            self._client_container_id,
+            ["cqlsh", ip, str(port), "-e", cql_command],
         )
-        if res.returncode != 0:
+        if returncode != 0:
             LOGGER.warning(
                 "cqlsh on client container returned non-zero exit code %d: %s",
-                res.returncode, res.stderr.strip(),
+                returncode, stderr.strip(),
             )
-        return res.stdout, res.stderr
+        return stdout, stderr
 
     def _setup_container_routes(self, container_name_or_id, node_name):
         """Set up IP routes inside a container for cross-rack connectivity.
@@ -1590,18 +1542,10 @@ class ScyllaPodmanCluster(ScyllaCluster):
         profile_options=None,
         quiet_start=False,
     ):
-        """Start nodes, then apply tc/netem rules for latency simulation.
+        """Start nodes, then apply any configured tc/netem rules.
 
-        Overrides ScyllaCluster.start_nodes() to skip ``watch_log_for``
-        calls (the parent's ``start_nodes`` waits for ``system.log``
-        patterns).  Podman containers always run with ``--log-to-stdout 1``
-        (hard-coded in the image's ``scylla-server.sh``), so ``system.log``
-        is never written to the bind-mounted logs directory, causing
-        ``watch_log_for`` to hang indefinitely.
-
-        CQL readiness is verified by the podman override of
-        ``wait_for_binary_interface()``, which checks the CQL port directly
-        via ``podman exec`` inside each ``node.start()`` call.
+        CQL readiness is verified by probing the CQL port via ``podman exec``
+        instead of the parent's log-based waits.
         """
 
         if wait_for_binary_proto is None:
@@ -1677,19 +1621,97 @@ class ScyllaPodmanCluster(ScyllaCluster):
                         )
 
         # Apply tc/netem rules now that all nodes are running
-        if self.network_topology:
-            skipped = []
-            for node in self.nodelist():
-                if node.is_running() and node.pid:
-                    node._apply_tc_rules()
-                else:
-                    skipped.append(node.name)
-            if skipped:
-                LOGGER.warning(
-                    "Skipped tc/netem rules for %d node(s) that are not running: %s",
-                    len(skipped), ", ".join(skipped),
-                )
+        self.apply_network_shaping()
         return started
+
+    def apply_network_shaping(self, nodes=None):
+        """Apply tc/netem delay/loss rules to running nodes; no-op if none configured.
+
+        ``start_nodes()`` calls this automatically; callers starting nodes
+        via ``node.start()`` directly must call it themselves.
+
+        Args:
+            nodes: nodes to shape; defaults to every node in the cluster.
+        """
+        if not self.network_topology:
+            return
+        target_nodes = list(nodes) if nodes is not None else self.nodelist()
+        # no-op when the topology defines no delay/loss rules
+        if not any(
+            self.network_topology.build_tc_commands(node.name) for node in target_nodes
+        ):
+            return
+
+        def shape(node):
+            if node.is_running() and node.pid:
+                node._apply_tc_rules()
+                return None, None
+            return node.name, None
+
+        def shape_safe(node):
+            try:
+                return shape(node)
+            except Exception as exc:  # noqa: BLE001 - report, don't swallow
+                return None, (node.name, exc)
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=min(16, len(target_nodes))
+        ) as pool:
+            results = list(pool.map(shape_safe, target_nodes))
+        skipped = [name for name, _ in results if name]
+        failures = [failure for _, failure in results if failure]
+        if skipped:
+            LOGGER.warning(
+                "Skipped tc/netem rules for %d node(s) that are not running: %s",
+                len(skipped), ", ".join(skipped),
+            )
+        if failures:
+            details = ", ".join(f"{name}: {exc}" for name, exc in failures)
+            raise RuntimeError(
+                f"Failed to apply tc/netem network shaping on {len(failures)} "
+                f"node(s): {details}"
+            )
+
+    def _batch_remove_nodes(self, nodes):
+        """Remove several nodes' containers in a few batched `rm` calls
+        instead of one `podman rm` subprocess per node.
+
+        Falls back to per-node removal (trying each node's alternate
+        target) only for whichever containers a batch failed to remove.
+        """
+        nodes = list(nodes)
+        if not nodes:
+            return
+        primary_target_to_node = {}
+        for n in nodes:
+            targets = n._detach_container()
+            n._pending_remove_targets = targets
+            if targets:
+                primary_target_to_node[targets[0]] = n
+
+        if not primary_target_to_node:
+            return
+        client = self.get_container_client()
+        failed_targets = client.remove_containers(
+            list(primary_target_to_node.keys()), force=True, volumes=True, chunk_size=10
+        )
+        for target in failed_targets:
+            n = primary_target_to_node[target]
+            fallback_targets = n._pending_remove_targets[1:]
+            removed = False
+            for fallback in fallback_targets:
+                try:
+                    client.remove_container(fallback, force=True, volumes=True, check=True)
+                    removed = True
+                    break
+                except ContainerClientError as exc:
+                    LOGGER.warning("podman rm -f %s failed: %s", fallback, exc)
+            if not removed:
+                LOGGER.error(
+                    "Failed to remove container for %s using targets %s",
+                    n.name,
+                    n._pending_remove_targets,
+                )
 
     def clear(self):
         """Remove all containers, then wipe node data directories.
@@ -1709,15 +1731,10 @@ class ScyllaPodmanCluster(ScyllaCluster):
             LOGGER.warning(
                 "Failed to stop client container during clear()", exc_info=True
             )
-        for n in list(self.nodes.values()):
-            try:
-                n.remove()
-            except Exception:
-                LOGGER.warning(
-                    "Failed to remove container for node %s during clear()",
-                    n.name,
-                    exc_info=True,
-                )
+        try:
+            self._batch_remove_nodes(self.nodes.values())
+        except Exception:
+            LOGGER.warning("Failed to batch-remove node containers during clear()", exc_info=True)
         # Wipe node data directories (node.pid is None after remove() so no container access)
         for n in list(self.nodes.values()):
             try:
@@ -1756,13 +1773,26 @@ class ScyllaPodmanCluster(ScyllaCluster):
                     "Failed to stop client container during remove()",
                     exc_info=True,
                 )
-            for n in list(self.nodes.values()):
+            try:
+                self._batch_remove_nodes(self.nodes.values())
+            except Exception:
+                LOGGER.warning("Failed to batch-remove node containers during remove()", exc_info=True)
+            # Stop the shared event monitor/log streams -- final teardown,
+            # otherwise this cluster leaks a background thread per process.
+            if self._event_monitor:
                 try:
-                    n.remove()
+                    self._event_monitor.stop()
                 except Exception:
                     LOGGER.warning(
-                        "Failed to remove container for node %s during remove()",
-                        n.name,
+                        "Failed to stop event monitor during remove()",
+                        exc_info=True,
+                    )
+            if self._log_manager:
+                try:
+                    self._log_manager.stop_all()
+                except Exception:
+                    LOGGER.warning(
+                        "Failed to stop log manager during remove()",
                         exc_info=True,
                     )
             try:
@@ -1823,13 +1853,7 @@ class ScyllaPodmanCluster(ScyllaCluster):
 
 
 class ScyllaPodmanNode(ScyllaNode):
-    """A ScyllaDB node running in a podman container with topology-aware networking.
-
-    TODO: Cluster startup takes ~2 minutes per node (3-node cluster ~6-7 min total).
-          This is significantly longer than expected; investigate root cause.
-          Candidates: supervisorctl update triggering a second Scylla start cycle,
-          gossip ring settling with --seeds handshake, or iproute install latency.
-    """
+    """A ScyllaDB node running in a podman container with topology-aware networking."""
 
     _STATUS_CACHE_TTL = 5
 
@@ -1869,6 +1893,10 @@ class ScyllaPodmanNode(ScyllaNode):
         # Default to 1 CPU (not 2 like ScyllaNode) to reduce resource usage
         self._smp = 1
 
+    def get_container_client(self):
+        """Return the shared PodmanClient used for all container operations."""
+        return _get_podman_client()
+
     def _supervisor_program_names(self):
         if self.pid is None:
             return set()
@@ -1876,21 +1904,18 @@ class ScyllaPodmanNode(ScyllaNode):
         # during the lifetime of a container).
         if self._cached_supervisor_programs is not None:
             return self._cached_supervisor_programs
-        res = run(
-            ["podman", "exec", self.pid, "supervisorctl", "status"],
-            stdout=PIPE,
-            stderr=PIPE,
-            text=True,
+        returncode, stdout, stderr = self.get_container_client().exec_command(
+            self.pid, ["supervisorctl", "status"]
         )
         # supervisorctl status exits with code 1 whenever any process is not
         # RUNNING (e.g. STOPPED after a graceful stop).  The output is still
         # valid program-list output, so parse it regardless of returncode.
         # Only bail out if stdout is completely empty (podman exec failed).
-        if not res.stdout.strip():
+        if not stdout.strip():
             return set()
         programs = {
             line.split()[0]
-            for line in res.stdout.splitlines()
+            for line in stdout.splitlines()
             if line.strip() and ":" not in line.split()[0]
         }
         if programs:
@@ -2060,6 +2085,7 @@ class ScyllaPodmanNode(ScyllaNode):
         if not os.path.exists(os.path.join(self.local_yaml_path, "scylla.yaml")):
             cache_dir = self.cluster._get_image_conf_cache_dir()
             _copy_conf_dir(cache_dir, self.local_yaml_path)
+        self._ensure_log_file()
         super(ScyllaPodmanNode, self).update_yaml()
 
         conf_file = os.path.join(self.get_conf_dir(), common.SCYLLA_CONF)
@@ -2126,25 +2152,23 @@ class ScyllaPodmanNode(ScyllaNode):
         The container is connected to its rack network with a static IP.
         After creation, IP routes and tc rules are set up.
         """
+        client = _get_podman_client()
         if self.pid:
             # Verify the container is still alive.  If it was killed
             # externally (OOM, ``podman stop``, etc.) we need to clear
             # the stale pid so a fresh container can be created.
-            res = run(
-                ["podman", "inspect", "--format", "{{.State.Status}}", self.pid],
-                stdout=PIPE, stderr=DEVNULL, text=True,
-            )
-            if res.returncode == 0 and res.stdout.strip() in ("running", "created", "paused"):
+            status = client.get_container_status(self.pid)
+            if status in _RUNNING_CONTAINER_STATES:
                 return
             LOGGER.warning(
                 "Container %s for node %s is no longer running (status: %s); "
                 "will recreate",
                 self.pid,
                 self.name,
-                res.stdout.strip() if res.returncode == 0 else "not found",
+                status or "not found",
             )
             # Clean up the dead container
-            run(["podman", "rm", "-f", self.pid], stdout=DEVNULL, stderr=DEVNULL)
+            client.remove_container(self.pid, force=True)
             self._cached_supervisor_programs = None
             if self._log_manager:
                 self._log_manager.stop_stream(self.pid)
@@ -2177,75 +2201,62 @@ class ScyllaPodmanNode(ScyllaNode):
         # Do not publish Alternator to fixed host ports. Each node already has a
         # stable per-rack container IP; host-port publishing would collide when
         # multiple nodes enable Alternator in the same cluster.
-        port_args = []
 
         self._prepare_bind_mounts()
 
-        # Volume mounts
-        # Use :z for SELinux relabeling so rootless podman can read the config
-        mount_args = [
-            "-v",
-            f"{self.local_yaml_path}:/etc/scylla:z",
-            "-v",
-            "/tmp:/tmp",
-        ]
+        # /tmp is excluded from SELinux relabeling below (shared system
+        # path; some policies refuse it, and it's used by other processes).
+        volumes = {
+            self.local_yaml_path: "/etc/scylla",
+            "/tmp": "/tmp",
+        }
         for d in self.share_directories:
-            mount_args.extend(
-                [
-                    "-v",
-                    f"{os.path.join(self.get_path(), d)}:{os.path.join(self.base_data_path, d)}:z",
-                ]
-            )
+            volumes[os.path.join(self.get_path(), d)] = os.path.join(self.base_data_path, d)
 
         existing_container = _remove_named_container_if_safe(
             self.podman_name, allow_reuse_current_running=True
         )
         if existing_container is not None:
             self.pid = existing_container.get("Id", self.podman_name)
+            # Reset caches, same as the recreate/error-cleanup paths below.
+            self._cached_supervisor_programs = None
+            self._cached_nodetool_support = {}
+            self._last_status_check = 0.0
             self.network_interfaces = {
                 k: (node_ip, v[1]) for k, v in list(self.network_interfaces.items())
             }
             return
 
+        cpu_assignments = getattr(self.cluster, "_cpu_assignments", {})
+        pinned_cpus = cpu_assignments.get(self.name)
+        cpuset_cpus = ",".join(str(c) for c in pinned_cpus) if pinned_cpus else None
+
         # Start the container.  All configuration is bind-mounted; supervisord
         # starts Scylla with the correct settings immediately.
-        cmd = [
-            "podman",
-            "run",
-            *port_args,
-            *mount_args,
-            "--name",
-            self.podman_name,
-            "--network",
-            network_name,
-            "--ip",
-            node_ip,
-            "--label",
-            f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}",
-            "--cap-add",
-            "NET_ADMIN",
-            *self._pinning_container_args(),
-            "-d",
-            self.cluster.podman_image,
-            *seed_args,
-            *args,
-        ]
-        res = run(cmd, stdout=PIPE, stderr=PIPE, text=True)
-
-        if res.returncode != 0:
-            LOGGER.error(res)
+        try:
+            self.pid = client.run_container(
+                image=self.cluster.podman_image,
+                name=self.podman_name,
+                volumes=volumes,
+                volumes_no_relabel=["/tmp"],
+                network=network_name,
+                ip=node_ip,
+                labels=_resource_labels(),
+                cap_add=["NET_ADMIN"],
+                cpuset_cpus=cpuset_cpus,
+                command=[*seed_args, *args],
+            )
+        except ContainerClientError as exc:
             raise RuntimeError(
-                f"Failed to create podman container {self.podman_name}: {res.stderr}"
+                f"Failed to create podman container {self.podman_name}: {exc}"
             )
 
-        self.pid = res.stdout.strip()
         self._fresh_container = True
+        self._last_status_check = 0.0  # invalidate status cache after state change
+        self._ensure_log_file()
 
         try:
-            # Log streaming is on-demand.  Skipping it here avoids one
-            # ``podman logs -f`` subprocess per container.
-            if self._event_monitor:
-                self._event_monitor.register(self, self.pid)
+            # event-monitor registration happens in _start_scylla()
 
             # Update network interfaces with the actual rack IP.
             self.network_interfaces = {
@@ -2271,13 +2282,10 @@ class ScyllaPodmanNode(ScyllaNode):
             if self._event_monitor and self.pid:
                 self._event_monitor.unregister(self.pid)
             if self.pid:
-                run(
-                    ["podman", "rm", "--volumes", "-f", self.pid],
-                    stdout=DEVNULL,
-                    stderr=DEVNULL,
-                )
+                client.remove_container(self.pid, force=True, volumes=True)
                 self.pid = None
             raise
+
 
     def _setup_routes(self):
         """Add IP routes inside the container for cross-rack connectivity.
@@ -2369,39 +2377,26 @@ class ScyllaPodmanNode(ScyllaNode):
             )
 
     def service_start(self, service_name):
+        client = self.get_container_client()
         # Clear any FATAL/EXITED state so supervisord will accept the start
         # command.  After an ungraceful stop (kill -9) the process lands in
         # FATAL and supervisorctl refuses a plain "start" until cleared.
         status = self.service_status(service_name)
         if status and status.upper() in ("FATAL", "EXITED", "BACKOFF"):
-            run(
-                ["podman", "exec", self.pid, "supervisorctl", "clear", service_name],
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True,
-            )
+            client.exec_command(self.pid, ["supervisorctl", "clear", service_name])
         # Retry up to 30s in case supervisord isn't ready yet (fresh
         # container just started by podman run -d).
         for attempt in range(30):
-            res = run(
-                [
-                    "podman",
-                    "exec",
-                    self.pid,
-                    "supervisorctl",
-                    "start",
-                    service_name,
-                ],
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True,
+            returncode, stdout, stderr = client.exec_command(
+                self.pid, ["supervisorctl", "start", service_name]
             )
-            if res.returncode == 0:
+            if returncode == 0:
+                self._last_status_check = 0.0  # invalidate status cache
                 return
             if attempt == 29:
-                LOGGER.debug(res.stdout)
+                LOGGER.debug(stdout)
                 raise RuntimeError(
-                    f"service {service_name} failed to start in {self.name}: {res.stderr}"
+                    f"service {service_name} failed to start in {self.name}: {stderr}"
                 )
             time.sleep(1)
 
@@ -2415,36 +2410,118 @@ class ScyllaPodmanNode(ScyllaNode):
                 service_name, self.name, current_status,
             )
             return
-        res = run(
-            ["podman", "exec", self.pid, "supervisorctl", "stop", service_name],
-            stdout=PIPE,
-            stderr=PIPE,
-            text=True,
+        returncode, stdout, stderr = self.get_container_client().exec_command(
+            self.pid, ["supervisorctl", "stop", service_name]
         )
-        if res.returncode != 0:
-            LOGGER.debug(res.stdout)
+        if returncode != 0:
+            LOGGER.debug(stdout)
             raise RuntimeError(
-                f"service {service_name} failed to stop in {self.name}: {res.stderr}"
+                f"service {service_name} failed to stop in {self.name}: {stderr}"
             )
+        self._last_status_check = 0.0  # invalidate status cache
 
     def service_status(self, service_name):
         if self.pid is None:
             return "DOWN"
-        res = run(
-            ["podman", "exec", self.pid, "supervisorctl", "status", service_name],
-            stdout=PIPE,
-            stderr=PIPE,
-            text=True,
+        returncode, stdout, stderr = self.get_container_client().exec_command(
+            self.pid, ["supervisorctl", "status", service_name]
         )
         # supervisorctl status <name> exits with 1 when the process exists but
         # is not RUNNING (e.g. STOPPED/EXITED/FATAL).  The second token on
         # stdout is still the status string we need.  Only fall back to DOWN
         # when podman exec itself failed (empty stdout).
-        parts = res.stdout.split()
+        parts = stdout.split()
         if len(parts) > 1:
             return parts[1]
-        LOGGER.debug("service %s failed to get status in %s: %s", service_name, self.name, res.stderr)
+        LOGGER.debug("service %s failed to get status in %s: %s", service_name, self.name, stderr)
         return "DOWN"
+
+    def _ensure_log_file(self):
+        """Create an empty logs/system.log so grep_log/watch_log_for don't crash
+        or hang on a missing file (--log-to-stdout means nothing writes it)."""
+        log_path = self.logfilename()
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        if not os.path.exists(log_path):
+            open(log_path, "a").close()
+
+    def _ensure_log_stream(self):
+        """Start on-demand `podman logs -f` streaming into system.log (idempotent)."""
+        self._ensure_log_file()
+        if self._log_manager and self.pid:
+            self._log_manager.start_stream(self.pid, self.logfilename())
+
+    def watch_log_for(self, exprs, from_mark=None, timeout=600, process=None,
+                      verbose=False, filename='system.log', polling_interval=0.01):
+        # start log streaming on demand
+        if filename == 'system.log':
+            self._ensure_log_stream()
+        return super(ScyllaPodmanNode, self).watch_log_for(
+            exprs, from_mark=from_mark, timeout=timeout, process=process,
+            verbose=verbose, filename=filename, polling_interval=polling_interval,
+        )
+
+    def _rest_api_get(self, path, timeout=10):
+        """GET a Scylla REST API path via curl inside the container.
+        The host cannot reach container IPs in rootless podman."""
+        if self.pid is None:
+            return None
+        returncode, stdout, stderr = self.get_container_client().exec_command(
+            self.pid,
+            ["curl", "-sf", "--max-time", str(int(timeout)),
+             f"http://localhost:{self.api_port}{path}"],
+            timeout=timeout + 5,
+        )
+        return stdout if returncode == 0 else None
+
+    def _rest_api_json(self, path, timeout=10):
+        body = self._rest_api_get(path, timeout=timeout)
+        if body is None:
+            return None
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            LOGGER.warning("Unexpected REST response from %s%s: %r", self.name, path, body)
+            return None
+
+    def hostid(self, timeout=60, force_refresh=False):
+        if self.node_hostid and not force_refresh:
+            return self.node_hostid
+        hostid = self._rest_api_json("/storage_service/hostid/local", timeout=min(timeout, 30))
+        if hostid is not None:
+            self.node_hostid = hostid
+        return self.node_hostid
+
+    def watch_rest_for_alive(self, nodes, timeout=120, wait_normal_token_owner=True):
+        """Same checks as ScyllaNode.watch_rest_for_alive, but via in-container curl."""
+        nodes_tofind = nodes if isinstance(nodes, list) else [nodes]
+        tofind = set(node.address() for node in nodes_tofind)
+        tofind_host_id_map = dict((node.address(), node.hostid()) for node in nodes_tofind)
+        endtime = time.time() + timeout
+        while time.time() < endtime:
+            live = set(self._rest_api_json("/gossiper/endpoint/live") or [])
+            live -= set(self._rest_api_json("/storage_service/nodes/joining") or [])
+            if tofind.issubset(live):
+                have_no_tokens = {
+                    addr for addr in tofind
+                    if not self._rest_api_json(f"/storage_service/tokens/{addr}")
+                }
+                if not have_no_tokens:
+                    if not wait_normal_token_owner:
+                        return
+                    host_id_map = {
+                        r["key"]: r["value"]
+                        for r in self._rest_api_json("/storage_service/host_id") or []
+                    }
+                    normal = {
+                        addr for addr, hid in host_id_map.items()
+                        if addr in tofind_host_id_map
+                        and (hid == tofind_host_id_map[addr] or not tofind_host_id_map[addr])
+                    }
+                    tofind -= normal
+                    if not tofind:
+                        return
+            time.sleep(0.1)
+        raise TimeoutError(f"watch_rest_for_alive() timeout after {timeout} seconds")
 
     def wait_for_binary_interface(self, **kwargs):
         timeout = kwargs.get("timeout", 420)
@@ -2456,6 +2533,7 @@ class ScyllaPodmanNode(ScyllaNode):
 
         binary_itf = self.network_interfaces["binary"]
         container_id = self.pid
+        client = self.get_container_client()
 
         def is_binary_interface_listening():
             if process is not None:
@@ -2466,26 +2544,16 @@ class ScyllaPodmanNode(ScyllaNode):
                     )
             if container_id is None:
                 return False
-            try:
-                res = run(
-                    [
-                        "podman",
-                        "exec",
-                        container_id,
-                        "bash",
-                        "-c",
-                        f"echo > /dev/tcp/{binary_itf[0]}/{binary_itf[1]}",
-                    ],
-                    stdout=DEVNULL,
-                    stderr=DEVNULL,
-                    timeout=5,
-                )
-                return res.returncode == 0
-            except subprocess.TimeoutExpired:
-                return False
+            returncode, stdout, stderr = client.exec_command(
+                container_id,
+                ["bash", "-c", f"echo > /dev/tcp/{binary_itf[0]}/{binary_itf[1]}"],
+                timeout=5,
+            )
+            return returncode == 0
 
+        # short initial delay before probing, scaled with cluster size
         n = len(self.cluster.nodes)
-        first = min(10.0 + n * 0.3, 60.0)
+        first = min(3.0 + n * 0.1, 30.0)
         step = min(1.0 + n * 0.05, 5.0)
         remaining = remaining_timeout()
         if not common.wait_for(func=is_binary_interface_listening, timeout=remaining, first=first, step=step):
@@ -2696,6 +2764,41 @@ class ScyllaPodmanNode(ScyllaNode):
         self._process_scylla = PodmanProcess(self.pid)
         return self._process_scylla
 
+    def _get_service_pid(self, service_name, warn_prefix=None):
+        """Return the in-container PID of *service_name* via supervisorctl, or None.
+
+        Shared by do_stop()/kill()/pause()/resume() (kill is a shell builtin,
+        not a binary in the container, so signals go via `bash -c`).
+        """
+        returncode, stdout, stderr = self.get_container_client().exec_command(
+            self.pid, ["supervisorctl", "pid", service_name]
+        )
+        if returncode != 0 or not stdout.strip():
+            log = LOGGER.warning if warn_prefix else LOGGER.debug
+            log(
+                "%sfailed to get pid of %s in %s: %s",
+                f"{warn_prefix}: " if warn_prefix else "",
+                service_name, self.name, stderr,
+            )
+            return None
+        pid = stdout.strip()
+        if not pid.isdigit() or pid == "0":
+            LOGGER.warning(
+                "Unexpected PID value from supervisorctl for %s in %s: %r",
+                service_name, self.name, pid,
+            )
+            return None
+        return int(pid)
+
+    def _signal_service(self, service_name, sig_name, warn_prefix=None):
+        """Send `sig_name` (e.g. '9', 'STOP', 'CONT') to *service_name*'s process."""
+        pid = self._get_service_pid(service_name, warn_prefix=warn_prefix)
+        if pid is None:
+            return
+        self.get_container_client().exec_command(
+            self.pid, ["bash", "-c", f"kill -{sig_name} {pid}"]
+        )
+
     def do_stop(self, gently=True):
         # Stop the log streamer so it doesn't become orphaned
         if self._log_manager and self.pid:
@@ -2714,80 +2817,17 @@ class ScyllaPodmanNode(ScyllaNode):
         else:
             jmx_service = self._jmx_service_name()
             scylla_service = self._scylla_service_name()
-            # Get the PID of the scylla service, then kill -9 via bash
-            pid_res = run(
-                [
-                    "podman",
-                    "exec",
-                    self.pid,
-                    "supervisorctl",
-                    "pid",
-                    scylla_service,
-                ],
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True,
-            )
-            if pid_res.returncode == 0 and pid_res.stdout.strip():
-                _pid = pid_res.stdout.strip()
-                if not _pid.isdigit() or _pid == "0":
-                    LOGGER.warning(
-                        "Unexpected PID value from supervisorctl for %s "
-                        "in %s: %r",
-                        scylla_service, self.name, _pid,
-                    )
-                else:
-                    run(
-                        [
-                            "podman",
-                            "exec",
-                            self.pid,
-                            "bash",
-                            "-c",
-                            f"kill -9 {_pid}",
-                        ],
-                        stdout=PIPE,
-                        stderr=PIPE,
-                    )
-            # Tell supervisord the service is stopped so autorestart
-            # does not kick in after the kill -9.
+            # kill -9 the service's process directly (kill is a shell
+            # builtin, not a binary in the Scylla container), then tell
+            # supervisord the service is stopped so autorestart does not
+            # kick in after the kill -9.
+            self._signal_service(scylla_service, "9")
             self.service_stop(scylla_service)
             if jmx_service:
-                jmx_pid_res = run(
-                    [
-                        "podman",
-                        "exec",
-                        self.pid,
-                        "supervisorctl",
-                        "pid",
-                        jmx_service,
-                    ],
-                    stdout=PIPE,
-                    stderr=PIPE,
-                    text=True,
-                )
-                if jmx_pid_res.returncode == 0 and jmx_pid_res.stdout.strip():
-                    _jmx_pid = jmx_pid_res.stdout.strip()
-                    if not _jmx_pid.isdigit() or _jmx_pid == "0":
-                        LOGGER.warning(
-                            "Unexpected PID value from supervisorctl for %s "
-                            "in %s: %r",
-                            jmx_service, self.name, _jmx_pid,
-                        )
-                    else:
-                        run(
-                            [
-                                "podman",
-                                "exec",
-                                self.pid,
-                                "bash",
-                                "-c",
-                                f"kill -9 {_jmx_pid}",
-                            ],
-                            stdout=PIPE,
-                            stderr=PIPE,
-                        )
+                self._signal_service(jmx_service, "9")
                 self.service_stop(jmx_service)
+        self._last_status_check = 0.0  # invalidate status cache
+
 
     def wait_until_stopped(self, wait_seconds=None, marks=None, dump_core=True):
         """Wait until the Scylla service inside the container is no longer running.
@@ -2818,7 +2858,16 @@ class ScyllaPodmanNode(ScyllaNode):
         _busybox_chmod(self.get_path(), "/node", "775", f"clear chmod for {self.name}")
         super(ScyllaPodmanNode, self).clear(*args, **kwargs)
 
-    def remove(self):
+    def _detach_container(self):
+        """Unhook this node from its container without removing it yet.
+
+        Stops log streaming/event tracking, invalidates container-tied
+        caches, and clears self.pid so subsequent is_running()/status calls
+        don't try to exec into a container that's about to disappear.
+
+        Returns the ordered list of remove targets to try (container ID
+        first, then the deterministic podman name as a fallback).
+        """
         if self._log_manager and self.pid:
             self._log_manager.stop_stream(self.pid)
         if self._event_monitor and self.pid:
@@ -2828,36 +2877,28 @@ class ScyllaPodmanNode(ScyllaNode):
         self._cached_supervisor_programs = None
         self._cached_nodetool_support = {}
         container_id = self.pid
-        # Clear pid first so that any subsequent is_running()/service_status()
-        # calls (e.g. from the parent stop() during teardown) take the early
-        # return path in _update_podman_status instead of exec-ing into a removed
-        # container.
         self.pid = None
-        # Try to remove by container ID first, then by deterministic podman
-        # name as a fallback.  Log and warn on failures — silent swallowing
-        # of podman rm errors leads to leaked containers.
         targets = []
         if container_id:
             targets.append(str(container_id))
         if hasattr(self, "podman_name") and self.podman_name:
             targets.append(self.podman_name)
+        return targets
+
+    def remove(self):
+        # Try to remove by container ID first, then by deterministic podman
+        # name as a fallback.  Log and warn on failures — silent swallowing
+        # of podman rm errors leads to leaked containers.
+        targets = self._detach_container()
         removed = False
+        client = self.get_container_client()
         for target in targets:
-            res = run(
-                ["podman", "rm", "--volumes", "-f", target],
-                stdout=PIPE,
-                stderr=PIPE,
-                text=True,
-            )
-            if res.returncode == 0:
+            try:
+                client.remove_container(target, force=True, volumes=True, check=True)
                 removed = True
                 break
-            LOGGER.warning(
-                "podman rm -f %s failed (rc=%d): %s",
-                target,
-                res.returncode,
-                res.stderr.strip(),
-            )
+            except ContainerClientError as exc:
+                LOGGER.warning("podman rm -f %s failed: %s", target, exc)
         if not removed and targets:
             LOGGER.error(
                 "Failed to remove container for %s using targets %s",
@@ -2936,7 +2977,7 @@ class ScyllaPodmanNode(ScyllaNode):
     def get_tool(self, toolname):
         if self.pid is None:
             raise RuntimeError(f"Cannot run {toolname} on {self.name}: no running container")
-        podman_bin = which("podman") or "podman"
+        podman_bin = self.get_container_client().runtime_path
         return [podman_bin, "exec", "-i", f"{self.pid}", f"{toolname}"]
 
     def _find_cmd(self, command_name):
@@ -2962,48 +3003,7 @@ class ScyllaPodmanNode(ScyllaNode):
     def kill(self, __signal):
         if self.pid is None:
             return
-        service_name = self._scylla_service_name()
-        # Get the PID of the service first, then send the signal via bash
-        # (kill is a shell builtin, not a binary in the Scylla container).
-        pid_res = run(
-            [
-                "podman",
-                "exec",
-                self.pid,
-                "supervisorctl",
-                "pid",
-                service_name,
-            ],
-            stdout=PIPE,
-            stderr=PIPE,
-            text=True,
-        )
-        if pid_res.returncode != 0 or not pid_res.stdout.strip():
-            LOGGER.debug(
-                "Failed to get pid of %s in %s: %s",
-                service_name, self.name, pid_res.stderr,
-            )
-            return
-        _pid = pid_res.stdout.strip()
-        if not _pid.isdigit() or _pid == "0":
-            LOGGER.warning(
-                "Unexpected PID value from supervisorctl for %s "
-                "in %s: %r",
-                service_name, self.name, _pid,
-            )
-            return
-        run(
-            [
-                "podman",
-                "exec",
-                self.pid,
-                "bash",
-                "-c",
-                f"kill -{int(__signal)} {_pid}",
-            ],
-            stdout=PIPE,
-            stderr=PIPE,
-        )
+        self._signal_service(self._scylla_service_name(), str(int(__signal)))
 
     def pause(self):
         """Pause the Scylla process inside the container using SIGSTOP.
@@ -3014,32 +3014,7 @@ class ScyllaPodmanNode(ScyllaNode):
         """
         if self.pid is None:
             return
-        service_name = self._scylla_service_name()
-        pid_res = run(
-            ["podman", "exec", self.pid, "supervisorctl", "pid", service_name],
-            stdout=PIPE,
-            stderr=PIPE,
-            text=True,
-        )
-        if pid_res.returncode != 0 or not pid_res.stdout.strip():
-            LOGGER.warning(
-                "Cannot pause %s: failed to get Scylla PID from supervisorctl",
-                self.name,
-            )
-            return
-        _pid = pid_res.stdout.strip()
-        if not _pid.isdigit() or _pid == "0":
-            LOGGER.warning(
-                "Cannot pause %s: unexpected PID value %r from supervisorctl",
-                self.name,
-                _pid,
-            )
-            return
-        run(
-            ["podman", "exec", self.pid, "bash", "-c", f"kill -STOP {_pid}"],
-            stdout=PIPE,
-            stderr=PIPE,
-        )
+        self._signal_service(self._scylla_service_name(), "STOP", warn_prefix=f"Cannot pause {self.name}")
 
     def resume(self):
         """Resume the Scylla process inside the container using SIGCONT.
@@ -3048,32 +3023,7 @@ class ScyllaPodmanNode(ScyllaNode):
         """
         if self.pid is None:
             return
-        service_name = self._scylla_service_name()
-        pid_res = run(
-            ["podman", "exec", self.pid, "supervisorctl", "pid", service_name],
-            stdout=PIPE,
-            stderr=PIPE,
-            text=True,
-        )
-        if pid_res.returncode != 0 or not pid_res.stdout.strip():
-            LOGGER.warning(
-                "Cannot resume %s: failed to get Scylla PID from supervisorctl",
-                self.name,
-            )
-            return
-        _pid = pid_res.stdout.strip()
-        if not _pid.isdigit() or _pid == "0":
-            LOGGER.warning(
-                "Cannot resume %s: unexpected PID value %r from supervisorctl",
-                self.name,
-                _pid,
-            )
-            return
-        run(
-            ["podman", "exec", self.pid, "bash", "-c", f"kill -CONT {_pid}"],
-            stdout=PIPE,
-            stderr=PIPE,
-        )
+        self._signal_service(self._scylla_service_name(), "CONT", warn_prefix=f"Cannot resume {self.name}")
 
     def unlink(self, file_path):
         if not os.path.exists(file_path):
@@ -3082,26 +3032,17 @@ class ScyllaPodmanNode(ScyllaNode):
         # mounted file IS the mount point — ``rm`` inside the container would
         # fail with EBUSY if we mounted the file directly.
         parent_dir = os.path.dirname(os.path.abspath(file_path))
-        res = run(
-            [
-                "podman",
-                "run",
-                "--rm",
-                "-v",
-                f"{parent_dir}:{parent_dir}",
-                BUSYBOX_IMAGE,
-                "rm",
-                os.path.abspath(file_path),
-            ],
-            stdout=DEVNULL,
-            stderr=PIPE,
-            text=True,
-        )
-        if res.returncode != 0:
-            LOGGER.warning(
-                "unlink %s via busybox failed (rc=%d): %s",
-                file_path, res.returncode, res.stderr.strip(),
+        try:
+            self.get_container_client().run_container(
+                image=BUSYBOX_IMAGE,
+                name=f"ccm-unlink-{uuid.uuid4().hex[:12]}",
+                volumes={parent_dir: parent_dir},
+                command=["rm", os.path.abspath(file_path)],
+                detach=False,
+                remove=True,
             )
+        except ContainerClientError as exc:
+            LOGGER.warning("unlink %s via busybox failed: %s", file_path, exc)
 
     def chmod(self, file_path, permissions):
         prefix = self.get_path()
@@ -3116,84 +3057,6 @@ class ScyllaPodmanNode(ScyllaNode):
         super(ScyllaPodmanNode, self).rmtree(path)
 
 
-class PodmanLogManager:
-    """Manages log streaming for all containers using per-container daemon threads.
-
-    Each container's log stream runs a ``podman logs -f`` process in a dedicated
-    daemon thread so that log streaming is available for every container regardless
-    of cluster size.
-    """
-
-    def __init__(self):
-        self._streams: dict[str, "_LogStreamState"] = {}
-
-    def start_stream(self, container_id: str, log_file_path: str):
-        """Begin streaming logs for *container_id* to *log_file_path*."""
-        if container_id in self._streams:
-            return
-        state = _LogStreamState(log_file_path)
-        self._streams[container_id] = state
-        thread = threading.Thread(
-            target=self._stream_logs,
-            args=(container_id, state),
-            name=f"podman-log-{container_id[:12]}",
-            daemon=True,
-        )
-        thread.start()
-        state.thread = thread
-
-    def stop_stream(self, container_id: str):
-        """Stop the log stream for *container_id*."""
-        state = self._streams.pop(container_id, None)
-        if state is not None:
-            state.stop_event.set()
-
-    def stop_all(self):
-        """Stop all managed log streams."""
-        for container_id, state in list(self._streams.items()):
-            state.stop_event.set()
-        self._streams.clear()
-
-    def _stream_logs(self, container_id, state):
-        """Background: run ``podman logs -f`` and write to the log file."""
-        try:
-            with open(state.log_file_path, "a", encoding="utf-8") as f:
-                process = Popen(
-                    ["podman", "logs", "-f", container_id],
-                    stdout=PIPE,
-                    stderr=STDOUT,
-                )
-                try:
-                    for line in process.stdout:
-                        if state.stop_event.is_set():
-                            break
-                        f.write(line.decode("utf-8", errors="replace"))
-                        f.flush()
-                except Exception:
-                    LOGGER.warning(
-                        "Podman log stream exception for %s", container_id,
-                        exc_info=True,
-                    )
-                finally:
-                    process.terminate()
-                    process.wait(timeout=5)
-        except Exception:
-            LOGGER.warning(
-                "Podman log stream failed to start for %s", container_id,
-                exc_info=True,
-            )
-
-
-class _LogStreamState:
-    """Internal state for a single container's log stream."""
-    __slots__ = ("log_file_path", "stop_event", "thread")
-
-    def __init__(self, log_file_path):
-        self.log_file_path = log_file_path
-        self.stop_event = threading.Event()
-        self.thread = None
-
-
 class PodmanEventMonitor:
     """A single daemon thread that subscribes to ``podman events --stream``.
 
@@ -3203,12 +3066,14 @@ class PodmanEventMonitor:
     ``podman exec supervisorctl status`` and per-node ``PodmanLogger`` threads.
     """
 
-    def __init__(self, log_manager: PodmanLogManager):
+    def __init__(self, log_manager: ContainerLogManager):
         self._log_manager = log_manager
         self._containers: dict[str, "ScyllaPodmanNode"] = {}
         self._lock = threading.Lock()
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
+        self._process: Popen | None = None
+        self._process_lock = threading.Lock()
 
     def register(self, node: "ScyllaPodmanNode", container_id: str):
         """Register a node so the monitor updates its status on death events."""
@@ -3232,8 +3097,23 @@ class PodmanEventMonitor:
         self._thread.start()
 
     def stop(self):
-        """Stop the event listener thread."""
+        """Stop the event listener thread.
+
+        Setting ``_stop_event`` alone would not unblock a worker thread
+        parked in the blocking ``for line in process.stdout`` read in
+        ``_event_loop()`` on a quiet event stream. Terminate the active
+        ``podman events`` subprocess first so that read gets EOF and the
+        loop can observe the stop event and exit, letting ``join()``
+        actually succeed instead of leaking the thread and subprocess.
+        """
         self._stop_event.set()
+        with self._process_lock:
+            process = self._process
+        if process is not None:
+            try:
+                process.terminate()
+            except Exception:
+                LOGGER.debug("Failed to terminate podman events process", exc_info=True)
         if self._thread is not None:
             self._thread.join(timeout=5)
             self._thread = None
@@ -3251,6 +3131,8 @@ class PodmanEventMonitor:
                 LOGGER.warning("podman binary not found; event monitor disabled")
                 return
 
+            with self._process_lock:
+                self._process = process
             try:
                 for line in process.stdout:
                     if self._stop_event.is_set():
@@ -3264,7 +3146,14 @@ class PodmanEventMonitor:
                 LOGGER.debug("Podman event stream ended", exc_info=True)
             finally:
                 process.terminate()
-                process.wait(timeout=5)
+                try:
+                    process.wait(timeout=5)
+                except TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+                with self._process_lock:
+                    if self._process is process:
+                        self._process = None
                 if not self._stop_event.is_set():
                     time.sleep(1)
 
@@ -3286,9 +3175,3 @@ class PodmanEventMonitor:
             node._notify_container_died()
         elif event_status in ("start", "restart"):
             node._notify_container_started()
-
-    _event_statuses: dict[str, str] = {}
-
-    def get_event_status(self, container_id):
-        """Return the last-known status for *container_id* or None."""
-        return self._event_statuses.get(container_id)

--- a/docs/podman-network-topology.md
+++ b/docs/podman-network-topology.md
@@ -1,0 +1,323 @@
+# Podman Network Topology for CCM
+
+CCM supports running ScyllaDB clusters in rootless podman containers with
+topology-aware network simulation. Each rack gets its own podman network, and
+the host's `tc`/`netem` binaries (applied via `nsenter`) simulate realistic
+latency between racks and datacenters.
+
+## Prerequisites
+
+- **Podman 4.0+** (rootless mode works)
+- **Linux kernel with `sch_netem` module** (`modprobe sch_netem`)
+- **iproute2** installed on the host (provides `tc` and `ip`)
+- **util-linux** installed on the host (provides `nsenter`)
+- A ScyllaDB container image (e.g. `scylladb/scylla:2026.1`)
+- IP forwarding enabled: `sysctl net.ipv4.ip_forward=1`
+
+## Architecture
+
+```
+Host (rootless podman, ip_forward=1, routes between rack bridges)
+  ├── ccm-{cluster}-dc1-rac1 (10.<prefix>.1.0/24) — node1, node2, ccm-client
+  ├── ccm-{cluster}-dc1-rac2 (10.<prefix>.2.0/24) — node3, node4
+  └── ccm-{cluster}-dc2-rac1 (10.<prefix>.3.0/24) — node5
+```
+
+- Each rack has its own podman network with a /24 subnet
+- Each node connects to its rack network only (single interface `eth0`)
+- Intra-rack: bridged directly, 0 latency
+- Cross-rack/DC: routed through host, `tc`/`netem` applied via `nsenter` adds per-destination delay
+- CQL client container sits on Rack1's network with same tc rules
+
+### IP Scheme
+
+| Component      | IP Pattern                           |
+|----------------|--------------------------------------|
+| Rack subnets   | `10.{prefix}.{rack_idx}.0/24`      |
+| Gateways       | `10.{prefix}.{rack_idx}.254`       |
+| Node IPs       | `10.{prefix}.{rack_idx}.{node_offset}` |
+| Client         | `10.{prefix}.1.100` (on first rack) |
+
+Where `rack_idx` starts at 1 and increments globally across all DCs.
+By default CCM prefers the `10.89.x.0/24` range, but if that overlaps with
+existing podman networks it automatically picks another free `10.x.0.0/16`
+prefix. To force a specific prefix, set `CCM_PODMAN_SUBNET_PREFIX`, for example
+`CCM_PODMAN_SUBNET_PREFIX=10.123`.
+
+### Latency Simulation
+
+Traffic shaping uses the host's `tc`/`netem` binaries applied via `nsenter`
+into each container's network namespace.  This avoids installing networking
+tools inside the container image.  The host must have `iproute2` installed
+(provides `tc`) and the kernel's `sch_netem` module loaded.
+
+Each container's `eth0` gets a classful `prio` qdisc with `u32` filters:
+
+- **Band 1** (default): intra-rack traffic — no delay
+- **Band 2**: inter-rack same DC — configurable (default: 1ms)
+- **Band 3**: inter-DC — configurable (default: 50ms) + optional packet loss
+
+## Usage
+
+### CLI
+
+Create a multi-DC cluster with podman:
+
+```bash
+# 2 DCs: DC1 has 2 racks (2 nodes each), DC2 has 1 rack (1 node)
+ccm create mycluster --podman-image scylladb/scylla:2026.1 \
+    -n 4:1 \
+    --inter-rack-delay 2 \
+    --inter-dc-delay 100 \
+    --packet-loss 0.1
+
+ccm start
+```
+
+The `-n` argument uses colon-separated notation for multi-DC. For multi-rack
+within a DC, use the Python API.
+
+### Python API
+
+```python
+from collections import OrderedDict
+from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+cluster = ScyllaPodmanCluster(
+    "/path/to/ccm",
+    "mycluster",
+    podman_image="scylladb/scylla:2026.1",
+    inter_rack_delay_ms=1,
+    inter_dc_delay_ms=50,
+    packet_loss_percent=0.5,
+)
+
+# Multi-DC, multi-rack topology:
+# DC1: RAC1 (2 nodes), RAC2 (2 nodes)
+# DC2: RAC1 (1 node)
+cluster.populate({"DC1": [2, 2], "DC2": [1]})
+cluster.start(wait_for_binary_proto=True)
+
+# Access node IPs from the topology
+topo = cluster.network_topology
+print(topo.get_node_ip("node1"))  # for example: 10.89.1.1
+
+# Start a CQL client container on Rack1's network
+cluster.start_client_container()
+
+# Clean up
+cluster.remove()
+```
+
+### Topology Argument Formats
+
+The `populate()` method accepts several formats:
+
+| Format | Example | Result |
+|--------|---------|--------|
+| `int` | `3` | 1 DC, 1 rack, 3 nodes |
+| `list` | `[2, 3]` | 2 DCs, 1 rack each, 2+3 nodes |
+| `dict(str→int)` | `{"DC1": 2, "DC2": 1}` | 2 DCs, 1 rack each |
+| `dict(str→list)` | `{"DC1": [2, 2], "DC2": [1]}` | DC1: 2 racks, DC2: 1 rack |
+| `dict(str→dict)` | `{"DC1": {"R1": 2, "R2": 2}}` | Explicit rack names |
+
+## Class Hierarchy
+
+```
+Cluster → ScyllaCluster → ScyllaPodmanCluster
+Node    → ScyllaNode    → ScyllaPodmanNode
+```
+
+Key classes:
+
+- `PodmanNetworkTopology` — manages subnet allocation, IP assignment, route
+  calculation, and tc command generation
+- `ScyllaPodmanCluster` — overrides `populate()`, `create_node()`,
+  `get_node_ip()`, `remove()`, `_update_config()`; manages client container
+- `ScyllaPodmanNode` — overrides container lifecycle, service management,
+  tool execution; handles route setup and tc application
+
+## Cluster Configuration Persistence
+
+Podman clusters save their state to `cluster.conf` with these keys:
+
+- `docker_image` — the container image (same key as Docker clusters)
+- `network_topology` — serialized topology including rack assignments, delays,
+  and packet loss settings
+
+The `ClusterFactory.load()` method detects the presence of `network_topology`
+in `cluster.conf` to distinguish a podman/topology cluster from a plain Docker
+one, and restores the full `ScyllaPodmanCluster` with its network topology.
+
+## Running Tests
+
+Unit tests (no podman required):
+
+```bash
+pytest tests/test_scylla_podman_cluster.py::TestPodmanNetworkTopology -v
+```
+
+Integration tests (require podman and a ScyllaDB image):
+
+```bash
+export SCYLLA_PODMAN_IMAGE=scylladb/scylla:2026.1
+pytest tests/test_scylla_podman_cluster.py -v -m network_topology
+```
+
+## Differences from Docker Support
+
+| Feature | Docker (broken) | Podman |
+|---------|----------------|--------|
+| Runtime | Docker | Podman (rootless) |
+| Network | Single flat network | Per-rack networks |
+| Latency sim | None | tc/netem via nsenter from host |
+| Multi-DC | Not topology-aware | Full DC/rack topology |
+| Client | Direct host access | Client container on Rack1 |
+| Status | Broken in master | Active |
+
+## Example: 2 DCs x 3 AZs
+
+A realistic deployment with 2 datacenters, 3 availability zones (racks) per DC,
+1 node per AZ, and configurable inter-AZ/inter-DC latency:
+
+```
+Host (rootless podman)
+  ├── ccm-mycluster-dc1-az1 (10.<prefix>.1.0/24) — node1, ccm-client
+  ├── ccm-mycluster-dc1-az2 (10.<prefix>.2.0/24) — node2
+  ├── ccm-mycluster-dc1-az3 (10.<prefix>.3.0/24) — node3
+  ├── ccm-mycluster-dc2-az1 (10.<prefix>.4.0/24) — node4
+  ├── ccm-mycluster-dc2-az2 (10.<prefix>.5.0/24) — node5
+  └── ccm-mycluster-dc2-az3 (10.<prefix>.6.0/24) — node6
+```
+
+### Python API
+
+```python
+from collections import OrderedDict
+from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+cluster = ScyllaPodmanCluster(
+    "/path/to/ccm",
+    "mycluster",
+    podman_image="scylladb/scylla:2026.1",
+    inter_rack_delay_ms=1,    # 1ms between AZs in the same DC
+    inter_dc_delay_ms=40,     # 40ms between DCs
+    packet_loss_percent=0.0,
+)
+
+# 2 DCs, 3 AZs each, 1 node per AZ
+cluster.populate({
+    "DC1": {"AZ1": 1, "AZ2": 1, "AZ3": 1},
+    "DC2": {"AZ1": 1, "AZ2": 1, "AZ3": 1},
+})
+
+cluster.start(wait_for_binary_proto=True)
+
+# Start the CQL client container on the first AZ's network
+cluster.start_client_container()
+
+# Node IPs:
+topo = cluster.network_topology
+print(topo.get_node_ip("node1"))  # for example: 10.89.1.1 (DC1/AZ1)
+print(topo.get_node_ip("node4"))  # for example: 10.89.4.1 (DC2/AZ1)
+
+# CQL client contact points
+print(cluster.get_client_contact_points())
+
+# Latency from DC1/AZ1 to DC1/AZ2: ~1ms (inter-rack same DC)
+# Latency from DC1/AZ1 to DC2/AZ1: ~40ms (inter-DC)
+
+cluster.remove()
+```
+
+### Connecting a CQL Driver
+
+To connect a Python CQL driver (e.g., `scylla-driver` or `cassandra-driver`) to the
+cluster from the host, use the node IPs from the topology:
+
+```python
+from cassandra.cluster import Cluster as CQLCluster
+from cassandra.policies import DCAwareRoundRobinPolicy
+
+contact_points = [ip for ip, port in cluster.get_client_contact_points()]
+cql = CQLCluster(
+    contact_points=contact_points,
+    port=9042,
+    load_balancing_policy=DCAwareRoundRobinPolicy(local_dc="DC1"),
+)
+session = cql.connect()
+
+session.execute("""
+    CREATE KEYSPACE IF NOT EXISTS test_ks
+    WITH replication = {
+        'class': 'NetworkTopologyStrategy',
+        'DC1': 3, 'DC2': 3
+    }
+""")
+session.execute("USE test_ks")
+session.execute("CREATE TABLE IF NOT EXISTS test (k int PRIMARY KEY, v text)")
+session.execute("INSERT INTO test (k, v) VALUES (1, 'hello')")
+print(session.execute("SELECT * FROM test").one())
+
+session.shutdown()
+cql.shutdown()
+```
+
+Note: if running from the host (outside containers), the host must have routes
+to the selected `10.<prefix>.x.0/24` subnets. Podman rootless mode typically handles this
+automatically. Alternatively, use `cluster.run_cqlsh_on_client()` to execute
+CQL commands from inside the client container, which is always on the correct
+network.
+
+### tc rules applied (via nsenter) to node1 (DC1/AZ1)
+
+```
+# Root: prio qdisc, all traffic defaults to band 1 (no delay)
+tc qdisc add dev eth0 root handle 1: prio bands 4 priomap 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+
+# Band 2: inter-AZ same DC (1ms delay)
+tc qdisc add dev eth0 parent 1:2 handle 20: netem delay 1ms
+tc filter add dev eth0 parent 1:0 protocol ip u32 match ip dst 10.89.2.0/24 flowid 1:2
+tc filter add dev eth0 parent 1:0 protocol ip u32 match ip dst 10.89.3.0/24 flowid 1:2
+
+# Band 3: inter-DC (40ms delay)
+tc qdisc add dev eth0 parent 1:3 handle 30: netem delay 40ms
+tc filter add dev eth0 parent 1:0 protocol ip u32 match ip dst 10.89.4.0/24 flowid 1:3
+tc filter add dev eth0 parent 1:0 protocol ip u32 match ip dst 10.89.5.0/24 flowid 1:3
+tc filter add dev eth0 parent 1:0 protocol ip u32 match ip dst 10.89.6.0/24 flowid 1:3
+```
+
+
+### nodetool status output (2 DC x 3 AZ, scylladb/scylla:2026.1)
+
+```
+Datacenter: dc1
+===============
+Status=Up/Down/eXcluded
+|/ State=Normal/Leaving/Joining/Moving
+-- Address   Load      Tokens Owns Host ID                              Rack
+UN 10.89.1.1 338.62 KB 1      ?    31dcc8a7-b63d-4b7e-8cc0-ebde48abc56c az1
+UN 10.89.2.1 347.41 KB 1      ?    a663710c-8f2c-44ef-a116-48f973e29417 az2
+UN 10.89.3.1 366.19 KB 1      ?    fa8b8a5d-1dbc-4eed-a283-c5f00a5b464c az3
+Datacenter: dc2
+===============
+Status=Up/Down/eXcluded
+|/ State=Normal/Leaving/Joining/Moving
+-- Address   Load      Tokens Owns Host ID                              Rack
+UN 10.89.4.1 421.56 KB 1      ?    1c1a314f-b2ca-4934-9058-f95e678086a3 az1
+UN 10.89.5.1 307.51 KB 1      ?    78c91881-80c5-4212-973b-aeb0ebb3c43e az2
+UN 10.89.6.1 330.97 KB 1      ?    34414cd8-57c2-4857-884b-048491d4b2c9 az3
+```
+
+Each node is UN (Up/Normal) with its own IP on the corresponding rack subnet:
+
+| Node  | DC  | Rack | IP        | Subnet        |
+|-------|-----|------|-----------|---------------|
+| node1 | dc1 | az1  | 10.89.1.1 | 10.89.1.0/24  |
+| node2 | dc1 | az2  | 10.89.2.1 | 10.89.2.0/24  |
+| node3 | dc1 | az3  | 10.89.3.1 | 10.89.3.0/24  |
+| node4 | dc2 | az1  | 10.89.4.1 | 10.89.4.0/24  |
+| node5 | dc2 | az2  | 10.89.5.1 | 10.89.5.0/24  |
+| node6 | dc2 | az3  | 10.89.6.1 | 10.89.6.0/24  |
+
+CQL client container: 10.89.1.100 on the dc1/az1 network.

--- a/docs/podman-network-topology.md
+++ b/docs/podman-network-topology.md
@@ -18,9 +18,9 @@ latency between racks and datacenters.
 
 ```
 Host (rootless podman, ip_forward=1, routes between rack bridges)
-  ├── ccm-{cluster}-dc1-rac1 (10.<prefix>.1.0/24) — node1, node2, ccm-client
-  ├── ccm-{cluster}-dc1-rac2 (10.<prefix>.2.0/24) — node3, node4
-  └── ccm-{cluster}-dc2-rac1 (10.<prefix>.3.0/24) — node5
+  ├── ccm-{cluster}-dc1-rac1 (<subnet_prefix>.1.0/24) — node1, node2, ccm-client
+  ├── ccm-{cluster}-dc1-rac2 (<subnet_prefix>.2.0/24) — node3, node4
+  └── ccm-{cluster}-dc2-rac1 (<subnet_prefix>.3.0/24) — node5
 ```
 
 - Each rack has its own podman network with a /24 subnet
@@ -33,10 +33,10 @@ Host (rootless podman, ip_forward=1, routes between rack bridges)
 
 | Component      | IP Pattern                           |
 |----------------|--------------------------------------|
-| Rack subnets   | `10.{prefix}.{rack_idx}.0/24`      |
-| Gateways       | `10.{prefix}.{rack_idx}.254`       |
-| Node IPs       | `10.{prefix}.{rack_idx}.{node_offset}` |
-| Client         | `10.{prefix}.1.100` (on first rack) |
+| Rack subnets   | `{subnet_prefix}.{rack_idx}.0/24`      |
+| Gateways       | `{subnet_prefix}.{rack_idx}.254`       |
+| Node IPs       | `{subnet_prefix}.{rack_idx}.{node_offset}` |
+| Client         | `{subnet_prefix}.1.100` (on first rack) |
 
 Where `rack_idx` starts at 1 and increments globally across all DCs.
 By default CCM prefers the `10.89.x.0/24` range, but if that overlaps with
@@ -87,8 +87,11 @@ test/development environments.
 
 ### Requirements
 
-- Host must have at least `total_nodes * smp` CPUs available
-- `smp` defaults to 2 (set via `node.set_smp()` or `SCYLLA_EXT_OPTS="--smp N"`)
+- Host must have at least the sum of each node's `smp` CPUs available (for
+  example, 6 nodes at the default `smp=1` need 6 CPUs; nodes may use
+  different `smp` values, in which case each node's own value is summed)
+- `smp` defaults to **1** for podman nodes (set via `node.set_smp()` or
+  `SCYLLA_EXT_OPTS="--smp N"`)
 
 ## Usage
 
@@ -224,12 +227,12 @@ A realistic deployment with 2 datacenters, 3 availability zones (racks) per DC,
 
 ```
 Host (rootless podman)
-  ├── ccm-mycluster-dc1-az1 (10.<prefix>.1.0/24) — node1, ccm-client
-  ├── ccm-mycluster-dc1-az2 (10.<prefix>.2.0/24) — node2
-  ├── ccm-mycluster-dc1-az3 (10.<prefix>.3.0/24) — node3
-  ├── ccm-mycluster-dc2-az1 (10.<prefix>.4.0/24) — node4
-  ├── ccm-mycluster-dc2-az2 (10.<prefix>.5.0/24) — node5
-  └── ccm-mycluster-dc2-az3 (10.<prefix>.6.0/24) — node6
+  ├── ccm-mycluster-dc1-az1 (<subnet_prefix>.1.0/24) — node1, ccm-client
+  ├── ccm-mycluster-dc1-az2 (<subnet_prefix>.2.0/24) — node2
+  ├── ccm-mycluster-dc1-az3 (<subnet_prefix>.3.0/24) — node3
+  ├── ccm-mycluster-dc2-az1 (<subnet_prefix>.4.0/24) — node4
+  ├── ccm-mycluster-dc2-az2 (<subnet_prefix>.5.0/24) — node5
+  └── ccm-mycluster-dc2-az3 (<subnet_prefix>.6.0/24) — node6
 ```
 
 ### Python API
@@ -306,7 +309,7 @@ cql.shutdown()
 ```
 
 Note: if running from the host (outside containers), the host must have routes
-to the selected `10.<prefix>.x.0/24` subnets. Podman rootless mode typically handles this
+to the selected `<subnet_prefix>.x.0/24` subnets. Podman rootless mode typically handles this
 automatically. Alternatively, use `cluster.run_cqlsh_on_client()` to execute
 CQL commands from inside the client container, which is always on the correct
 network.

--- a/docs/podman-network-topology.md
+++ b/docs/podman-network-topology.md
@@ -93,6 +93,30 @@ test/development environments.
 - `smp` defaults to **1** for podman nodes (set via `node.set_smp()` or
   `SCYLLA_EXT_OPTS="--smp N"`)
 
+## TLS and Compression
+
+Node-to-node TLS (`cluster.enable_internode_ssl()`) and CQL client TLS
+(`cluster.enable_ssl()`) work transparently with podman clusters:
+`ScyllaPodmanNode.update_yaml()` copies each cert referenced in
+`server_encryption_options`/`client_encryption_options` into the node's
+container-visible `keys/` directory and rewrites the option to the
+in-container path. `internode_compression` (`all`/`dc`/`rack`/`none`) is a
+plain scylla.yaml option, no podman-specific handling needed.
+
+```python
+# Set non-SSL options *before* enable_ssl()/enable_internode_ssl() — this
+# ordering is what's been tested; calling set_configuration_options()
+# afterward re-runs import_config_files() on every node and hasn't been
+# verified safe.
+cluster.set_configuration_options(values={"internode_compression": "rack"})
+
+generate_ssl_stores(ssl_dir)
+cluster.enable_ssl(ssl_dir, require_client_auth=False)
+cluster.enable_internode_ssl(ssl_dir)
+
+cluster.start(wait_for_binary_proto=True)
+```
+
 ## Usage
 
 ### CLI

--- a/docs/podman-network-topology.md
+++ b/docs/podman-network-topology.md
@@ -57,6 +57,39 @@ Each container's `eth0` gets a classful `prio` qdisc with `u32` filters:
 - **Band 2**: inter-rack same DC — configurable (default: 1ms)
 - **Band 3**: inter-DC — configurable (default: 50ms) + optional packet loss
 
+## CPU Pinning (Optional)
+
+When the `--pinning` flag is passed (or `pinning=True` in the Python API),
+CCM assigns each node a dedicated, non-overlapping set of host CPU cores.
+This is disabled by default.
+
+### How it works
+
+1. At `populate()` time, CCM checks: `total_nodes * smp <= host_cpu_count`.
+2. If there are enough CPUs, each node gets a contiguous block of `smp` cores
+   (e.g. node1 gets CPUs 0-1, node2 gets 2-3, node3 gets 4-5 for smp=2).
+3. If there are **not** enough CPUs, pinning is automatically disabled with a
+   warning and the cluster falls back to overprovisioned mode.
+
+### What changes when pinning is active
+
+| Aspect | Without pinning (default) | With pinning |
+|--------|--------------------------|--------------|
+| `--overprovisioned` | Always set | **Removed** |
+| `--cpuset` | Not set | Set to assigned cores |
+| `podman --cpuset-cpus` | Not set | Set to assigned cores |
+| IO tuning | Skipped (overprovisioned) | `io_properties.yaml` generated |
+| `--io-setup` | Not set | Set to `0` (skip iotune) |
+
+The generated `io_properties.yaml` uses generous per-core values (100k IOPS,
+1 GB/s bandwidth per core) to prevent Scylla from throttling I/O in
+test/development environments.
+
+### Requirements
+
+- Host must have at least `total_nodes * smp` CPUs available
+- `smp` defaults to 2 (set via `node.set_smp()` or `SCYLLA_EXT_OPTS="--smp N"`)
+
 ## Usage
 
 ### CLI
@@ -64,7 +97,7 @@ Each container's `eth0` gets a classful `prio` qdisc with `u32` filters:
 Create a multi-DC cluster with podman:
 
 ```bash
-# 2 DCs: DC1 has 2 racks (2 nodes each), DC2 has 1 rack (1 node)
+# 2 DCs: DC1 has 1 rack (4 nodes), DC2 has 1 rack (1 node)
 ccm create mycluster --podman-image scylladb/scylla:2026.1 \
     -n 4:1 \
     --inter-rack-delay 2 \
@@ -72,6 +105,13 @@ ccm create mycluster --podman-image scylladb/scylla:2026.1 \
     --packet-loss 0.1
 
 ccm start
+
+# Same but with CPU pinning (each node gets dedicated cores):
+ccm create mycluster --podman-image scylladb/scylla:2026.1 \
+    -n 4:1 \
+    --inter-rack-delay 2 \
+    --inter-dc-delay 100 \
+    --pinning
 ```
 
 The `-n` argument uses colon-separated notation for multi-DC. For multi-rack
@@ -90,6 +130,7 @@ cluster = ScyllaPodmanCluster(
     inter_rack_delay_ms=1,
     inter_dc_delay_ms=50,
     packet_loss_percent=0.5,
+    # pinning=True,  # uncomment to pin each node to dedicated CPU cores
 )
 
 # Multi-DC, multi-rack topology:
@@ -142,6 +183,7 @@ Key classes:
 Podman clusters save their state to `cluster.conf` with these keys:
 
 - `docker_image` — the container image (same key as Docker clusters)
+- `pinning` — whether CPU pinning is enabled (default: `false`)
 - `network_topology` — serialized topology including rack assignments, delays,
   and packet loss settings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ log_date_format = "%Y-%m-%d %H:%M:%S"
 log_file = "tests/test_results/ccm.log"
 markers = [
   "docker: Run tests with docker image",
+  "network_topology: Run tests with container-based network topology simulation",
   "reloc: Run tests with relocatable packages",
   "cassandra: Run tests with cassandra binaries",
   "repo_tests: Run test for testing get versions",

--- a/skills/podman-cluster/SKILL.md
+++ b/skills/podman-cluster/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: podman-cluster
+description: Start a multi-DC podman-based Scylla cluster with configurable topology, latency simulation, and CPU pinning
+license: Apache-2.0
+compatibility: opencode
+metadata:
+  audience: scylla-developers
+  workflow: operational
+---
+
+**IMPORTANT**: All skill code must be edited in the source repository at `~/github/scylla-ccm/skills/podman-cluster/SKILL.md`, not the installed copy under `~/.config/opencode/skills/podman-cluster/`.
+
+## What I do
+
+Start a multi-DC, multi-rack Scylla cluster using podman containers with optional inter-DC/inter-rack latency simulation, packet loss, and CPU pinning. Creates a CCM-based podman cluster using the `ScyllaPodmanCluster` API.
+
+## Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `--version` | no | `master` | ScyllaDB version (e.g. `master`, `5.4`, `2024.1`). When `master`, uses the nightly image. Otherwise maps to `docker.io/scylladb/scylla:{version}`. |
+| `--image` | no | derived from `--version` | Scylla container image (overrides version-based default) |
+| `--topology` | no | `dc1:rack1:5,rack2:5,rack3:5;dc2:rack1:5,rack2:5,rack3:5;dc3:rack1:5,rack2:5,rack3:5` | Topology as `dc:rack:N,...;dc:rack:N,...` |
+| `--concurrency` | no | `2` | Number of parallel node starts |
+| `--inter-dc-delay` | no | `40` | Simulated inter-DC latency in ms |
+| `--inter-rack-delay` | no | `1` | Simulated inter-rack latency in ms |
+| `--packet-loss` | no | `0` | Cross-DC packet loss percentage |
+| `--pinning` | no | `false` | Pin each node to dedicated CPU cores |
+| `--keep` | no | `false` | Keep cluster running after success |
+| `--name` | no | `test-cluster` | Cluster name |
+
+All parameters are optional. The default is a 45-node cluster across 3 DCs × 3 racks × 5 nodes.
+
+## Prerequisites
+
+- Linux host with podman 4.0+
+- `tc` (iproute2) and `nsenter` (util-linux) for latency simulation
+- `python3` with `ccm` installed from this repo
+- Sufficient disk/memory for the containers
+- For `--pinning`: enough host CPUs (`>= total_nodes * smp`)
+
+## Workflow
+
+### Step 1: Validate prerequisites
+
+Check that podman, tc, and nsenter are available:
+
+```bash
+command -v podman >/dev/null || { echo "podman not found"; exit 1; }
+command -v tc >/dev/null || { echo "tc not found"; exit 1; }
+command -v nsenter >/dev/null || { echo "nsenter not found"; exit 1; }
+```
+
+### Step 2: Parse topology argument
+
+Parse the `--topology` string into a Python nested dict:
+
+```python
+topology = {}
+for dc_part in topology_str.split(";"):
+    dc_name, _, rest = dc_part.strip().partition(":")
+    racks = {}
+    for rp in rest.split(","):
+        rp = rp.strip()
+        if not rp:
+            continue
+        rack_name, count = rp.split(":")
+        racks[rack_name] = int(count)
+    topology[dc_name] = racks
+```
+
+### Step 3: Ask for ScyllaDB version (if not already provided)
+
+If `--version` was not passed on the command line, use the `question` tool to ask the user which ScyllaDB version they want. Offer `master` (Recommended), `2024.1`, `2025.1`, `5.4`, and `6.0` as options, with `master` as the default. Set `custom: true` so they can type any version string.
+
+If `--version` was provided on the command line, use that value directly.
+
+### Step 4: Resolve image from version
+
+```python
+if not image:
+    if version == "master":
+        image = "docker.io/scylladb/scylla-nightly:latest"
+    else:
+        image = f"docker.io/scylladb/scylla:{version}"
+```
+
+### Step 5: Create and populate the cluster
+
+```python
+from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+import tempfile
+
+cluster = ScyllaPodmanCluster(
+    str(tempfile.mkdtemp(prefix="ccm-podman-")),
+    name=cluster_name,
+    podman_image=image,
+    inter_dc_delay_ms=inter_dc_delay,
+    inter_rack_delay_ms=inter_rack_delay,
+    packet_loss_percent=packet_loss,
+    pinning=pinning,
+)
+cluster.populate(topology)
+total_nodes = len(cluster.nodelist())
+```
+
+### Step 6: Configure and start nodes
+
+```python
+import concurrent.futures
+import time
+import logging
+
+LOG = logging.getLogger("podman-cluster")
+
+cluster.set_configuration_options(values={
+    "read_request_timeout_in_ms": 10000,
+    "range_request_timeout_in_ms": 10000,
+    "write_request_timeout_in_ms": 10000,
+    "truncate_request_timeout_in_ms": 10000,
+    "request_timeout_in_ms": 10000,
+})
+
+nodes = cluster.nodelist()
+t0 = time.time()
+failures = []
+
+def start_node(node):
+    LOG.info("Starting %s ...", node.name)
+    node.start(wait_for_binary_proto=True, wait_other_notice=False)
+    LOG.info("Started %s", node.name)
+    return node
+
+# Nodes are started concurrently via node.start() directly (not
+# cluster.start_nodes()) so the requested --concurrency is honored; this
+# means tc/netem shaping (normally applied by start_nodes()) must be
+# applied explicitly below, once all nodes are confirmed running.
+with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
+    futures = {pool.submit(start_node, n): n for n in nodes}
+    done = 0
+    for future in concurrent.futures.as_completed(futures):
+        n = futures[future]
+        done += 1
+        try:
+            future.result()
+            elapsed = time.time() - t0
+            LOG.info("[%d/%d] %s UP in %.1f s", done, total_nodes, n.name, elapsed)
+        except Exception as exc:
+            LOG.error("%s FAILED: %s", n.name, exc)
+            failures.append((n.name, exc))
+
+# Abort on any node-start failure instead of silently reporting success --
+# a partially-up cluster with none of the advertised network shaping is
+# worse than a clear error.
+if failures:
+    LOG.error(
+        "%d/%d node(s) failed to start: %s",
+        len(failures), total_nodes,
+        ", ".join(name for name, _ in failures),
+    )
+    if not keep:
+        cluster.remove()
+    raise SystemExit(1)
+
+LOG.info("Applying tc/netem network shaping...")
+cluster.apply_network_shaping()
+```
+
+### Step 7: Report status
+
+```python
+total = time.time() - t0
+running = sum(1 for n in nodes if n.is_running())
+nodetool_status = nodes[0].nodetool('status')[0]
+print(f"Total time: {total:.1f} s ({total/60:.1f} min)")
+print(f"Nodes UP: {running}/{total_nodes}")
+```
+
+Print the output exactly as:
+
+```
+[Step 1/7] Validating prerequisites...
+[Step 2/7] Parsing topology: <topology_str>
+[Step 3/7] Asking for ScyllaDB version...
+[Step 4/7] Resolving image from version: <version>
+[Step 5/7] Creating and populating cluster...
+[Step 6/7] Starting <N> nodes with concurrency <M>...
+[Step 7/7] Reporting status...
+Total time: <X> s (<Y> min)
+Nodes UP: <running>/<total>
+```
+
+### Step 8: Clean up (unless --keep)
+
+```python
+if not keep:
+    print("Cleaning up...")
+    cluster.remove()
+    print("Done.")
+```
+
+If `--keep` is set, print the cluster path and instructions:
+
+```
+Cluster path: <path>
+Keep it with: ccm switch <name> && ccm start
+Remove it with: ccm remove <name>
+```
+
+Print the end result -- `nodetool status` for the whole cluster (all nodes, with
+Datacenter/Rack topology) -- as the final output:
+
+```python
+print("\nEnd result -- nodetool status (all nodes, DC/rack topology):")
+print(nodetool_status)
+```
+
+```
+End result -- nodetool status (all nodes, DC/rack topology):
+Datacenter: dc1
+================
+Rack    Rack1
+--------------
+...
+<full nodetool status output>
+```
+
+## When to use me
+
+- You need a realistic multi-DC Scylla cluster for manual testing
+- You want to test LWT or Raft behavior under inter-DC latency
+- You need a quick performance benchmark environment
+- You want to reproduce cluster-level issues without provisioning real VMs
+
+## Example usage
+
+```
+# Default 45-node cluster (ScyllaDB master/nightly)
+/podman-cluster
+
+# Specific ScyllaDB version
+/podman-cluster --version "2024.1"
+
+# Small 2-node cluster
+/podman-cluster --topology "dc1:rack1:1,rack2:1" --concurrency 1
+
+# 2 DC with 50ms inter-DC delay
+/podman-cluster --topology "dc1:rack1:3;dc2:rack1:3" --inter-dc-delay 50
+
+# CPU-pinned 12-node cluster (requires 24+ host CPUs with smp=2)
+/podman-cluster --topology "dc1:rack1:4,rack2:4,rack3:4" --pinning --concurrency 4
+
+# Keep running for investigation
+/podman-cluster --topology "dc1:rack1:2" --keep
+```
+
+## Critical implementation constraints
+
+1. ALWAYS print progress steps with `[Step N/M]` prefix.
+2. Default topology creates a 45-node cluster (3 DC × 3 rack × 5 node) — warn the user about resource usage.
+3. All parameters are optional; use defaults when omitted.
+4. Do NOT implement anything that requires root privileges (podman is rootless).
+5. The run_big_cluster.py in tests/ is a reference, but this skill uses its own Python code inline.

--- a/skills/podman-cluster/SKILL.md
+++ b/skills/podman-cluster/SKILL.md
@@ -28,6 +28,7 @@ Start a multi-DC, multi-rack Scylla cluster using podman containers with optiona
 | `--pinning` | no | `false` | Pin each node to dedicated CPU cores |
 | `--keep` | no | `false` | Keep cluster running after success |
 | `--name` | no | `test-cluster` | Cluster name |
+| `--dir` | no | `/tmp` | Directory holding the cluster data (the containers' disks). Defaults to `/tmp` (tmpfs) for speed; point it at a real filesystem for large clusters |
 
 All parameters are optional. The default is a 45-node cluster across 3 DCs × 3 racks × 5 nodes.
 
@@ -91,8 +92,9 @@ if not image:
 from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
 import tempfile
 
+data_dir = dir if dir else "/tmp"
 cluster = ScyllaPodmanCluster(
-    str(tempfile.mkdtemp(prefix="ccm-podman-")),
+    str(tempfile.mkdtemp(prefix="ccm-podman-", dir=data_dir)),
     name=cluster_name,
     podman_image=image,
     inter_dc_delay_ms=inter_dc_delay,
@@ -252,6 +254,9 @@ Rack    Rack1
 
 # Keep running for investigation
 /podman-cluster --topology "dc1:rack1:2" --keep
+
+# Large cluster on a real filesystem instead of /tmp (tmpfs)
+/podman-cluster --topology "dc1:rack1:7,rack2:7,rack3:7;dc2:rack1:7,rack2:7,rack3:7;dc3:rack1:7,rack2:7,rack3:7" --dir ~/scylla-clusters
 ```
 
 ## Critical implementation constraints

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,9 @@ def _prune_stale_ccm_podman_resources():
 @pytest.fixture(scope="session", autouse=True)
 def prune_stale_podman_resources():
     """Auto-use fixture: prune stale CCM podman containers/networks before and after the session."""
+    if not shutil.which("podman"):
+        yield
+        return
     _prune_stale_ccm_podman_resources()
     yield
     _prune_stale_ccm_podman_resources()
@@ -157,7 +160,7 @@ def test_dir(test_id, results_dir):
 
     if dir_count >= max_test_dirs:
         LOGGER.critical(f"Number of test directories is '{dir_count}'. Max allowed: '{max_test_dirs}'")
-        assert dir_count >= max_test_dirs
+        assert dir_count < max_test_dirs
     test_dir = os.getcwd() / test_dir
     test_dir.mkdir()
     LOGGER.info(f"Test directory '{test_dir}' created.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,135 @@
+import json
 import logging
 import os
+import shutil
 from datetime import datetime
 from pathlib import Path
+from subprocess import DEVNULL, PIPE, run
 
 import pytest
-from tests.test_config import RESULTS_DIR, TEST_ID, SCYLLA_DOCKER_IMAGE, SCYLLA_RELOCATABLE_VERSION
+from tests.test_config import RESULTS_DIR, TEST_ID, SCYLLA_DOCKER_IMAGE, SCYLLA_RELOCATABLE_VERSION, SCYLLA_PODMAN_IMAGE
 
 from ccmlib.scylla_cluster import ScyllaCluster
 from ccmlib.scylla_docker_cluster import ScyllaDockerCluster
+from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
 from .ccmcluster import CCMCluster
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _pid_is_alive(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _resource_owner_pid(labels):
+    if not isinstance(labels, dict):
+        return None
+    owner_pid = labels.get("org.scylladb.ccm-owner-pid")
+    if owner_pid is None:
+        return None
+    try:
+        return int(owner_pid)
+    except (TypeError, ValueError):
+        return None
+
+
+def _prune_stale_ccm_podman_resources():
+    """Remove any leftover CCM podman containers and networks from previous test runs.
+
+    Only resources owned by a dead pytest session are removed. This avoids
+    tearing down a concurrently running CCM podman session on the same host.
+    """
+    CCM_CONTAINER_PREFIX = "ccm-"
+    CCM_NETWORK_PREFIX = "ccm-"
+
+    stale_container_names = []
+    try:
+        res = run(
+            ["podman", "ps", "-a", "--format", "json"],
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+        if res.returncode == 0 and res.stdout.strip():
+            containers = json.loads(res.stdout)
+            for c in containers:
+                names = c.get("Names", [])
+                name = names[0] if names else c.get("Name", "")
+                state = c.get("State", "")
+                owner_pid = _resource_owner_pid(c.get("Labels", {}))
+                if (
+                    name.startswith(CCM_CONTAINER_PREFIX)
+                    and owner_pid is not None
+                    and not _pid_is_alive(owner_pid)
+                ):
+                    LOGGER.info(
+                        "Pruning stale CCM container: %s (state=%s)", name, state
+                    )
+                    rm_res = run(["podman", "rm", "-f", name], stdout=DEVNULL, stderr=DEVNULL)
+                    if rm_res.returncode == 0:
+                        stale_container_names.append(name)
+    except Exception:
+        LOGGER.debug("Failed to prune stale CCM containers", exc_info=True)
+
+    stale_container_names = set(stale_container_names)
+    try:
+        res = run(
+            ["podman", "network", "ls", "--format", "json"],
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
+        )
+        if res.returncode == 0 and res.stdout.strip():
+            networks = json.loads(res.stdout)
+            for net in networks:
+                name = net.get("name", "")
+                owner_pid = _resource_owner_pid(net.get("labels", {}))
+                if not name.startswith(CCM_NETWORK_PREFIX):
+                    continue
+                if owner_pid is None or _pid_is_alive(owner_pid):
+                    continue
+                inspect_res = run(
+                    ["podman", "network", "inspect", name],
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    text=True,
+                )
+                if inspect_res.returncode != 0 or not inspect_res.stdout.strip():
+                    continue
+                inspect_data = json.loads(inspect_res.stdout)
+                containers_on_net = (
+                    inspect_data[0].get("containers", {}) if inspect_data else {}
+                )
+                attached_names = {
+                    details.get("name")
+                    for details in containers_on_net.values()
+                    if isinstance(details, dict) and details.get("name")
+                }
+                if attached_names - stale_container_names:
+                    continue
+                LOGGER.info("Pruning stale CCM network: %s", name)
+                run(
+                    ["podman", "network", "rm", "-f", name],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                )
+    except Exception:
+        LOGGER.debug("Failed to prune stale CCM networks", exc_info=True)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prune_stale_podman_resources():
+    """Auto-use fixture: prune stale CCM podman containers/networks before and after the session."""
+    _prune_stale_ccm_podman_resources()
+    yield
+    _prune_stale_ccm_podman_resources()
 
 
 @pytest.fixture(scope="session")
@@ -148,3 +266,34 @@ def ccm_reloc_latest_cluster():
 def cluster_under_test(request):
     cluster = request.getfixturevalue(request.param)
     return cluster
+
+
+@pytest.fixture(scope="session")
+def podman_cluster(test_dir, test_id):
+    if not shutil.which("podman"):
+        pytest.skip("podman binary not found")
+    cluster_name = f"podman_cluster_{test_id}"
+    cluster = None
+    try:
+        cluster = ScyllaPodmanCluster(
+            str(test_dir),
+            name=cluster_name,
+            podman_image=SCYLLA_PODMAN_IMAGE,
+            inter_dc_delay_ms=40,
+            inter_rack_delay_ms=1,
+        )
+        cluster.populate({"dc1": {"rack1": 1, "rack2": 1}, "dc2": {"rack1": 1}})
+        cluster.set_configuration_options(
+            values={
+                "read_request_timeout_in_ms": 10000,
+                "range_request_timeout_in_ms": 10000,
+                "write_request_timeout_in_ms": 10000,
+                "truncate_request_timeout_in_ms": 10000,
+                "request_timeout_in_ms": 10000,
+            }
+        )
+        cluster.start(wait_for_binary_proto=True)
+        yield cluster
+    finally:
+        if cluster is not None:
+            cluster.remove()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import shutil
+import uuid
 from datetime import datetime
 from pathlib import Path
 from subprocess import DEVNULL, PIPE, run
@@ -11,11 +12,30 @@ from tests.test_config import RESULTS_DIR, TEST_ID, SCYLLA_DOCKER_IMAGE, SCYLLA_
 
 from ccmlib.scylla_cluster import ScyllaCluster
 from ccmlib.scylla_docker_cluster import ScyllaDockerCluster
-from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+from ccmlib.scylla_podman_cluster import (
+    PODMAN_RESOURCE_OWNER_LABEL,
+    PODMAN_TEST_SESSION_ENV,
+    PODMAN_TEST_SESSION_LABEL,
+    ScyllaPodmanCluster,
+)
 from .ccmcluster import CCMCluster
 
 
 LOGGER = logging.getLogger(__name__)
+
+# Mark every podman container/network created during this test session so
+# that stale-resource pruning (below) can be scoped to *this* test-created
+# session specifically. A static value here (e.g. "pytest") would make two
+# concurrent/unrelated test sessions share the same label, letting one
+# session's cleanup delete the other's still-running resources -- and would
+# also make pruning delete "ccm-"-named resources from a normal interactive
+# `ccm create ... -s` CLI invocation: that CLI process exits right after
+# startup while the cluster it created keeps running, so its containers
+# would otherwise look identical to an abandoned crashed-test-run leftover
+# (dead owner PID). `setdefault` lets a caller override the value with their
+# own session id while still defaulting to a random per-process UUID.
+os.environ.setdefault(PODMAN_TEST_SESSION_ENV, uuid.uuid4().hex)
+_THIS_TEST_SESSION_ID = os.environ[PODMAN_TEST_SESSION_ENV]
 
 
 def _pid_is_alive(pid):
@@ -31,7 +51,7 @@ def _pid_is_alive(pid):
 def _resource_owner_pid(labels):
     if not isinstance(labels, dict):
         return None
-    owner_pid = labels.get("org.scylladb.ccm-owner-pid")
+    owner_pid = labels.get(PODMAN_RESOURCE_OWNER_LABEL)
     if owner_pid is None:
         return None
     try:
@@ -40,11 +60,31 @@ def _resource_owner_pid(labels):
         return None
 
 
+def _has_test_session_label(labels):
+    """Return True if *labels* marks the resource as created by THIS test session.
+
+    Used to scope stale-resource pruning to resources this specific pytest
+    session created -- never resources from an interactive `ccm` CLI
+    invocation, nor from a concurrent/unrelated test session (which would
+    carry a different session id).
+    """
+    if not isinstance(labels, dict):
+        return False
+    return labels.get(PODMAN_TEST_SESSION_LABEL) == _THIS_TEST_SESSION_ID
+
+
 def _prune_stale_ccm_podman_resources():
     """Remove any leftover CCM podman containers and networks from previous test runs.
 
     Only resources owned by a dead pytest session are removed. This avoids
     tearing down a concurrently running CCM podman session on the same host.
+
+    Scoped to resources carrying the test-session label (see
+    ``PODMAN_TEST_SESSION_LABEL`` / ``os.environ.setdefault`` above): a
+    "ccm-"-named container with a dead owner PID is not necessarily stale --
+    a plain `ccm create ... -s` CLI invocation exits right after starting
+    the cluster, while the cluster/containers it created keep running. Only
+    resources tagged as test-created are eligible for this sweep.
     """
     CCM_CONTAINER_PREFIX = "ccm-"
     CCM_NETWORK_PREFIX = "ccm-"
@@ -63,9 +103,11 @@ def _prune_stale_ccm_podman_resources():
                 names = c.get("Names", [])
                 name = names[0] if names else c.get("Name", "")
                 state = c.get("State", "")
-                owner_pid = _resource_owner_pid(c.get("Labels", {}))
+                labels = c.get("Labels", {})
+                owner_pid = _resource_owner_pid(labels)
                 if (
                     name.startswith(CCM_CONTAINER_PREFIX)
+                    and _has_test_session_label(labels)
                     and owner_pid is not None
                     and not _pid_is_alive(owner_pid)
                 ):
@@ -90,8 +132,11 @@ def _prune_stale_ccm_podman_resources():
             networks = json.loads(res.stdout)
             for net in networks:
                 name = net.get("name", "")
-                owner_pid = _resource_owner_pid(net.get("labels", {}))
+                labels = net.get("labels", {})
+                owner_pid = _resource_owner_pid(labels)
                 if not name.startswith(CCM_NETWORK_PREFIX):
+                    continue
+                if not _has_test_session_label(labels):
                     continue
                 if owner_pid is None or _pid_is_alive(owner_pid):
                     continue

--- a/tests/run_big_cluster.py
+++ b/tests/run_big_cluster.py
@@ -1,9 +1,10 @@
 """Start a large podman cluster with configurable topology and concurrency.
 
 Usage:
-  python tests/run_big_cluster.py [--concurrency N] [--nodes DC:AZ:N ...]
+  python tests/run_big_cluster.py [--concurrency N] [--nodes DC:RACK:N ...]
 """
 
+import argparse
 import concurrent.futures
 import logging
 import os
@@ -22,9 +23,68 @@ LOG = logging.getLogger("run_big_cluster")
 for name in ("ccmlib.scylla_podman_cluster", "ccmlib.node", "ccmlib.cluster"):
     logging.getLogger(name).setLevel(logging.WARNING)
 
+_DEFAULT_TOPOLOGY = {"dc1": {"rack1": 5, "rack2": 5, "rack3": 5},
+                     "dc2": {"rack1": 5, "rack2": 5, "rack3": 5},
+                     "dc3": {"rack1": 5, "rack2": 5, "rack3": 5}}
+
+
+def _parse_topology_arg(node_specs):
+    """Parse repeated ``--nodes DC:RACK:N`` values into a topology dict."""
+    topology = {}
+    for spec in node_specs:
+        parts = spec.split(":")
+        if len(parts) != 3:
+            raise argparse.ArgumentTypeError(
+                f"Invalid --nodes value {spec!r}; expected DC:RACK:N"
+            )
+        dc, rack, count_str = parts
+        try:
+            count = int(count_str)
+        except ValueError:
+            raise argparse.ArgumentTypeError(
+                f"Invalid --nodes value {spec!r}: node count must be an integer"
+            )
+        if count <= 0:
+            raise argparse.ArgumentTypeError(
+                f"Invalid --nodes value {spec!r}: node count must be positive"
+            )
+        topology.setdefault(dc, {})[rack] = count
+    return topology
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Start a large podman cluster with configurable topology and concurrency.",
+    )
+    parser.add_argument(
+        "--concurrency", type=int, default=None,
+        help="Number of non-seed nodes to start concurrently "
+             "(default: all at once, after the seed node is up)",
+    )
+    parser.add_argument(
+        "--nodes", action="append", default=None, metavar="DC:RACK:N",
+        help="Add N nodes to DC/RACK; repeatable. "
+             "Default: 3 DCs x 3 racks x 5 nodes each.",
+    )
+    parser.add_argument(
+        "--inter-dc-delay-ms", type=int, default=0,
+        help="Simulated inter-DC latency in ms (default: 0 = no shaping)",
+    )
+    parser.add_argument(
+        "--inter-rack-delay-ms", type=int, default=0,
+        help="Simulated inter-rack latency in ms (default: 0 = no shaping)",
+    )
+    parser.add_argument(
+        "--smp", type=int, default=None,
+        help="Shards per node (default: node default, 1)",
+    )
+    return parser.parse_args(argv)
+
 
 def main():
     import shutil
+
+    args = parse_args()
 
     if not shutil.which("podman"):
         print("podman not found", file=sys.stderr)
@@ -35,77 +95,96 @@ def main():
         os.environ.get("SCYLLA_DOCKER_IMAGE", "docker.io/scylladb/scylla-nightly:latest"),
     )
 
-    topology = {"dc1": {"rack1": 5, "rack2": 5, "rack3": 5},
-                "dc2": {"rack1": 5, "rack2": 5, "rack3": 5},
-                "dc3": {"rack1": 5, "rack2": 5, "rack3": 5}}
+    topology = _parse_topology_arg(args.nodes) if args.nodes else _DEFAULT_TOPOLOGY
 
     node_count = sum(sum(racks.values()) for racks in topology.values())
-    concurrency = 2
+    concurrency = args.concurrency
 
     print(f"Image: {image}")
     print(f"Topology: {node_count} nodes across {len(topology)} DCs")
-    print(f"Concurrency: {concurrency}")
+    print(f"Concurrency: {concurrency or 'all at once (after seed)'}")
     print()
 
     from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
 
     test_dir = tempfile.mkdtemp(prefix="ccm-bigcluster-")
-    cluster = ScyllaPodmanCluster(
-        str(test_dir),
-        name="bigcluster",
-        podman_image=image,
-        inter_dc_delay_ms=40,
-        inter_rack_delay_ms=1,
-    )
+    cluster = None
+    failures = 0
+    try:
+        cluster = ScyllaPodmanCluster(
+            str(test_dir),
+            name="bigcluster",
+            podman_image=image,
+            inter_dc_delay_ms=args.inter_dc_delay_ms,
+            inter_rack_delay_ms=args.inter_rack_delay_ms,
+        )
 
-    cluster.populate(topology)
+        cluster.populate(topology)
 
-    total_nodes = len(cluster.nodelist())
-    print(f"Populated {total_nodes} nodes")
+        total_nodes = len(cluster.nodelist())
+        print(f"Populated {total_nodes} nodes")
 
-    cluster.set_configuration_options(values={
-        "read_request_timeout_in_ms": 10000,
-        "range_request_timeout_in_ms": 10000,
-        "write_request_timeout_in_ms": 10000,
-        "truncate_request_timeout_in_ms": 10000,
-        "request_timeout_in_ms": 10000,
-    })
+        cluster.set_configuration_options(values={
+            "read_request_timeout_in_ms": 10000,
+            "range_request_timeout_in_ms": 10000,
+            "write_request_timeout_in_ms": 10000,
+            "truncate_request_timeout_in_ms": 10000,
+            "request_timeout_in_ms": 10000,
+        })
 
-    nodes = cluster.nodelist()
-    t0 = time.time()
+        nodes = cluster.nodelist()
+        if args.smp:
+            for node in nodes:
+                node.set_smp(args.smp)
+        t0 = time.time()
 
-    def start_node(node):
-        LOG.info("Starting %s ...", node.name)
-        node.start(wait_for_binary_proto=True, wait_other_notice=False)
-        LOG.info("Started %s", node.name)
-        return node
+        def start_node(node):
+            LOG.info("Starting %s ...", node.name)
+            node.start(wait_for_binary_proto=True, wait_other_notice=False)
+            LOG.info("Started %s", node.name)
+            return node
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
-        futures = {pool.submit(start_node, n): n for n in nodes}
-        done = 0
-        for future in concurrent.futures.as_completed(futures):
-            n = futures[future]
-            done += 1
-            try:
-                future.result()
-                elapsed = time.time() - t0
-                LOG.info(
-                    "[%d/%d] %s UP in %.1f s",
-                    done, total_nodes, n.name, elapsed,
-                )
-            except Exception as exc:
-                LOG.error("%s FAILED: %s", n.name, exc)
-                traceback.print_exc()
+        # Start the seed alone, then the rest concurrently (all at once by default).
+        seed, rest = nodes[0], nodes[1:]
+        start_node(seed)
+        LOG.info("[1/%d] %s (seed) UP in %.1f s", total_nodes, seed.name, time.time() - t0)
 
-    total = time.time() - t0
-    print(f"\nTotal time: {total:.1f} s ({total/60:.1f} min)")
+        max_workers = concurrency or max(len(rest), 1)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {pool.submit(start_node, n): n for n in rest}
+            done = 1
+            for future in concurrent.futures.as_completed(futures):
+                n = futures[future]
+                done += 1
+                try:
+                    future.result()
+                    elapsed = time.time() - t0
+                    LOG.info(
+                        "[%d/%d] %s UP in %.1f s",
+                        done, total_nodes, n.name, elapsed,
+                    )
+                except Exception as exc:
+                    failures += 1
+                    LOG.error("%s FAILED: %s", n.name, exc)
+                    traceback.print_exc()
 
-    running = sum(1 for n in nodes if n.is_running())
-    print(f"Nodes UP: {running}/{total_nodes}")
+        # node.start() bypasses cluster.start_nodes(); apply tc/netem rules here
+        t_shape = time.time()
+        cluster.apply_network_shaping()
+        LOG.info("tc/netem shaping took %.1f s", time.time() - t_shape)
 
-    print("\nCleaning up...")
-    cluster.remove()
-    print("Done.")
+        total = time.time() - t0
+        print(f"\nTotal time: {total:.1f} s ({total/60:.1f} min)")
+
+        running = sum(1 for n in nodes if n.is_running())
+        print(f"Nodes UP: {running}/{total_nodes}")
+    finally:
+        if cluster is not None:
+            print("\nCleaning up...")
+            cluster.remove()
+            print("Done.")
+
+    return 1 if failures else 0
 
 
 if __name__ == "__main__":

--- a/tests/run_big_cluster.py
+++ b/tests/run_big_cluster.py
@@ -78,6 +78,10 @@ def parse_args(argv=None):
         "--smp", type=int, default=None,
         help="Shards per node (default: node default, 1)",
     )
+    parser.add_argument(
+        "--dir", default=None, metavar="DIR",
+        help="Directory to hold the cluster data (default: tempfile under /tmp, tmpfs)",
+    )
     return parser.parse_args(argv)
 
 
@@ -107,7 +111,7 @@ def main():
 
     from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
 
-    test_dir = tempfile.mkdtemp(prefix="ccm-bigcluster-")
+    test_dir = tempfile.mkdtemp(prefix="ccm-bigcluster-", dir=args.dir)
     cluster = None
     failures = 0
     try:

--- a/tests/run_big_cluster.py
+++ b/tests/run_big_cluster.py
@@ -1,0 +1,112 @@
+"""Start a large podman cluster with configurable topology and concurrency.
+
+Usage:
+  python tests/run_big_cluster.py [--concurrency N] [--nodes DC:AZ:N ...]
+"""
+
+import concurrent.futures
+import logging
+import os
+import sys
+import tempfile
+import time
+import traceback
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+LOG = logging.getLogger("run_big_cluster")
+
+for name in ("ccmlib.scylla_podman_cluster", "ccmlib.node", "ccmlib.cluster"):
+    logging.getLogger(name).setLevel(logging.WARNING)
+
+
+def main():
+    import shutil
+
+    if not shutil.which("podman"):
+        print("podman not found", file=sys.stderr)
+        return 1
+
+    image = os.environ.get(
+        "SCYLLA_PODMAN_IMAGE",
+        os.environ.get("SCYLLA_DOCKER_IMAGE", "docker.io/scylladb/scylla-nightly:latest"),
+    )
+
+    topology = {"dc1": {"rack1": 5, "rack2": 5, "rack3": 5},
+                "dc2": {"rack1": 5, "rack2": 5, "rack3": 5},
+                "dc3": {"rack1": 5, "rack2": 5, "rack3": 5}}
+
+    node_count = sum(sum(racks.values()) for racks in topology.values())
+    concurrency = 2
+
+    print(f"Image: {image}")
+    print(f"Topology: {node_count} nodes across {len(topology)} DCs")
+    print(f"Concurrency: {concurrency}")
+    print()
+
+    from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+    test_dir = tempfile.mkdtemp(prefix="ccm-bigcluster-")
+    cluster = ScyllaPodmanCluster(
+        str(test_dir),
+        name="bigcluster",
+        podman_image=image,
+        inter_dc_delay_ms=40,
+        inter_rack_delay_ms=1,
+    )
+
+    cluster.populate(topology)
+
+    total_nodes = len(cluster.nodelist())
+    print(f"Populated {total_nodes} nodes")
+
+    cluster.set_configuration_options(values={
+        "read_request_timeout_in_ms": 10000,
+        "range_request_timeout_in_ms": 10000,
+        "write_request_timeout_in_ms": 10000,
+        "truncate_request_timeout_in_ms": 10000,
+        "request_timeout_in_ms": 10000,
+    })
+
+    nodes = cluster.nodelist()
+    t0 = time.time()
+
+    def start_node(node):
+        LOG.info("Starting %s ...", node.name)
+        node.start(wait_for_binary_proto=True, wait_other_notice=False)
+        LOG.info("Started %s", node.name)
+        return node
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = {pool.submit(start_node, n): n for n in nodes}
+        done = 0
+        for future in concurrent.futures.as_completed(futures):
+            n = futures[future]
+            done += 1
+            try:
+                future.result()
+                elapsed = time.time() - t0
+                LOG.info(
+                    "[%d/%d] %s UP in %.1f s",
+                    done, total_nodes, n.name, elapsed,
+                )
+            except Exception as exc:
+                LOG.error("%s FAILED: %s", n.name, exc)
+                traceback.print_exc()
+
+    total = time.time() - t0
+    print(f"\nTotal time: {total:.1f} s ({total/60:.1f} min)")
+
+    running = sum(1 for n in nodes if n.is_running())
+    print(f"Nodes UP: {running}/{total_nodes}")
+
+    print("\nCleaning up...")
+    cluster.remove()
+    print("Done.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ RESULTS_DIR = "test_results"
 TEST_ID = os.environ.get("CCM_TEST_ID", None)
 SCYLLA_DOCKER_IMAGE = os.environ.get(
     "SCYLLA_DOCKER_IMAGE", "scylladb/scylla:latest")
-SCYLLA_PODMAN_IMAGE = os.environ.get("SCYLLA_PODMAN_IMAGE") or SCYLLA_DOCKER_IMAGE
+SCYLLA_PODMAN_IMAGE = os.environ.get("SCYLLA_PODMAN_IMAGE", "scylladb/scylla:latest")
 SCYLLA_RELOCATABLE_VERSION = "release:2024.2.3"
 
 # Feb/8 comment to refresh the action cache

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ RESULTS_DIR = "test_results"
 TEST_ID = os.environ.get("CCM_TEST_ID", None)
 SCYLLA_DOCKER_IMAGE = os.environ.get(
     "SCYLLA_DOCKER_IMAGE", "scylladb/scylla:latest")
+SCYLLA_PODMAN_IMAGE = os.environ.get("SCYLLA_PODMAN_IMAGE") or SCYLLA_DOCKER_IMAGE
 SCYLLA_RELOCATABLE_VERSION = "release:2024.2.3"
 
 # Feb/8 comment to refresh the action cache

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ RESULTS_DIR = "test_results"
 TEST_ID = os.environ.get("CCM_TEST_ID", None)
 SCYLLA_DOCKER_IMAGE = os.environ.get(
     "SCYLLA_DOCKER_IMAGE", "scylladb/scylla:latest")
-SCYLLA_PODMAN_IMAGE = os.environ.get("SCYLLA_PODMAN_IMAGE", "scylladb/scylla:latest")
+SCYLLA_PODMAN_IMAGE = os.environ.get("SCYLLA_PODMAN_IMAGE", SCYLLA_DOCKER_IMAGE)
 SCYLLA_RELOCATABLE_VERSION = "release:2024.2.3"
 
 # Feb/8 comment to refresh the action cache

--- a/tests/test_container_client.py
+++ b/tests/test_container_client.py
@@ -5,12 +5,16 @@ These tests mock the container runtime to avoid requiring Docker/Podman installa
 """
 
 import pytest
+import threading
+import time
 from unittest.mock import patch, MagicMock
 
 from ccmlib.container_client import (
+    ContainerLogManager,
     DockerClient,
     PodmanClient,
     get_container_client,
+    ContainerExecError,
     ContainerRuntimeNotFoundError,
     ContainerStartError,
 )
@@ -55,6 +59,15 @@ class TestDockerClient:
             DockerClient()
         
         assert 'docker is not installed' in str(exc_info.value).lower()
+
+    def test_init_version_check_timeout_treated_as_not_available(self, mock_which):
+        """A hung `docker version` must be treated as unavailable, not raise
+        TimeoutExpired out of __init__."""
+        from subprocess import TimeoutExpired
+
+        with patch('ccmlib.container_client.run', side_effect=TimeoutExpired(cmd=['docker', 'version'], timeout=5)):
+            with pytest.raises(ContainerRuntimeNotFoundError):
+                DockerClient()
     
     def test_run_container_basic(self, mock_run, mock_which):
         """Test running a basic container."""
@@ -275,7 +288,82 @@ class TestDockerClient:
         assert '-f' in args
         assert '-v' in args
         assert 'container123' in args
-    
+
+    def test_remove_container_check_raises_on_failure(self, mock_run, mock_which):
+        """check=True surfaces failures via exception for safety-critical callers."""
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = 'no such container'
+
+        with pytest.raises(ContainerExecError):
+            client.remove_container('container123', force=True, check=True)
+
+    def test_remove_container_no_check_logs_warning_on_failure(self, mock_run, mock_which):
+        """Default (check=False) preserves the legacy warn-and-continue behaviour."""
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = 'no such container'
+
+        client.remove_container('container123', force=True)  # should not raise
+
+    def test_remove_container_force_no_time_flag_for_docker(self, mock_run, mock_which):
+        """Docker's `rm -f` is already an instant SIGKILL and has no --time flag."""
+        client = DockerClient()
+        mock_run.reset_mock()
+
+        client.remove_container('container123', force=True)
+
+        args = mock_run.call_args[0][0]
+        assert args == ['docker', 'rm', '-f', 'container123']
+        assert '--time' not in args
+
+    def test_remove_containers_batches_into_one_call(self, mock_run, mock_which):
+        """Multiple IDs fit in one chunk should be removed with a single `rm` call."""
+        client = DockerClient()
+        mock_run.reset_mock()
+
+        failed = client.remove_containers(['c1', 'c2', 'c3'], force=True, volumes=True)
+
+        assert failed == []
+        assert mock_run.call_count == 1
+        args = mock_run.call_args[0][0]
+        assert args == ['docker', 'rm', '-f', '-v', 'c1', 'c2', 'c3']
+
+    def test_remove_containers_chunks_large_lists(self, mock_run, mock_which):
+        """More IDs than chunk_size should be split across multiple `rm` calls."""
+        client = DockerClient()
+        mock_run.reset_mock()
+
+        ids = [f'c{i}' for i in range(25)]
+        failed = client.remove_containers(ids, force=True, chunk_size=10)
+
+        assert failed == []
+        assert mock_run.call_count == 3
+        chunk_lens = [len(call.args[0]) - 3 for call in mock_run.call_args_list]  # minus [runtime, rm, -f]
+        assert chunk_lens == [10, 10, 5]
+
+    def test_remove_containers_empty_list_is_noop(self, mock_run, mock_which):
+        """No container IDs should mean no subprocess calls at all."""
+        client = DockerClient()
+        mock_run.reset_mock()
+
+        failed = client.remove_containers([], force=True)
+
+        assert failed == []
+        mock_run.assert_not_called()
+
+    def test_remove_containers_reports_failed_chunk(self, mock_run, mock_which):
+        """A chunk that fails should have all its IDs reported back to the caller."""
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value = MagicMock(returncode=1, stdout='', stderr='boom')
+
+        failed = client.remove_containers(['c1', 'c2'], force=True)
+
+        assert failed == ['c1', 'c2']
+
     def test_get_container_ip(self, mock_run, mock_which):
         """Test getting container IP address."""
         client = DockerClient()
@@ -378,6 +466,41 @@ class TestPodmanClient:
         client = PodmanClient()
         assert client.runtime_name == 'podman'
 
+    def test_remove_container_force_adds_time_zero(self, mock_run, mock_which):
+        """Plain `podman rm -f` still waits podman's default 10s stop-grace
+        before SIGKILL; --time 0 makes force-removal actually instant."""
+        mock_which.return_value = '/usr/bin/podman'
+        client = PodmanClient()
+        mock_run.reset_mock()
+
+        client.remove_container('container123', force=True, volumes=True)
+
+        args = mock_run.call_args[0][0]
+        assert args == ['podman', 'rm', '-f', '--time', '0', '-v', 'container123']
+
+    def test_remove_container_non_force_no_time_flag(self, mock_run, mock_which):
+        """--time is only relevant to force removal; don't add it otherwise."""
+        mock_which.return_value = '/usr/bin/podman'
+        client = PodmanClient()
+        mock_run.reset_mock()
+
+        client.remove_container('container123', force=False)
+
+        args = mock_run.call_args[0][0]
+        assert args == ['podman', 'rm', 'container123']
+
+    def test_remove_containers_batch_adds_time_zero(self, mock_run, mock_which):
+        """Batched podman removal should also skip the stop-grace period."""
+        mock_which.return_value = '/usr/bin/podman'
+        client = PodmanClient()
+        mock_run.reset_mock()
+
+        failed = client.remove_containers(['c1', 'c2'], force=True, volumes=True)
+
+        assert failed == []
+        args = mock_run.call_args[0][0]
+        assert args == ['podman', 'rm', '-f', '--time', '0', '-v', 'c1', 'c2']
+
 
 class TestGetContainerClient:
     """Test container client factory function."""
@@ -463,6 +586,19 @@ class TestContainerClientEdgeCases:
         result = client.inspect_container('container123')
         
         assert result is None
+
+    def test_inspect_container_empty_stdout_returns_none_without_logging_error(self, mock_run, mock_which, caplog):
+        """returncode=0 with empty stdout (e.g. a lenient test double) is treated
+        as 'not found', same as inspect_network(), instead of attempting to
+        json.loads('') and logging a parse-error."""
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = ''
+
+        result = client.inspect_container('container123')
+
+        assert result is None
+        assert not any('Failed to parse' in r.message for r in caplog.records)
     
     def test_get_container_ip_empty_response(self, mock_run, mock_which):
         """Test getting IP when container has no IP."""
@@ -496,3 +632,584 @@ class TestContainerClientEdgeCases:
         result = client.create_network('existing-network')
         
         assert result is True
+
+
+class TestRunContainerExtendedArgs:
+    """Test the extended run_container()/create_network()/exec_command() parameters
+    needed by ScyllaPodmanCluster (static IP, labels, CPU pinning, timeouts)."""
+
+    def test_run_container_podman_relabels_volumes_by_default(self, mock_run, mock_which):
+        """On podman, volumes get the :z SELinux relabel suffix by default."""
+        mock_which.return_value = '/usr/bin/podman'
+        client = PodmanClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = 'container123'
+
+        client.run_container(
+            image='img', name='n',
+            volumes={'/host/conf': '/etc/scylla'},
+        )
+
+        args = mock_run.call_args[0][0]
+        mount_args = [args[i + 1] for i, x in enumerate(args) if x == '-v']
+        assert mount_args == ['/host/conf:/etc/scylla:z']
+
+    def test_run_container_docker_never_relabels_volumes(self, mock_run, mock_which):
+        """Docker has no :z relabel concept; volumes are never suffixed."""
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = 'container123'
+
+        client.run_container(
+            image='img', name='n',
+            volumes={'/host/conf': '/etc/scylla', '/tmp': '/tmp'},
+            volumes_no_relabel=['/tmp'],
+        )
+
+        args = mock_run.call_args[0][0]
+        mount_args = [args[i + 1] for i, x in enumerate(args) if x == '-v']
+        assert '/host/conf:/etc/scylla' in mount_args
+        assert '/tmp:/tmp' in mount_args
+
+    def test_run_container_volumes_no_relabel_excludes_specific_paths(self, mock_run, mock_which):
+        """volumes_no_relabel opts specific host paths out of the :z suffix
+        on podman (e.g. /tmp, which some SELinux policies refuse to relabel
+        and which shouldn't be relabeled since it's a shared system path)."""
+        mock_which.return_value = '/usr/bin/podman'
+        client = PodmanClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = 'container123'
+
+        client.run_container(
+            image='img', name='n',
+            volumes={'/host/conf': '/etc/scylla', '/tmp': '/tmp'},
+            volumes_no_relabel=['/tmp'],
+        )
+
+        args = mock_run.call_args[0][0]
+        mount_args = [args[i + 1] for i, x in enumerate(args) if x == '-v']
+        assert '/host/conf:/etc/scylla:z' in mount_args
+        assert '/tmp:/tmp' in mount_args
+        assert '/tmp:/tmp:z' not in mount_args
+
+    def test_run_container_with_ip(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = 'container123'
+
+        client.run_container(image='img', name='n', network='net1', ip='10.89.1.5')
+
+        args = mock_run.call_args[0][0]
+        assert '--ip' in args
+        assert args[args.index('--ip') + 1] == '10.89.1.5'
+
+    def test_run_container_with_labels(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = 'container123'
+
+        client.run_container(image='img', name='n', labels={'owner': '123', 'kind': 'ccm'})
+
+        args = mock_run.call_args[0][0]
+        label_args = [args[i + 1] for i, x in enumerate(args) if x == '--label']
+        assert 'owner=123' in label_args
+        assert 'kind=ccm' in label_args
+
+    def test_run_container_with_cpuset_cpus(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = 'container123'
+
+        client.run_container(image='img', name='n', cpuset_cpus='0,1,2')
+
+        args = mock_run.call_args[0][0]
+        assert '--cpuset-cpus' in args
+        assert args[args.index('--cpuset-cpus') + 1] == '0,1,2'
+
+    def test_run_container_with_hostname(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = 'container123'
+
+        client.run_container(image='img', name='n', hostname='node1')
+
+        args = mock_run.call_args[0][0]
+        assert '--hostname' in args
+        assert args[args.index('--hostname') + 1] == 'node1'
+
+    def test_exec_command_timeout_passed_through(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+
+        client.exec_command('container123', ['echo', 'hi'], timeout=5)
+
+        assert mock_run.call_args.kwargs.get('timeout') == 5
+
+    def test_run_command_timeout_expired_returns_failure_tuple(self, mock_which):
+        """A timed-out command should surface as a normal failure, not raise."""
+        from subprocess import TimeoutExpired
+        with patch('ccmlib.container_client.run', side_effect=[
+            MagicMock(returncode=0, stdout='', stderr=''),  # init version check
+            TimeoutExpired(cmd=['docker'], timeout=5),  # the actual call
+        ]):
+            client = DockerClient()
+            returncode, stdout, stderr = client._run_command(['docker', 'exec', 'x'], timeout=5)
+
+        assert returncode == -1
+        assert 'timed out' in stderr
+
+    def test_create_network_with_subnet_and_gateway(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+
+        client.create_network('ccm-rack1', subnet='10.89.1.0/24', gateway='10.89.1.254',
+                              labels={'owner': '42'})
+
+        args = mock_run.call_args[0][0]
+        assert '--subnet' in args
+        assert args[args.index('--subnet') + 1] == '10.89.1.0/24'
+        assert '--gateway' in args
+        assert args[args.index('--gateway') + 1] == '10.89.1.254'
+        assert '--label' in args
+        assert args[args.index('--label') + 1] == 'owner=42'
+
+    def test_create_network_extended_raises_on_failure(self, mock_run, mock_which):
+        """Extended form (subnet given) surfaces failures via exception, not a bool,
+        so callers can inspect stderr (e.g. to detect subnet conflicts and retry)."""
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = 'subnet 10.89.1.0/24 overlaps with existing network'
+
+        with pytest.raises(ContainerStartError) as exc_info:
+            client.create_network('ccm-rack1', subnet='10.89.1.0/24')
+
+        assert 'overlaps' in str(exc_info.value)
+
+    def test_create_network_simple_form_still_returns_bool_on_failure(self, mock_run, mock_which):
+        """Legacy callers (ScyllaDockerCluster) that don't pass subnet/gateway/labels
+        keep the original return-False-and-log behaviour."""
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = 'some other error'
+
+        result = client.create_network('plain-network')
+
+        assert result is False
+
+    def test_remove_network_force(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+
+        client.remove_network('ccm-rack1', force=True)
+
+        args = mock_run.call_args[0][0]
+        assert args == ['docker', 'network', 'rm', '-f', 'ccm-rack1']
+
+    def test_remove_network_check_raises_on_failure(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = 'network in use'
+
+        with pytest.raises(ContainerExecError):
+            client.remove_network('ccm-rack1', force=True, check=True)
+
+    def test_inspect_network_found(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = '[{"name": "ccm-rack1", "subnets": [{"subnet": "10.89.1.0/24"}]}]'
+
+        info = client.inspect_network('ccm-rack1')
+
+        assert info['name'] == 'ccm-rack1'
+        args = mock_run.call_args[0][0]
+        assert args == ['docker', 'network', 'inspect', 'ccm-rack1']
+
+    def test_inspect_network_not_found(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = ''
+
+        assert client.inspect_network('missing') is None
+
+    def test_list_networks(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = '[{"name": "a"}, {"name": "b"}]'
+
+        networks = client.list_networks()
+
+        assert [n['name'] for n in networks] == ['a', 'b']
+        args = mock_run.call_args[0][0]
+        assert args == ['docker', 'network', 'ls', '--format', 'json']
+
+    def test_list_networks_on_error_returns_empty(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = 'boom'
+
+        assert client.list_networks() == []
+
+    def test_get_container_pid(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = '12345\n'
+
+        assert client.get_container_pid('c1') == 12345
+        args = mock_run.call_args[0][0]
+        assert args == ['docker', 'inspect', '--format', '{{.State.Pid}}', 'c1']
+
+    def test_get_container_pid_not_running(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = '0\n'
+
+        assert client.get_container_pid('c1') is None
+
+    def test_get_container_pid_not_found(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = ''
+        mock_run.return_value.stderr = 'no such container'
+
+        assert client.get_container_pid('c1') is None
+
+    def test_get_container_pid_unparseable_output_logs_and_returns_none(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = '<no value>\n'
+
+        assert client.get_container_pid('c1') is None
+
+    def test_get_container_status(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = 'running\n'
+
+        assert client.get_container_status('c1') == 'running'
+        args = mock_run.call_args[0][0]
+        assert args == ['docker', 'inspect', '--format', '{{.State.Status}}', 'c1']
+
+    def test_get_container_status_not_found(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = ''
+
+        assert client.get_container_status('c1') is None
+
+    def test_get_container_labels(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = '[{"Config": {"Labels": {"owner": "42"}}}]'
+
+        assert client.get_container_labels('c1') == {'owner': '42'}
+
+    def test_get_container_labels_missing_returns_empty_dict(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = ''
+
+        assert client.get_container_labels('c1') == {}
+
+    def test_copy_from_container(self, mock_which):
+        client_run_patch = patch('ccmlib.container_client.run')
+        with client_run_patch as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=b'', stderr=b'')
+            client = DockerClient()
+            mock_run.reset_mock()
+            mock_run.return_value = MagicMock(returncode=0, stdout=b'tarball-bytes', stderr=b'')
+
+            data = client.copy_from_container('c1', '/etc/scylla/')
+
+        assert data == b'tarball-bytes'
+        args = mock_run.call_args[0][0]
+        assert args == ['docker', 'container', 'cp', '-a', 'c1:/etc/scylla/', '-']
+
+    def test_copy_from_container_failure_raises(self, mock_which):
+        with patch('ccmlib.container_client.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=b'', stderr=b'')
+            client = DockerClient()
+            mock_run.reset_mock()
+            mock_run.return_value = MagicMock(returncode=1, stdout=b'', stderr=b'no such container')
+
+            with pytest.raises(ContainerExecError):
+                client.copy_from_container('missing', '/etc/scylla/')
+
+
+class TestStreamLogs:
+    """Test the one-shot (non-follow) log-fetching helper."""
+
+    def test_stream_logs_basic(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = 'log line 1\n'
+        mock_run.return_value.stderr = ''
+
+        output = client.stream_logs('container123')
+
+        assert output == 'log line 1\n'
+        args = mock_run.call_args[0][0]
+        assert args == ['docker', 'logs', 'container123']
+
+    def test_stream_logs_with_tail(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+
+        client.stream_logs('container123', tail=50)
+
+        args = mock_run.call_args[0][0]
+        assert '--tail' in args
+        assert args[args.index('--tail') + 1] == '50'
+
+    def test_stream_logs_tail_zero_is_not_silently_dropped(self, mock_run, mock_which):
+        """tail=0 must still pass --tail 0; `if tail:` would drop it as falsy."""
+        client = DockerClient()
+        mock_run.reset_mock()
+
+        client.stream_logs('container123', tail=0)
+
+        args = mock_run.call_args[0][0]
+        assert '--tail' in args
+        assert args[args.index('--tail') + 1] == '0'
+
+    def test_stream_logs_no_tail_omits_flag(self, mock_run, mock_which):
+        client = DockerClient()
+        mock_run.reset_mock()
+
+        client.stream_logs('container123')
+
+        args = mock_run.call_args[0][0]
+        assert '--tail' not in args
+
+
+class TestPodmanUnshare:
+    """Test the Podman-only `unshare` escape hatch."""
+
+    def test_unshare_success(self, mock_run, mock_which):
+        mock_which.return_value = '/usr/bin/podman'
+        client = PodmanClient()
+        mock_run.reset_mock()
+        mock_run.return_value.stdout = 'ok'
+
+        returncode, stdout, stderr = client.unshare(['chown', '-R', '999:999', '/some/path'])
+
+        assert returncode == 0
+        args = mock_run.call_args[0][0]
+        assert args == ['podman', 'unshare', 'chown', '-R', '999:999', '/some/path']
+
+    def test_unshare_check_raises_on_failure(self, mock_run, mock_which):
+        mock_which.return_value = '/usr/bin/podman'
+        client = PodmanClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = 'permission denied'
+
+        with pytest.raises(ContainerExecError):
+            client.unshare(['chown', '-R', '999:999', '/some/path'], check=True)
+
+    def test_unshare_not_check_returns_tuple_on_failure(self, mock_run, mock_which):
+        mock_which.return_value = '/usr/bin/podman'
+        client = PodmanClient()
+        mock_run.reset_mock()
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = 'permission denied'
+
+        returncode, stdout, stderr = client.unshare(['chown', '-R', '999:999', '/some/path'])
+
+        assert returncode == 1
+        assert stderr == 'permission denied'
+
+    def test_docker_client_has_no_unshare(self, mock_run, mock_which):
+        client = DockerClient()
+        assert not hasattr(client, 'unshare')
+
+
+class TestContainerLogManager:
+    """Test the shared log-streaming manager used by both Docker and Podman clusters."""
+
+    def _make_client(self, mock_which):
+        mock_which.return_value = '/usr/bin/podman'
+        with patch('ccmlib.container_client.run') as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout='', stderr='')
+            return PodmanClient()
+
+    def test_start_stream_spawns_thread_and_writes_lines(self, mock_which, tmp_path):
+        client = self._make_client(mock_which)
+        manager = ContainerLogManager(client)
+        log_file = tmp_path / "system.log"
+
+        fake_process = MagicMock()
+        fake_process.stdout = iter(["line1\n", "line2\n"])
+        with patch('ccmlib.container_client.Popen', return_value=fake_process) as mock_popen:
+            manager.start_stream('container123', str(log_file))
+            # Wait for the daemon thread to finish consuming the fake iterator.
+            state = manager._streams.get('container123')
+            if state and state.thread:
+                state.thread.join(timeout=5)
+
+        assert mock_popen.call_args[0][0][0] in ('podman', '/usr/bin/podman')
+        assert mock_popen.call_args[0][0][1:3] == ['logs', '-f']
+        assert log_file.read_text() == "line1\nline2\n"
+
+    def test_start_stream_is_idempotent(self, mock_which, tmp_path):
+        client = self._make_client(mock_which)
+        manager = ContainerLogManager(client)
+        log_file = tmp_path / "system.log"
+
+        fake_process = MagicMock()
+        fake_process.stdout = iter([])
+        with patch('ccmlib.container_client.Popen', return_value=fake_process) as mock_popen:
+            manager.start_stream('container123', str(log_file))
+            state = manager._streams.get('container123')
+            manager.start_stream('container123', str(log_file))
+            if state and state.thread:
+                state.thread.join(timeout=5)
+
+        # Second call should be a no-op since the stream is already registered.
+        assert mock_popen.call_count == 1
+
+    def test_stop_stream_sets_stop_event(self, mock_which, tmp_path):
+        client = self._make_client(mock_which)
+        manager = ContainerLogManager(client)
+        log_file = tmp_path / "system.log"
+
+        fake_process = MagicMock()
+        fake_process.stdout = iter([])
+        with patch('ccmlib.container_client.Popen', return_value=fake_process):
+            manager.start_stream('container123', str(log_file))
+            state = manager._streams['container123']
+            manager.stop_stream('container123')
+
+        assert state.stop_event.is_set()
+        assert 'container123' not in manager._streams
+
+    def test_stop_all_clears_all_streams(self, mock_which, tmp_path):
+        client = self._make_client(mock_which)
+        manager = ContainerLogManager(client)
+
+        fake_process = MagicMock()
+        fake_process.stdout = iter([])
+        with patch('ccmlib.container_client.Popen', return_value=fake_process):
+            manager.start_stream('c1', str(tmp_path / "1.log"))
+            manager.start_stream('c2', str(tmp_path / "2.log"))
+            manager.stop_all()
+
+        assert manager._streams == {}
+
+    def test_stop_stream_terminates_process_immediately_when_quiescent(self, mock_which, tmp_path):
+        """A quiet container's stream must not linger after stop_stream() --
+        the blocking read on process.stdout won't return on its own."""
+        client = self._make_client(mock_which)
+        manager = ContainerLogManager(client)
+        log_file = tmp_path / "system.log"
+        terminated = threading.Event()
+
+        class BlockingStdout:
+            """Simulates `logs -f` on a quiet container: blocks until terminated."""
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if not terminated.wait(timeout=10):
+                    raise AssertionError("process was not terminated within 10s")
+                raise StopIteration
+
+        fake_process = MagicMock()
+        fake_process.stdout = BlockingStdout()
+        fake_process.terminate.side_effect = terminated.set
+
+        with patch('ccmlib.container_client.Popen', return_value=fake_process):
+            manager.start_stream('container123', str(log_file))
+            state = manager._streams['container123']
+            # Wait for the background thread to publish state.process
+            # (i.e. reach the blocking read) before stopping it.
+            for _ in range(200):
+                with state.lock:
+                    if state.process is not None:
+                        break
+                time.sleep(0.01)
+            else:
+                pytest.fail("background thread never published state.process")
+
+            manager.stop_stream('container123')
+            state.thread.join(timeout=5)
+
+        assert not state.thread.is_alive()
+        fake_process.terminate.assert_called()
+
+    def test_stop_stream_before_process_published_terminates_on_publish(self, mock_which, tmp_path):
+        """If stop_stream() races start_stream() before Popen() runs, the
+        thread must still notice stop_event and terminate the process."""
+        client = self._make_client(mock_which)
+        manager = ContainerLogManager(client)
+        log_file = tmp_path / "system.log"
+
+        fake_process = MagicMock()
+        fake_process.stdout = iter([])
+
+        with patch('ccmlib.container_client.Popen', return_value=fake_process):
+            # Directly construct the race: register a state and mark it
+            # stopped *before* the streaming thread runs at all.
+            from ccmlib.container_client import _LogStreamState
+            state = _LogStreamState(str(log_file))
+            with manager._lock:
+                manager._streams['container123'] = state
+            state.stop_event.set()
+
+            thread = threading.Thread(
+                target=manager._stream_logs, args=('container123', state), daemon=True
+            )
+            thread.start()
+            thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        fake_process.terminate.assert_called()
+
+
+class TestPodmanClientSingletonRace:
+    """Regression test for the double-checked-locking fix on the module-level
+    PodmanClient singleton in scylla_podman_cluster.py."""
+
+    def test_concurrent_get_podman_client_constructs_exactly_once(self, monkeypatch):
+        import ccmlib.scylla_podman_cluster as podman_mod
+
+        monkeypatch.setattr(podman_mod, "_PODMAN_CLIENT", None)
+
+        construct_count = {"n": 0}
+        real_init = podman_mod.PodmanClient.__init__
+
+        def counting_init(self):
+            # Simulate a slow `podman version` call so races overlap.
+            time.sleep(0.05)
+            construct_count["n"] += 1
+            self.runtime_name = "podman"
+            self.runtime_path = "podman"
+
+        monkeypatch.setattr(podman_mod.PodmanClient, "__init__", counting_init)
+
+        results = []
+        barrier = threading.Barrier(8)
+
+        def worker():
+            barrier.wait(timeout=5)
+            results.append(podman_mod._get_podman_client())
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert construct_count["n"] == 1
+        assert len(results) == 8
+        assert all(r is results[0] for r in results)
+
+        monkeypatch.setattr(podman_mod.PodmanClient, "__init__", real_init)

--- a/tests/test_scylla_podman_cluster.py
+++ b/tests/test_scylla_podman_cluster.py
@@ -1,0 +1,1395 @@
+"""Integration tests for ScyllaPodmanCluster with multi-DC network topology.
+
+These tests require:
+- podman installed and working (rootless)
+- SCYLLA_PODMAN_IMAGE env var set to a valid ScyllaDB container image
+  (defaults to SCYLLA_DOCKER_IMAGE)
+
+Run with: pytest tests/test_scylla_podman_cluster.py -v -m network_topology
+"""
+
+import re
+import os
+import subprocess
+import tempfile
+import pytest
+from collections import OrderedDict
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from ruamel.yaml import YAML
+
+from ccmlib.scylla_podman_cluster import PodmanNetworkTopology
+from ccmlib.scylla_podman_cluster import PodmanProcess
+from ccmlib import common
+
+
+# ============================================================================
+# Unit tests for PodmanNetworkTopology (no podman required)
+# ============================================================================
+
+
+class TestPodmanNetworkTopology:
+    """Unit tests for the topology/IP allocation logic."""
+
+    @pytest.fixture
+    def multi_dc_topology(self):
+        """DC1: 2 racks (2+2 nodes), DC2: 1 rack (1 node)"""
+        topology = OrderedDict(
+            [
+                ("DC1", OrderedDict([("RAC1", 2), ("RAC2", 2)])),
+                ("DC2", OrderedDict([("RAC1", 1)])),
+            ]
+        )
+        return PodmanNetworkTopology(
+            cluster_name="test-cluster",
+            topology=topology,
+            inter_rack_delay_ms=1,
+            inter_dc_delay_ms=50,
+            packet_loss_percent=0.5,
+        )
+
+    def test_node_ip_assignment(self, multi_dc_topology):
+        topo = multi_dc_topology
+        # DC1/RAC1 => rack_idx=1
+        assert topo.get_node_ip("node1") == "10.89.1.1"
+        assert topo.get_node_ip("node2") == "10.89.1.2"
+        # DC1/RAC2 => rack_idx=2
+        assert topo.get_node_ip("node3") == "10.89.2.1"
+        assert topo.get_node_ip("node4") == "10.89.2.2"
+        # DC2/RAC1 => rack_idx=3
+        assert topo.get_node_ip("node5") == "10.89.3.1"
+
+    def test_network_naming(self, multi_dc_topology):
+        topo = multi_dc_topology
+        assert topo.get_node_network("node1") == "ccm-test-cluster-dc1-rac1"
+        assert topo.get_node_network("node3") == "ccm-test-cluster-dc1-rac2"
+        assert topo.get_node_network("node5") == "ccm-test-cluster-dc2-rac1"
+
+    def test_network_naming_sanitization(self):
+        """Names with special characters should be sanitized to alphanumeric + hyphens."""
+        topology = OrderedDict([("DC_1.us east", OrderedDict([("RAC 1!", 1)]))])
+        topo = PodmanNetworkTopology(
+            cluster_name="my.cluster_v2",
+            topology=topology,
+        )
+        net = topo.get_node_network("node1")
+        assert net == "ccm-my-cluster-v2-dc-1-us-east-rac-1"
+
+    def test_custom_subnet_prefix(self):
+        topology = OrderedDict([("DC1", OrderedDict([("RAC1", 2)]))])
+        topo = PodmanNetworkTopology(
+            cluster_name="test-cluster",
+            topology=topology,
+            subnet_prefix="10.123",
+        )
+        assert topo.get_node_ip("node1") == "10.123.1.1"
+        assert topo.get_all_rack_subnets() == ["10.123.1.0/24"]
+        assert topo.get_client_ip() == "10.123.1.100"
+
+    def test_rack_subnets(self, multi_dc_topology):
+        topo = multi_dc_topology
+        subnets = topo.get_all_rack_subnets()
+        assert subnets == [
+            "10.89.1.0/24",
+            "10.89.2.0/24",
+            "10.89.3.0/24",
+        ]
+
+    def test_foreign_subnets_dc1_rac1(self, multi_dc_topology):
+        topo = multi_dc_topology
+        foreign = topo.get_foreign_subnets("node1")
+        # node1 is in DC1/RAC1 (10.89.1.0/24)
+        # Inter-rack same DC: DC1/RAC2 = 10.89.2.0/24
+        assert foreign["inter_rack"] == ["10.89.2.0/24"]
+        # Inter-DC: DC2/RAC1 = 10.89.3.0/24
+        assert foreign["inter_dc"] == ["10.89.3.0/24"]
+
+    def test_foreign_subnets_dc2(self, multi_dc_topology):
+        topo = multi_dc_topology
+        foreign = topo.get_foreign_subnets("node5")
+        # node5 is in DC2/RAC1 (10.89.3.0/24)
+        assert foreign["inter_rack"] == []
+        assert set(foreign["inter_dc"]) == {"10.89.1.0/24", "10.89.2.0/24"}
+
+    def test_routes_for_node(self, multi_dc_topology):
+        topo = multi_dc_topology
+        routes = topo.get_routes_for_node("node1")
+        # node1 is in DC1/RAC1, gateway = 10.89.1.254
+        # Should have routes to 10.89.2.0/24 and 10.89.3.0/24
+        assert len(routes) == 2
+        destinations = {r[0] for r in routes}
+        assert destinations == {"10.89.2.0/24", "10.89.3.0/24"}
+        # All go through the same gateway
+        assert all(r[1] == "10.89.1.254" for r in routes)
+
+    def test_tc_commands_structure(self, multi_dc_topology):
+        topo = multi_dc_topology
+        cmds = topo.build_tc_commands("node1")
+        # Should have: root qdisc, inter-rack netem, inter-rack filter,
+        #              inter-dc netem, inter-dc filter
+        assert any("prio bands 4" in c for c in cmds), "Missing root prio qdisc"
+        assert any("netem delay 1ms" in c for c in cmds), "Missing inter-rack delay"
+        assert any("netem delay 50ms" in c for c in cmds), "Missing inter-DC delay"
+        assert any("loss 0.5%" in c for c in cmds), "Missing packet loss"
+        # Filter for inter-rack subnet
+        assert any("10.89.2.0/24" in c and "flowid 1:2" in c for c in cmds)
+        # Filter for inter-DC subnet
+        assert any("10.89.3.0/24" in c and "flowid 1:3" in c for c in cmds)
+
+    def test_tc_commands_no_delay(self):
+        """When delays are 0, no netem qdiscs should be created."""
+        topology = OrderedDict(
+            [
+                ("DC1", OrderedDict([("RAC1", 1), ("RAC2", 1)])),
+            ]
+        )
+        topo = PodmanNetworkTopology(
+            cluster_name="test",
+            topology=topology,
+            inter_rack_delay_ms=0,
+            inter_dc_delay_ms=0,
+        )
+        cmds = topo.build_tc_commands("node1")
+        # Only the root qdisc should be present
+        assert len(cmds) == 1
+        assert "prio bands 4" in cmds[0]
+
+    def test_client_ip(self, multi_dc_topology):
+        topo = multi_dc_topology
+        assert topo.get_client_ip() == "10.89.1.100"
+
+    def test_client_network(self, multi_dc_topology):
+        topo = multi_dc_topology
+        assert topo.get_client_network() == "ccm-test-cluster-dc1-rac1"
+
+    def test_serialization_roundtrip(self, multi_dc_topology):
+        topo = multi_dc_topology
+        data = topo.to_dict()
+        restored = PodmanNetworkTopology.from_dict("test-cluster", data)
+        assert restored.get_node_ip("node1") == topo.get_node_ip("node1")
+        assert restored.get_node_ip("node5") == topo.get_node_ip("node5")
+        assert restored.inter_rack_delay_ms == topo.inter_rack_delay_ms
+        assert restored.inter_dc_delay_ms == topo.inter_dc_delay_ms
+        assert restored.packet_loss_percent == topo.packet_loss_percent
+        assert restored.get_all_rack_subnets() == topo.get_all_rack_subnets()
+        assert restored.subnet_prefix == topo.subnet_prefix
+
+    def test_single_dc_topology(self):
+        """Single DC with 1 rack collapses correctly."""
+        topology = OrderedDict(
+            [
+                ("dc1", OrderedDict([("RAC1", 3)])),
+            ]
+        )
+        topo = PodmanNetworkTopology(
+            cluster_name="single",
+            topology=topology,
+        )
+        assert topo.get_node_ip("node1") == "10.89.1.1"
+        assert topo.get_node_ip("node3") == "10.89.1.3"
+        assert len(topo.get_all_rack_subnets()) == 1
+        # No foreign subnets
+        foreign = topo.get_foreign_subnets("node1")
+        assert foreign["inter_rack"] == []
+        assert foreign["inter_dc"] == []
+
+    def test_parse_topology_int(self):
+        """Integer nodes argument."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        result = ScyllaPodmanCluster._parse_topology(None, 3)
+        assert result == OrderedDict([("dc1", OrderedDict([("RAC1", 3)]))])
+
+    def test_parse_topology_list(self):
+        """List nodes argument (multi-DC, 1 rack each)."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        result = ScyllaPodmanCluster._parse_topology(None, [2, 3])
+        assert result == OrderedDict(
+            [
+                ("dc1", OrderedDict([("RAC1", 2)])),
+                ("dc2", OrderedDict([("RAC1", 3)])),
+            ]
+        )
+
+    def test_parse_topology_dict_with_list(self):
+        """Dict with list values (multi-rack)."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        result = ScyllaPodmanCluster._parse_topology(None, {"DC1": [2, 2], "DC2": [1]})
+        assert result == OrderedDict(
+            [
+                ("DC1", OrderedDict([("RAC1", 2), ("RAC2", 2)])),
+                ("DC2", OrderedDict([("RAC1", 1)])),
+            ]
+        )
+
+    def test_validation_too_many_nodes_in_first_rack(self):
+        """First rack with >= 100 nodes should fail (client container IP collision)."""
+        topology = OrderedDict([("dc1", OrderedDict([("RAC1", 100)]))])
+        with pytest.raises(ValueError, match="client container"):
+            PodmanNetworkTopology(cluster_name="test", topology=topology)
+
+    def test_validation_too_many_nodes_gateway_collision(self):
+        """Rack with >= 254 nodes should fail (gateway IP collision)."""
+        topology = OrderedDict(
+            [
+                ("dc1", OrderedDict([("RAC1", 1)])),
+                ("dc2", OrderedDict([("RAC1", 254)])),
+            ]
+        )
+        with pytest.raises(ValueError, match="gateway"):
+            PodmanNetworkTopology(cluster_name="test", topology=topology)
+
+    def test_validation_too_many_racks(self):
+        """More than 255 racks should fail (subnet exhaustion)."""
+        racks = OrderedDict([(f"RAC{i}", 1) for i in range(1, 257)])
+        topology = OrderedDict([("dc1", racks)])
+        with pytest.raises(ValueError, match="Too many racks"):
+            PodmanNetworkTopology(cluster_name="test", topology=topology)
+
+    def test_2dc_3az_topology(self):
+        """2 DCs x 3 AZs, 1 node per AZ, 40ms inter-DC, 1ms inter-AZ — matches docs example."""
+        topology = OrderedDict(
+            [
+                (
+                    "DC1",
+                    OrderedDict([("AZ1", 1), ("AZ2", 1), ("AZ3", 1)]),
+                ),
+                (
+                    "DC2",
+                    OrderedDict([("AZ1", 1), ("AZ2", 1), ("AZ3", 1)]),
+                ),
+            ]
+        )
+        topo = PodmanNetworkTopology(
+            cluster_name="mycluster",
+            topology=topology,
+            inter_rack_delay_ms=1,
+            inter_dc_delay_ms=40,
+            packet_loss_percent=0.0,
+        )
+
+        # 6 nodes, 6 rack subnets
+        assert len(topo.node_assignments) == 6
+        assert len(topo.get_all_rack_subnets()) == 6
+
+        # IP assignments match docs
+        assert topo.get_node_ip("node1") == "10.89.1.1"  # DC1/AZ1
+        assert topo.get_node_ip("node2") == "10.89.2.1"  # DC1/AZ2
+        assert topo.get_node_ip("node3") == "10.89.3.1"  # DC1/AZ3
+        assert topo.get_node_ip("node4") == "10.89.4.1"  # DC2/AZ1
+        assert topo.get_node_ip("node5") == "10.89.5.1"  # DC2/AZ2
+        assert topo.get_node_ip("node6") == "10.89.6.1"  # DC2/AZ3
+
+        # Network names match docs
+        assert topo.get_node_network("node1") == "ccm-mycluster-dc1-az1"
+        assert topo.get_node_network("node4") == "ccm-mycluster-dc2-az1"
+
+        # Client on first rack
+        assert topo.get_client_ip() == "10.89.1.100"
+        assert topo.get_client_network() == "ccm-mycluster-dc1-az1"
+
+        # Foreign subnets for node1 (DC1/AZ1)
+        foreign = topo.get_foreign_subnets("node1")
+        assert set(foreign["inter_rack"]) == {"10.89.2.0/24", "10.89.3.0/24"}
+        assert set(foreign["inter_dc"]) == {
+            "10.89.4.0/24",
+            "10.89.5.0/24",
+            "10.89.6.0/24",
+        }
+
+        # tc commands for node1 — verify structure matches docs
+        cmds = topo.build_tc_commands("node1")
+        assert any("prio bands 4" in c for c in cmds)
+        assert any("netem delay 1ms" in c for c in cmds)
+        assert any("netem delay 40ms" in c for c in cmds)
+        # Inter-AZ filters (band 2)
+        assert any("10.89.2.0/24" in c and "flowid 1:2" in c for c in cmds)
+        assert any("10.89.3.0/24" in c and "flowid 1:2" in c for c in cmds)
+        # Inter-DC filters (band 3)
+        assert any("10.89.4.0/24" in c and "flowid 1:3" in c for c in cmds)
+        assert any("10.89.5.0/24" in c and "flowid 1:3" in c for c in cmds)
+        assert any("10.89.6.0/24" in c and "flowid 1:3" in c for c in cmds)
+        # No packet loss since 0.0%
+        assert not any("loss" in c for c in cmds)
+
+    def test_validation_negative_inter_rack_delay(self):
+        """Negative inter-rack delay should fail."""
+        topology = OrderedDict([("dc1", OrderedDict([("RAC1", 1)]))])
+        with pytest.raises(ValueError, match="inter_rack_delay_ms must be >= 0"):
+            PodmanNetworkTopology(
+                cluster_name="test", topology=topology, inter_rack_delay_ms=-1
+            )
+
+    def test_validation_negative_inter_dc_delay(self):
+        """Negative inter-DC delay should fail."""
+        topology = OrderedDict([("dc1", OrderedDict([("RAC1", 1)]))])
+        with pytest.raises(ValueError, match="inter_dc_delay_ms must be >= 0"):
+            PodmanNetworkTopology(
+                cluster_name="test", topology=topology, inter_dc_delay_ms=-5
+            )
+
+    def test_validation_packet_loss_out_of_range(self):
+        """Packet loss outside 0-100 should fail."""
+        topology = OrderedDict([("dc1", OrderedDict([("RAC1", 1)]))])
+        with pytest.raises(ValueError, match="packet_loss_percent must be between"):
+            PodmanNetworkTopology(
+                cluster_name="test", topology=topology, packet_loss_percent=101.0
+            )
+        with pytest.raises(ValueError, match="packet_loss_percent must be between"):
+            PodmanNetworkTopology(
+                cluster_name="test", topology=topology, packet_loss_percent=-0.1
+            )
+
+
+class TestPodmanProcess:
+    """Unit tests for PodmanProcess."""
+
+    def test_poll_returns_none_initially(self):
+        """A new PodmanProcess should have returncode=None."""
+        p = PodmanProcess("nonexistent-container-id-12345")
+        assert p.returncode is None
+
+    def test_poll_detects_missing_container(self):
+        """poll() should set returncode=-1 for a non-existent container."""
+        p = PodmanProcess("nonexistent-container-id-12345")
+        result = p.poll()
+        # Container doesn't exist, so returncode should be set to -1
+        assert result == -1
+        assert p.returncode == -1
+
+    def test_poll_caches_returncode(self):
+        """Once returncode is set, poll() should return it without re-checking."""
+        p = PodmanProcess("nonexistent-container-id-12345")
+        p.returncode = 42
+        assert p.poll() == 42
+
+
+class TestFilterArgs:
+    """Unit tests for ScyllaPodmanNode.filter_args."""
+
+    def test_filter_args_does_not_mutate_input(self):
+        """filter_args should not modify the original list."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        original = [
+            "scylla",
+            "--opt1",
+            "val1",
+            "--overprovisioned",
+            "--seeds",
+            "10.0.0.1",
+        ]
+        original_copy = list(original)
+        ScyllaPodmanNode.filter_args(original)
+        assert original == original_copy, "filter_args mutated the input list"
+
+    def test_filter_args_skips_preamble_and_options_file(self):
+        """filter_args should skip the launch binary, --options-file, and
+        --log-to-stdout while keeping whitelisted flags."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        args = [
+            "/path/to/scylla",
+            "--options-file",
+            "/path/to/scylla.yaml",
+            "--log-to-stdout",
+            "1",
+            "--smp",
+            "2",
+            "--memory",
+            "512M",
+            "--seeds",
+            "10.0.0.1",
+            "--developer-mode",
+            "true",
+        ]
+        result = ScyllaPodmanNode.filter_args(args)
+        assert "--options-file" not in result
+        assert "--log-to-stdout" not in result
+        assert "/path/to/scylla" not in result
+        assert "--seeds" in result
+        assert "10.0.0.1" in result
+        assert "--smp" in result
+        assert "2" in result
+        # --developer-mode true should become --developer-mode 1
+        idx = result.index("--developer-mode")
+        assert result[idx + 1] == "1"
+
+
+class TestPodmanNodeBehavior:
+    def test_wait_for_binary_interface_checks_inside_container(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.cluster = SimpleNamespace(version=lambda: "2026.1")
+        node.network_interfaces = {"binary": ("10.90.1.1", 9042)}
+        node.pid = "container-id"
+
+        seen = {"watch_log_for": False, "wait_for": False, "run": []}
+
+        monkeypatch.setattr(
+            node,
+            "watch_log_for",
+            lambda *args, **kwargs: seen.__setitem__("watch_log_for", True),
+        )
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.common.check_socket_listening",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("host-side socket check should not be used")
+            ),
+        )
+
+        def fake_run(cmd, stdout=None, stderr=None):
+            seen["run"].append(cmd)
+            return SimpleNamespace(returncode=0)
+
+        def fake_wait_for(func, timeout, first=0.0, step=1.0):
+            seen["wait_for"] = True
+            return func()
+
+        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.common.wait_for", fake_wait_for
+        )
+
+        node.wait_for_binary_interface(timeout=5)
+
+        assert seen["watch_log_for"]
+        assert seen["wait_for"]
+        assert seen["run"] == [
+            [
+                "podman",
+                "exec",
+                "container-id",
+                "python3",
+                "-c",
+                "import socket; sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM); sock.settimeout(1.0); sock.connect(('10.90.1.1', 9042)); sock.close()",
+            ]
+        ]
+
+    def test_wait_for_binary_interface_times_out_when_container_probe_fails(
+        self, monkeypatch
+    ):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.cluster = SimpleNamespace(version=lambda: "2026.1")
+        node.network_interfaces = {"binary": ("10.90.1.1", 9042)}
+        node.pid = "container-id"
+
+        monkeypatch.setattr(node, "watch_log_for", lambda *args, **kwargs: True)
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.common.check_socket_listening",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("host-side socket check should not be used")
+            ),
+        )
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=1),
+        )
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.common.wait_for",
+            lambda func, timeout, first=0.0, step=1.0: False,
+        )
+
+        with pytest.raises(TimeoutError, match="10.90.1.1:9042"):
+            node.wait_for_binary_interface(timeout=5)
+
+
+class TestPodmanClusterBehavior:
+    def test_populate_retries_with_another_subnet_prefix_on_collision(
+        self, monkeypatch
+    ):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.name = "testcluster"
+        cluster.inter_rack_delay_ms = 1
+        cluster.inter_dc_delay_ms = 50
+        cluster.packet_loss_percent = 0.0
+        cluster.network_topology = None
+        cluster.nodes = OrderedDict()
+        cluster.snitch = "org.apache.cassandra.locator.GossipingPropertyFileSnitch"
+        cluster.seeds = []
+        cluster.use_vnodes = False
+        cluster._config_options = {}
+        cluster._scylla_manager = None
+
+        monkeypatch.setattr(
+            cluster,
+            "_parse_topology",
+            lambda nodes: OrderedDict([("DC1", OrderedDict([("RAC1", 1)]))]),
+        )
+        monkeypatch.setattr(cluster, "set_configuration_options", lambda values: None)
+        monkeypatch.setattr(
+            cluster, "balanced_tokens", lambda node_count: [None] * node_count
+        )
+        monkeypatch.setattr(
+            cluster,
+            "balanced_tokens_across_dcs",
+            lambda node_locations: [None] * len(node_locations),
+        )
+        monkeypatch.setattr(cluster, "new_node", lambda *args, **kwargs: None)
+        monkeypatch.setattr(cluster, "_update_config", lambda *args, **kwargs: None)
+        monkeypatch.setattr(cluster, "cluster_cleanup", lambda: None)
+
+        attempted_prefixes = []
+        prefixes = iter(["10.89", "10.90"])
+
+        def fake_find_available_subnet_prefix(exclude_prefixes=None):
+            prefix = next(prefixes)
+            attempted_prefixes.append(prefix)
+            return prefix
+
+        def fake_create_networks(self):
+            if self.subnet_prefix == "10.89":
+                raise RuntimeError(
+                    "Failed to create podman network test: Error: subnet 10.89.1.0/24 is already used on the host or by another config"
+                )
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster._find_available_subnet_prefix",
+            fake_find_available_subnet_prefix,
+        )
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.PodmanNetworkTopology.create_networks",
+            fake_create_networks,
+        )
+
+        cluster.populate(1)
+
+        assert attempted_prefixes == ["10.89", "10.90"]
+        assert cluster.network_topology is not None
+        assert cluster.network_topology.subnet_prefix == "10.90"
+        assert cluster.network_topology.get_node_ip("node1") == "10.90.1.1"
+
+    def test_populate_honors_env_subnet_prefix_without_retry(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.name = "testcluster"
+        cluster.inter_rack_delay_ms = 1
+        cluster.inter_dc_delay_ms = 50
+        cluster.packet_loss_percent = 0.0
+        cluster.network_topology = None
+        cluster.nodes = OrderedDict()
+        cluster.snitch = "org.apache.cassandra.locator.GossipingPropertyFileSnitch"
+        cluster.seeds = []
+        cluster.use_vnodes = False
+        cluster._config_options = {}
+        cluster._scylla_manager = None
+
+        monkeypatch.setattr(
+            cluster,
+            "_parse_topology",
+            lambda nodes: OrderedDict([("DC1", OrderedDict([("RAC1", 1)]))]),
+        )
+        monkeypatch.setattr(cluster, "set_configuration_options", lambda values: None)
+        monkeypatch.setattr(
+            cluster, "balanced_tokens", lambda node_count: [None] * node_count
+        )
+        monkeypatch.setattr(
+            cluster,
+            "balanced_tokens_across_dcs",
+            lambda node_locations: [None] * len(node_locations),
+        )
+        monkeypatch.setattr(cluster, "new_node", lambda *args, **kwargs: None)
+        monkeypatch.setattr(cluster, "_update_config", lambda *args, **kwargs: None)
+        monkeypatch.setattr(cluster, "cluster_cleanup", lambda: None)
+        monkeypatch.setenv("CCM_PODMAN_SUBNET_PREFIX", "10.123")
+
+        def fake_create_networks(self):
+            raise RuntimeError(
+                "Failed to create podman network test: Error: subnet 10.123.1.0/24 is already used on the host or by another config"
+            )
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.PodmanNetworkTopology.create_networks",
+            fake_create_networks,
+        )
+
+        with pytest.raises(RuntimeError, match="already used"):
+            cluster.populate(1)
+
+    def test_cluster_add_rejected_for_podman(self):
+        from ccmlib.cmds.cluster_cmds import ClusterAddCmd
+
+        cmd = object.__new__(ClusterAddCmd)
+        cmd.options = SimpleNamespace(
+            scylla_node=True,
+            bootstrap=False,
+            is_seed=False,
+            data_center=None,
+            rack=None,
+        )
+        cmd.cluster = SimpleNamespace(is_podman=lambda: True, is_docker=lambda: False)
+        cmd.name = "node4"
+        cmd.storage = ("10.0.0.4", 7000)
+        cmd.binary = ("10.0.0.4", 9042)
+        cmd.jmx_port = "7199"
+        cmd.remote_debug_port = "0"
+        cmd.initial_token = None
+
+        with patch("sys.exit", side_effect=SystemExit(1)):
+            with pytest.raises(SystemExit):
+                cmd.run()
+
+    def test_start_client_container_uses_documented_ip_flags(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import PODMAN_RESOURCE_OWNER_LABEL
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.name = "testcluster"
+        cluster.podman_image = "docker.io/scylladb/scylla:2026.1"
+        cluster._client_container_id = None
+        cluster.network_topology = SimpleNamespace(
+            get_client_ip=lambda: "10.89.1.100",
+            get_client_network=lambda: "ccm-testcluster-dc1-rack1",
+            build_tc_commands=lambda node_name: [],
+        )
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:3] == ["podman", "run", "-d"]:
+                return SimpleNamespace(returncode=0, stdout="client123\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr(
+            cluster,
+            "_setup_container_routes",
+            lambda client_name, node_name: None,
+        )
+
+        cluster.start_client_container()
+
+        run_cmd = next(cmd for cmd in calls if cmd[:3] == ["podman", "run", "-d"])
+        assert "--network" in run_cmd
+        network_idx = run_cmd.index("--network")
+        assert run_cmd[network_idx + 1] == "ccm-testcluster-dc1-rack1"
+        assert "--ip" in run_cmd
+        ip_idx = run_cmd.index("--ip")
+        assert run_cmd[ip_idx + 1] == "10.89.1.100"
+        assert f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}" in run_cmd
+        assert not any(":ip=" in part for part in run_cmd)
+
+    def test_setup_container_routes_logs_failures(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.network_topology = SimpleNamespace(
+            get_routes_for_node=lambda node_name: [("10.89.2.0/24", "10.89.1.254")]
+        )
+
+        warnings = []
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster._nsenter_net_run",
+            lambda container_id, command: SimpleNamespace(
+                returncode=1, stderr="route failed"
+            ),
+        )
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.LOGGER.warning",
+            lambda *args: warnings.append(args[0] if len(args) == 1 else args[0] % args[1:]),
+        )
+
+        cluster._setup_container_routes("client123", "node1")
+
+        assert warnings == [
+            "Failed to add route 10.89.2.0/24 via 10.89.1.254 in client123: route failed"
+        ]
+
+
+class TestPodmanContainerCreate:
+    def test_create_container_uses_documented_ip_flags(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import PODMAN_RESOURCE_OWNER_LABEL
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.pid = None
+        node.podman_name = "ccm-test-node1"
+        node.base_data_path = "/var/lib/scylla"
+        node.local_yaml_path = "/tmp/node1-conf"
+        node.share_directories = []
+        node.log_thread = None
+        node.network_interfaces = {
+            "storage": ("127.0.0.1", 7000),
+            "binary": ("127.0.0.1", 9042),
+        }
+        node.cluster = SimpleNamespace(
+            podman_image="docker.io/scylladb/scylla:2026.1",
+            network_topology=SimpleNamespace(
+                get_node_network=lambda node_name: "ccm-testcluster-dc1-rack1"
+            ),
+            nodelist=lambda: [
+                SimpleNamespace(
+                    name="node1", network_interfaces={"storage": ("10.89.1.1", 7000)}
+                )
+            ],
+        )
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:2] == ["podman", "run"]:
+                return SimpleNamespace(returncode=0, stdout="container123\n", stderr="")
+            if cmd[:3] == ["podman", "exec", "container123"]:
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.common.wait_for",
+            lambda func, timeout, step: True,
+        )
+        monkeypatch.setattr(node, "_prepare_bind_mounts", lambda: None)
+        monkeypatch.setattr(node, "_get_rack_ip", lambda: "10.89.1.1")
+        monkeypatch.setattr(node, "read_scylla_yaml", lambda: {})
+        monkeypatch.setattr(node, "get_path", lambda: "/tmp/node1")
+        monkeypatch.setattr(node, "_scylla_service_name", lambda: "scylla")
+        monkeypatch.setattr(node, "_jmx_service_name", lambda: None)
+        monkeypatch.setattr(node, "service_stop", lambda service_name: None)
+        monkeypatch.setattr(node, "_setup_routes", lambda: None)
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.PodmanLogger",
+            lambda node_obj, log_path: SimpleNamespace(
+                start=lambda: None, stop=lambda: None
+            ),
+        )
+
+        node.create_container([])
+
+        run_cmd = next(cmd for cmd in calls if cmd[:2] == ["podman", "run"])
+        assert "--network" in run_cmd
+        network_idx = run_cmd.index("--network")
+        assert run_cmd[network_idx + 1] == "ccm-testcluster-dc1-rack1"
+        assert "--ip" in run_cmd
+        ip_idx = run_cmd.index("--ip")
+        assert run_cmd[ip_idx + 1] == "10.89.1.1"
+        assert f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}" in run_cmd
+        assert not any(":ip=" in part for part in run_cmd)
+
+
+class TestPodmanConftestCleanup:
+    def test_prune_stale_resources_keeps_live_owner_resources(self, monkeypatch):
+        from tests import conftest
+
+        run_calls = []
+
+        def fake_run(cmd, stdout=None, stderr=None, text=False):
+            run_calls.append(cmd)
+            if cmd[:4] == ["podman", "ps", "-a", "--format"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='[{"Names":["ccm-live"],"State":"running","Labels":{"org.scylladb.ccm-owner-pid":"111"}},{"Names":["ccm-dead"],"State":"running","Labels":{"org.scylladb.ccm-owner-pid":"222"}}]',
+                    stderr="",
+                )
+            if cmd[:4] == ["podman", "network", "ls", "--format"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='[{"name":"ccm-live-net","labels":{"org.scylladb.ccm-owner-pid":"111"}},{"name":"ccm-dead-net","labels":{"org.scylladb.ccm-owner-pid":"222"}}]',
+                    stderr="",
+                )
+            if cmd[:3] == ["podman", "network", "inspect"]:
+                if cmd[-1] == "ccm-dead-net":
+                    return SimpleNamespace(
+                        returncode=0,
+                        stdout='[{"containers":{"abc":{"name":"ccm-dead"}}}]',
+                        stderr="",
+                    )
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='[{"containers":{"xyz":{"name":"ccm-live"}}}]',
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(conftest, "run", fake_run)
+        monkeypatch.setattr(conftest, "_pid_is_alive", lambda pid: pid == 111)
+
+        conftest._prune_stale_ccm_podman_resources()
+
+        assert ["podman", "rm", "-f", "ccm-dead"] in run_calls
+        assert ["podman", "network", "rm", "-f", "ccm-dead-net"] in run_calls
+        assert ["podman", "rm", "-f", "ccm-live"] not in run_calls
+        assert ["podman", "network", "rm", "-f", "ccm-live-net"] not in run_calls
+
+    def test_prune_stale_resources_ignores_unlabeled_resources(self, monkeypatch):
+        from tests import conftest
+
+        run_calls = []
+
+        def fake_run(cmd, stdout=None, stderr=None, text=False):
+            run_calls.append(cmd)
+            if cmd[:4] == ["podman", "ps", "-a", "--format"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='[{"Names":["ccm-unlabeled"],"State":"exited","Labels":{}}]',
+                    stderr="",
+                )
+            if cmd[:4] == ["podman", "network", "ls", "--format"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='[{"name":"ccm-unlabeled-net","labels":{}}]',
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(conftest, "run", fake_run)
+        monkeypatch.setattr(conftest, "_pid_is_alive", lambda pid: False)
+
+        conftest._prune_stale_ccm_podman_resources()
+
+        assert ["podman", "rm", "-f", "ccm-unlabeled"] not in run_calls
+        assert ["podman", "network", "rm", "-f", "ccm-unlabeled-net"] not in run_calls
+
+    def test_podman_cluster_fixture_removes_cluster_on_start_failure(self, monkeypatch):
+        from tests import conftest
+
+        removed = {"called": False}
+
+        class FakeCluster:
+            def set_configuration_options(self, values):
+                pass
+
+            def populate(self, nodes):
+                pass
+
+            def start(self, wait_for_binary_proto=True):
+                raise RuntimeError("boom")
+
+            def remove(self):
+                removed["called"] = True
+
+        monkeypatch.setattr(
+            conftest, "ScyllaPodmanCluster", lambda *args, **kwargs: FakeCluster()
+        )
+
+        fixture = conftest.podman_cluster.__wrapped__("/tmp/testdir", "tid")
+        with pytest.raises(RuntimeError, match="boom"):
+            next(fixture)
+        assert removed["called"]
+
+
+class TestPodmanNodeRemoveAndStatus:
+    """Unit tests for remove(), service_status(), kill(), and __update_status() interaction."""
+
+    def _make_node(self):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        class TestableScyllaPodmanNode(ScyllaPodmanNode):
+            @property
+            def api_port(self):
+                return 10000
+
+        node = object.__new__(TestableScyllaPodmanNode)
+        node.name = "node1"
+        node.pid = "abc123"
+        node.log_thread = None
+        node.status = SimpleNamespace()  # placeholder
+        node._cached_nodetool_support = {}
+        return node
+
+    def test_remove_clears_pid_before_podman_rm(self, monkeypatch):
+        """Verify that remove() sets self.pid = None before calling podman rm.
+
+        This ordering prevents __update_status() from exec-ing into a removed container.
+        """
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = self._make_node()
+
+        call_order = []
+        original_pid = node.pid
+
+        def fake_run(cmd, **kwargs):
+            call_order.append(("run", cmd, node.pid))
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+
+        node.remove()
+
+        # pid should be None after remove
+        assert node.pid is None
+        # podman rm should have been called (first try succeeds, no fallback)
+        assert len(call_order) == 1
+        run_entry = call_order[0]
+        assert "podman" in run_entry[1]
+        assert original_pid in run_entry[1]
+        # pid was already None when podman rm was called
+        assert run_entry[2] is None
+
+    def test_remove_with_none_pid_is_noop(self, monkeypatch):
+        """Verify remove() doesn't crash when pid is already None."""
+        node = self._make_node()
+        node.pid = None
+        calls = []
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.run",
+            lambda *a, **kw: calls.append(1) or SimpleNamespace(returncode=0),
+        )
+        node.remove()
+        assert calls == []  # no podman rm should have been called
+
+    def test_remove_stops_log_thread(self, monkeypatch):
+        """Verify remove() stops the log thread."""
+        node = self._make_node()
+        stopped = {"called": False}
+        node.log_thread = SimpleNamespace(
+            stop=lambda: stopped.__setitem__("called", True)
+        )
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.run",
+            lambda *a, **kw: SimpleNamespace(returncode=0),
+        )
+        node.remove()
+        assert stopped["called"]
+        assert node.log_thread is None
+
+    def test_service_status_returns_down_when_pid_is_none(self):
+        """Verify service_status() returns 'DOWN' when container is gone."""
+        node = self._make_node()
+        node.pid = None
+        assert node.service_status("scylla") == "DOWN"
+
+    def test_service_status_returns_status_on_success(self, monkeypatch):
+        """Verify service_status() parses supervisorctl output correctly."""
+        node = self._make_node()
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.run",
+            lambda *a, **kw: SimpleNamespace(
+                returncode=0, stdout="scylla RUNNING pid 123, uptime 0:01:00", stderr=""
+            ),
+        )
+        assert node.service_status("scylla") == "RUNNING"
+
+    def test_service_status_returns_down_on_failure(self, monkeypatch):
+        """Verify service_status() returns 'DOWN' on exec failure."""
+        node = self._make_node()
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.run",
+            lambda *a, **kw: SimpleNamespace(
+                returncode=1, stdout="", stderr="no such container"
+            ),
+        )
+        assert node.service_status("scylla") == "DOWN"
+
+    def test_service_status_handles_unexpected_output(self, monkeypatch):
+        """Verify service_status() doesn't crash on short/unexpected output."""
+        node = self._make_node()
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.run",
+            lambda *a, **kw: SimpleNamespace(returncode=0, stdout="scylla", stderr=""),
+        )
+        # Only one word in output — can't parse status, should return "DOWN", not crash
+        assert node.service_status("scylla") == "DOWN"
+
+    def test_kill_with_none_pid_is_noop(self, monkeypatch):
+        """Verify kill() doesn't crash when pid is None."""
+        node = self._make_node()
+        node.pid = None
+        calls = []
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.run",
+            lambda *a, **kw: (
+                calls.append(1) or SimpleNamespace(returncode=0, stdout="", stderr="")
+            ),
+        )
+        node.kill(9)
+        assert calls == []
+
+    def test_kill_sends_signal_to_correct_pid(self, monkeypatch):
+        """Verify kill() gets service PID then sends signal without shell."""
+        node = self._make_node()
+        calls = []
+
+        def fake_run(cmd, stdout=None, stderr=None, text=False):
+            calls.append(cmd)
+            if "supervisorctl" in cmd and "pid" in cmd:
+                return SimpleNamespace(returncode=0, stdout="42\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        # Need _scylla_service_name to work
+        monkeypatch.setattr(node, "_scylla_service_name", lambda: "scylla")
+
+        node.kill(15)
+
+        # First call: supervisorctl pid scylla
+        assert "supervisorctl" in calls[0]
+        assert "pid" in calls[0]
+        # Second call: bash -c "kill -15 42" (kill is a shell builtin, not a binary)
+        assert "bash" in calls[1]
+        assert "-c" in calls[1]
+        kill_arg = calls[1][-1]
+        assert "kill" in kill_arg
+        assert "-15" in kill_arg
+        assert "42" in kill_arg
+
+    def test_nodetool_raises_when_pid_is_none(self):
+        """Verify nodetool() raises RuntimeError when container is gone."""
+        node = self._make_node()
+        node.pid = None
+        with pytest.raises(RuntimeError, match="no running container"):
+            node.nodetool("status")
+
+    def test_nodetool_caches_supported_command_probe(self, monkeypatch):
+        """Supported native nodetool commands should only be probed once per node."""
+        node = self._make_node()
+        check_calls = []
+        run_calls = []
+
+        def fake_check_call(cmd, **kwargs):
+            check_calls.append(cmd)
+            return 0
+
+        def fake_do_run_nodetool(cmd, capture_output, wait, timeout, verbose):
+            run_calls.append(cmd)
+            return "ok", ""
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.subprocess.check_call", fake_check_call
+        )
+        monkeypatch.setattr(node, "_do_run_nodetool", fake_do_run_nodetool)
+
+        assert node.nodetool("status") == ("ok", "")
+        assert node.nodetool("status") == ("ok", "")
+
+        assert len(check_calls) == 1
+        assert len(run_calls) == 2
+        assert run_calls[0] == [
+            "podman",
+            "exec",
+            "abc123",
+            "scylla",
+            "nodetool",
+            "-h",
+            "localhost",
+            "-p",
+            "10000",
+            "status",
+        ]
+
+    def test_nodetool_caches_unsupported_command_probe(self, monkeypatch):
+        """Unsupported native commands should only probe once before JMX fallback."""
+        node = self._make_node()
+        node._cached_supervisor_programs = {"scylla", "scylla-jmx"}
+        check_calls = []
+        run_calls = []
+
+        def fake_check_call(cmd, **kwargs):
+            check_calls.append(cmd)
+            raise subprocess.CalledProcessError(1, cmd)
+
+        def fake_do_run_nodetool(cmd, capture_output, wait, timeout, verbose):
+            run_calls.append(cmd)
+            return "fallback", ""
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.subprocess.check_call", fake_check_call
+        )
+        monkeypatch.setattr(node, "_do_run_nodetool", fake_do_run_nodetool)
+
+        assert node.nodetool("cleanup") == ("fallback", "")
+        assert node.nodetool("cleanup") == ("fallback", "")
+
+        assert len(check_calls) == 1
+        assert run_calls == [
+            [
+                "podman",
+                "exec",
+                "abc123",
+                "nodetool",
+                "-Dcom.scylladb.apiPort=10000",
+                "cleanup",
+            ],
+            [
+                "podman",
+                "exec",
+                "abc123",
+                "nodetool",
+                "-Dcom.scylladb.apiPort=10000",
+                "cleanup",
+            ],
+        ]
+
+    def test_service_start_raises_on_failure(self, monkeypatch):
+        """Verify failed supervisor start does not silently continue."""
+        node = self._make_node()
+        calls = []
+        run_kwargs = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            run_kwargs.append(kw)
+            # First call is service_status() — return STOPPED so no clear needed
+            if len(calls) == 1:
+                return SimpleNamespace(returncode=0, stdout="scylla STOPPED", stderr="")
+            # Second call is supervisorctl start — fail
+            return SimpleNamespace(returncode=1, stdout="", stderr="boom")
+
+        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        with pytest.raises(RuntimeError, match="failed to start.*boom"):
+            node.service_start("scylla")
+
+        assert run_kwargs[1]["text"] is True
+
+    def test_service_start_clears_fatal_before_start(self, monkeypatch):
+        """Verify service_start() clears FATAL state before starting."""
+        node = self._make_node()
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            if len(calls) == 1:
+                # service_status returns FATAL
+                return SimpleNamespace(returncode=0, stdout="scylla FATAL", stderr="")
+            # clear and start both succeed
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        node.service_start("scylla")
+
+        # Should have 3 calls: status, clear, start
+        assert len(calls) == 3
+        assert "status" in calls[0][-1] or calls[0] == [
+            "podman",
+            "exec",
+            "abc123",
+            "supervisorctl",
+            "status",
+            "scylla",
+        ]
+        assert calls[1] == [
+            "podman",
+            "exec",
+            "abc123",
+            "supervisorctl",
+            "clear",
+            "scylla",
+        ]
+        assert calls[2] == [
+            "podman",
+            "exec",
+            "abc123",
+            "supervisorctl",
+            "start",
+            "scylla",
+        ]
+
+    def test_wait_until_stopped_does_not_call_os_kill(self, monkeypatch):
+        """Verify wait_until_stopped doesn't try os.kill on a container ID string."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+        from ccmlib.node import Status
+
+        node = self._make_node()
+        node.status = Status.UP
+        call_count = {"status": 0}
+
+        def fake_run(cmd, **kw):
+            call_count["status"] += 1
+            # After first check, report as stopped
+            if call_count["status"] >= 2:
+                return SimpleNamespace(returncode=0, stdout="scylla STOPPED", stderr="")
+            return SimpleNamespace(
+                returncode=0, stdout="scylla RUNNING pid 42, uptime 0:01:00", stderr=""
+            )
+
+        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        # Stub out _update_config since it needs a full cluster/filesystem
+        monkeypatch.setattr(ScyllaPodmanNode, "_update_config", lambda self: None)
+        # Should not raise, and should not try os.kill on a string pid
+        node.wait_until_stopped(wait_seconds=5)
+        assert not node.is_running()
+
+
+class TestPodmanClusterFactoryLoad:
+    def test_load_restores_log_level_and_topology_without_rewriting_config(
+        self, monkeypatch
+    ):
+        from ccmlib.cluster_factory import ClusterFactory
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster_dir = os.path.join(tmpdir, "podman-cluster")
+            os.mkdir(cluster_dir)
+            cluster_conf = os.path.join(cluster_dir, "cluster.conf")
+            original_data = {
+                "name": "podman-cluster",
+                "nodes": [],
+                "seeds": [],
+                "partitioner": None,
+                "config_options": {},
+                "dse_config_options": {},
+                "log_level": "DEBUG",
+                "use_vnodes": False,
+                "id": 0,
+                "ipprefix": None,
+                "docker_image": "docker.io/scylladb/scylla:2026.1",
+                "network_topology": {
+                    "cluster_name": "podman-cluster",
+                    "topology": {"DC1": {"RAC1": 1}},
+                    "inter_rack_delay_ms": 1,
+                    "inter_dc_delay_ms": 40,
+                    "packet_loss_percent": 0.0,
+                    "subnet_prefix": "10.89",
+                },
+            }
+            with open(cluster_conf, "w") as f:
+                YAML().dump(original_data, f)
+
+            monkeypatch.setattr(
+                "ccmlib.cluster_factory.Node.load",
+                lambda cluster_path, node_name, cluster: None,
+            )
+
+            cluster = ClusterFactory.load(tmpdir, "podman-cluster")
+
+            assert getattr(cluster, "_Cluster__log_level") == "DEBUG"
+            assert cluster.network_topology is not None
+            assert cluster.network_topology.inter_dc_delay_ms == 40
+
+            with open(cluster_conf, "r") as f:
+                loaded_data = YAML().load(f)
+
+            assert loaded_data == original_data
+
+
+# ============================================================================
+# Integration tests (require podman and a ScyllaDB image)
+# ============================================================================
+
+
+@pytest.mark.network_topology
+class TestScyllaPodmanCluster:
+    """Integration tests for a multi-DC podman cluster.
+
+    These tests use the `podman_cluster` fixture from conftest.py which creates:
+    - DC1: RAC1 (1 node), RAC2 (1 node)
+    - DC2: RAC1 (1 node)
+
+    IMPORTANT: Tests are numbered (test_01 through test_09) and MUST run in
+    order.  Later tests depend on state created by earlier ones (e.g. test_05
+    reads data inserted by test_04; test_07 restarts the node stopped by
+    test_06).  Do not use pytest-randomly or reorder these tests.
+    """
+
+    @staticmethod
+    def parse_nodetool_status(lines):
+        """Parse output of nodetool status into a list of node info dicts."""
+        keys = ["status", "address"]
+        nodes_statuses = []
+        line_re = re.compile(
+            r"(?P<status>[UNDJ]{2}?)\s+(?P<address>[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}\.[\d]{1,3}?)\s"
+        )
+        for line in lines:
+            node_status = {}
+            res = line_re.search(line)
+            if res:
+                for key in keys:
+                    node_status[key] = res[key]
+                nodes_statuses.append(node_status)
+        return nodes_statuses
+
+    def test_01_cluster_topology(self, podman_cluster):
+        """Verify nodes are correctly assigned to DCs and racks."""
+        nodes = podman_cluster.nodelist()
+        assert len(nodes) == 3
+
+        topo = podman_cluster.network_topology
+        assert topo is not None
+        prefix = topo.subnet_prefix
+
+        # Verify IP assignments
+        assert topo.get_node_ip("node1") == f"{prefix}.1.1"  # DC1/RAC1
+        assert topo.get_node_ip("node2") == f"{prefix}.2.1"  # DC1/RAC2
+        assert topo.get_node_ip("node3") == f"{prefix}.3.1"  # DC2/RAC1
+
+    def test_02_all_nodes_up(self, podman_cluster):
+        """Verify all nodes are running."""
+        for node in podman_cluster.nodelist():
+            assert node.is_running(), f"Node {node.name} is not running"
+
+    def test_03_nodetool_status(self, podman_cluster):
+        """Verify nodetool status shows all nodes as UN."""
+        node1 = podman_cluster.nodelist()[0]
+        status, error = node1.nodetool("status")
+        assert error == ""
+        nodes_statuses = self.parse_nodetool_status(status.splitlines())
+        assert len(nodes_statuses) == 3
+        assert all(node["status"] == "UN" for node in nodes_statuses), (
+            f"Not all nodes are UN: {nodes_statuses}"
+        )
+
+    def test_04_cqlsh(self, podman_cluster):
+        """Verify CQL operations work across the cluster."""
+        node1 = podman_cluster.nodelist()[0]
+
+        node1.run_cqlsh(
+            """
+            CREATE KEYSPACE IF NOT EXISTS test_ks
+            WITH replication = {
+                'class': 'NetworkTopologyStrategy',
+                'dc1': 2,
+                'dc2': 1
+            };
+            USE test_ks;
+            CREATE TABLE IF NOT EXISTS test (key int PRIMARY KEY, value text);
+            INSERT INTO test (key, value) VALUES (1, 'hello');
+            """
+        )
+        rv = node1.run_cqlsh("SELECT * FROM test_ks.test", return_output=True)
+        assert "hello" in rv[0], f"Expected 'hello' in output, got: {rv[0]}"
+        assert rv[1] == ""
+
+    def test_05_cross_dc_query(self, podman_cluster):
+        """Verify queries work from a node in DC2 after data was written in DC1."""
+        node3 = podman_cluster.nodelist()[2]  # DC2/RAC1
+        rv = node3.run_cqlsh(
+            "SELECT * FROM test_ks.test WHERE key = 1",
+            return_output=True,
+        )
+        assert "hello" in rv[0], f"Cross-DC read failed: {rv[0]}"
+
+    def test_06_stop_and_start_node(self, podman_cluster):
+        """Verify a node can be stopped and restarted."""
+        node2 = podman_cluster.nodelist()[1]  # DC1/RAC2
+
+        node2.stop(gently=True)
+        assert not node2.is_running()
+
+        node2.start(wait_for_binary_proto=True)
+        assert node2.is_running()
+
+    def test_07_stop_ungently(self, podman_cluster):
+        """Verify ungraceful stop (kill -9) works."""
+        node2 = podman_cluster.nodelist()[1]  # DC1/RAC2
+
+        node2.stop(gently=False)
+        node2.start(wait_for_binary_proto=True)
+        assert node2.is_running()
+
+    def test_08_network_isolation(self, podman_cluster):
+        """Verify that nodes are on different podman networks per rack."""
+        topo = podman_cluster.network_topology
+        # Each rack should have its own network
+        networks = set()
+        for node in podman_cluster.nodelist():
+            networks.add(topo.get_node_network(node.name))
+        assert len(networks) == 3, f"Expected 3 distinct networks, got {networks}"
+
+    def test_09_is_podman(self, podman_cluster):
+        """Verify cluster and nodes report as podman."""
+        assert podman_cluster.is_podman()
+        assert podman_cluster.is_docker()  # is_docker() returns True for compat
+        for node in podman_cluster.nodelist():
+            assert node.is_podman()

--- a/tests/test_scylla_podman_cluster.py
+++ b/tests/test_scylla_podman_cluster.py
@@ -2591,3 +2591,109 @@ class TestImageConfCache:
 
         assert extract_calls == [], "_extract_image_conf must not be called when cache exists"
         assert result == cache_dir
+
+
+class TestEncryptionOptionsRemap:
+    """enable_ssl()/enable_internode_ssl() write cert/key paths at the cluster
+    level, outside anything bind-mounted into a node's container.
+    ScyllaPodmanNode.update_yaml() must copy those files into this node's own
+    keys/ dir (which IS mounted) and rewrite the paths to be container-internal,
+    for both client and internode (server) encryption options.
+    """
+
+    def _make_node(self, tmp_path, cluster):
+        node_dir = str(tmp_path / "node1")
+        node_conf_dir = os.path.join(node_dir, "conf")
+        os.makedirs(node_conf_dir, exist_ok=True)
+        # scylla.yaml must already exist so update_yaml() skips the cache-copy step.
+        with open(os.path.join(node_conf_dir, "scylla.yaml"), "w") as f:
+            f.write("cluster_name: test\n")
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.cluster = cluster
+        node.local_yaml_path = node_conf_dir
+        node.name = "node1"
+        node.base_data_path = "/usr/lib/scylla"
+        node.network_interfaces = {
+            "storage": ("127.0.0.1", 7000),
+            "binary": ("127.0.0.1", 9042),
+        }
+        node.get_path = lambda: node_dir
+        return node
+
+    def _make_cluster(self):
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.podman_image = "docker.io/scylladb/scylla:test"
+        cluster._image_conf_cache_lock = threading.Lock()
+        cluster.network_topology = None
+        return cluster
+
+    def test_client_encryption_options_certs_are_remapped(self, monkeypatch, tmp_path):
+        cert_path = str(tmp_path / "ccm_node.pem")
+        key_path = str(tmp_path / "ccm_node.key")
+        for p in (cert_path, key_path):
+            with open(p, "w") as f:
+                f.write("dummy")
+
+        monkeypatch.setattr(ScyllaNode, "update_yaml", lambda self: None)
+        monkeypatch.setattr(
+            ScyllaPodmanNode, "read_scylla_yaml",
+            lambda self: {"client_encryption_options": {
+                "enabled": True, "certificate": cert_path, "keyfile": key_path,
+            }},
+        )
+        monkeypatch.setattr(ScyllaPodmanNode, "_get_rack_ip", lambda self: "127.0.0.1")
+
+        node = self._make_node(tmp_path, self._make_cluster())
+        node.update_yaml()
+
+        keys_dir = os.path.join(node.get_path(), "keys")
+        assert os.path.exists(os.path.join(keys_dir, "ccm_node.pem"))
+        assert os.path.exists(os.path.join(keys_dir, "ccm_node.key"))
+
+        with open(os.path.join(node.get_conf_dir(), "scylla.yaml")) as f:
+            written = YAML().load(f)
+        opts = written["client_encryption_options"]
+        assert opts["certificate"] == "/usr/lib/scylla/keys/ccm_node.pem"
+        assert opts["keyfile"] == "/usr/lib/scylla/keys/ccm_node.key"
+
+    def test_server_encryption_options_still_remapped(self, monkeypatch, tmp_path):
+        """Regression guard for the pre-existing internode-SSL remap."""
+        cert_path = str(tmp_path / "internode-ccm_node.pem")
+        key_path = str(tmp_path / "internode-ccm_node.key")
+        for p in (cert_path, key_path):
+            with open(p, "w") as f:
+                f.write("dummy")
+
+        monkeypatch.setattr(ScyllaNode, "update_yaml", lambda self: None)
+        monkeypatch.setattr(
+            ScyllaPodmanNode, "read_scylla_yaml",
+            lambda self: {"server_encryption_options": {
+                "internode_encryption": "all", "certificate": cert_path, "keyfile": key_path,
+            }},
+        )
+        monkeypatch.setattr(ScyllaPodmanNode, "_get_rack_ip", lambda self: "127.0.0.1")
+
+        node = self._make_node(tmp_path, self._make_cluster())
+        node.update_yaml()
+
+        keys_dir = os.path.join(node.get_path(), "keys")
+        assert os.path.exists(os.path.join(keys_dir, "internode-ccm_node.pem"))
+        assert os.path.exists(os.path.join(keys_dir, "internode-ccm_node.key"))
+
+        with open(os.path.join(node.get_conf_dir(), "scylla.yaml")) as f:
+            written = YAML().load(f)
+        opts = written["server_encryption_options"]
+        assert opts["certificate"] == "/usr/lib/scylla/keys/internode-ccm_node.pem"
+        assert opts["keyfile"] == "/usr/lib/scylla/keys/internode-ccm_node.key"
+
+    def test_no_encryption_options_is_a_noop(self, monkeypatch, tmp_path):
+        """update_yaml() must not blow up when no encryption is configured."""
+        monkeypatch.setattr(ScyllaNode, "update_yaml", lambda self: None)
+        monkeypatch.setattr(ScyllaPodmanNode, "read_scylla_yaml", lambda self: {})
+        monkeypatch.setattr(ScyllaPodmanNode, "_get_rack_ip", lambda self: "127.0.0.1")
+
+        node = self._make_node(tmp_path, self._make_cluster())
+        node.update_yaml()
+
+        assert not os.path.exists(os.path.join(node.get_path(), "keys"))

--- a/tests/test_scylla_podman_cluster.py
+++ b/tests/test_scylla_podman_cluster.py
@@ -18,6 +18,7 @@ import pytest
 from collections import OrderedDict
 from types import SimpleNamespace
 from unittest.mock import patch
+from ccmlib.node import TimeoutError
 
 from ruamel.yaml import YAML
 
@@ -568,25 +569,13 @@ class TestPodmanNodeBehavior:
         from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
 
         node = object.__new__(ScyllaPodmanNode)
-        node.cluster = SimpleNamespace(version=lambda: "2026.1")
+        node.cluster = SimpleNamespace(version=lambda: "2026.1", nodes={})
         node.network_interfaces = {"binary": ("10.90.1.1", 9042)}
         node.pid = "container-id"
 
-        seen = {"watch_log_for": False, "wait_for": False, "run": []}
+        seen = {"wait_for": False, "run": []}
 
-        monkeypatch.setattr(
-            node,
-            "watch_log_for",
-            lambda *args, **kwargs: seen.__setitem__("watch_log_for", True),
-        )
-        monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.common.check_socket_listening",
-            lambda *args, **kwargs: (_ for _ in ()).throw(
-                AssertionError("host-side socket check should not be used")
-            ),
-        )
-
-        def fake_run(cmd, stdout=None, stderr=None):
+        def fake_run(cmd, stdout=None, stderr=None, **kwargs):
             seen["run"].append(cmd)
             return SimpleNamespace(returncode=0)
 
@@ -601,7 +590,6 @@ class TestPodmanNodeBehavior:
 
         node.wait_for_binary_interface(timeout=5)
 
-        assert seen["watch_log_for"]
         assert seen["wait_for"]
         assert seen["run"] == [
             [
@@ -617,10 +605,11 @@ class TestPodmanNodeBehavior:
     def test_wait_for_binary_interface_uses_remaining_timeout_after_log_wait(
         self, monkeypatch
     ):
+        """Verify that remaining_timeout is correctly computed from kwargs."""
         from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
 
         node = object.__new__(ScyllaPodmanNode)
-        node.cluster = SimpleNamespace(version=lambda: "2026.1")
+        node.cluster = SimpleNamespace(version=lambda: "2026.1", nodes={})
         node.network_interfaces = {"binary": ("10.90.1.1", 9042)}
         node.pid = "container-id"
         node.name = "node1"
@@ -632,7 +621,6 @@ class TestPodmanNodeBehavior:
             "ccmlib.scylla_podman_cluster.time.time",
             lambda: next(timeline),
         )
-        monkeypatch.setattr(node, "watch_log_for", lambda *args, **kwargs: True)
         monkeypatch.setattr(
             "ccmlib.scylla_podman_cluster.run",
             lambda *args, **kwargs: SimpleNamespace(returncode=0),
@@ -656,17 +644,10 @@ class TestPodmanNodeBehavior:
         from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
 
         node = object.__new__(ScyllaPodmanNode)
-        node.cluster = SimpleNamespace(version=lambda: "2026.1")
+        node.cluster = SimpleNamespace(version=lambda: "2026.1", nodes={})
         node.network_interfaces = {"binary": ("10.90.1.1", 9042)}
         node.pid = "container-id"
 
-        monkeypatch.setattr(node, "watch_log_for", lambda *args, **kwargs: True)
-        monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.common.check_socket_listening",
-            lambda *args, **kwargs: (_ for _ in ()).throw(
-                AssertionError("host-side socket check should not be used")
-            ),
-        )
         monkeypatch.setattr(
             "ccmlib.scylla_podman_cluster.run",
             lambda *args, **kwargs: SimpleNamespace(returncode=1),
@@ -728,6 +709,7 @@ class TestPodmanNodeBehavior:
         node.log_thread = None
         node.mark = 0
         node._fresh_container = False
+        node._event_monitor = None
 
         cluster = SimpleNamespace(pinning=True, _cpu_assignments={})
 
@@ -755,7 +737,7 @@ class TestPodmanNodeBehavior:
         monkeypatch.setattr(node, "_scylla_service_name", lambda: "scylla")
         monkeypatch.setattr(node, "get_path", lambda: "/tmp/node1")
         monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.PodmanLogger",
+            "ccmlib.scylla_podman_cluster.PodmanLogManager",
             lambda node_obj, log_path: SimpleNamespace(
                 start=lambda: None,
                 stop=lambda: None,
@@ -788,6 +770,8 @@ class TestPodmanClusterBehavior:
         cluster._scylla_manager = None
         cluster.pinning = False
         cluster._cpu_assignments = {}
+        cluster._log_manager = SimpleNamespace()
+        cluster._event_monitor = SimpleNamespace(start=lambda: None)
 
         monkeypatch.setattr(
             cluster,
@@ -806,6 +790,7 @@ class TestPodmanClusterBehavior:
         monkeypatch.setattr(cluster, "new_node", lambda *args, **kwargs: None)
         monkeypatch.setattr(cluster, "_update_config", lambda *args, **kwargs: None)
         monkeypatch.setattr(cluster, "cluster_cleanup", lambda: None)
+        monkeypatch.setattr(cluster, "_prepare_cluster_permissions", lambda: None)
 
         attempted_prefixes = []
         prefixes = iter(["10.89", "10.90"])
@@ -1081,7 +1066,8 @@ class TestPodmanContainerCreate:
         node.base_data_path = "/var/lib/scylla"
         node.local_yaml_path = "/tmp/node1-conf"
         node.share_directories = []
-        node.log_thread = None
+        node._log_manager = None
+        node._event_monitor = None
         node.network_interfaces = {
             "storage": ("127.0.0.1", 7000),
             "binary": ("127.0.0.1", 9042),
@@ -1097,6 +1083,10 @@ class TestPodmanContainerCreate:
                     name="node1", network_interfaces={"storage": ("10.89.1.1", 7000)}
                 )
             ],
+            seeds=[SimpleNamespace(
+                name="node1",
+                network_interfaces={"storage": ("10.89.1.1", 7000)},
+            )],
         )
 
         calls = []
@@ -1122,12 +1112,6 @@ class TestPodmanContainerCreate:
         monkeypatch.setattr(node, "_jmx_service_name", lambda: None)
         monkeypatch.setattr(node, "service_stop", lambda service_name: None)
         monkeypatch.setattr(node, "_setup_routes", lambda: None)
-        monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.PodmanLogger",
-            lambda node_obj, log_path: SimpleNamespace(
-                start=lambda: None, stop=lambda: None
-            ),
-        )
 
         node.create_container([])
 
@@ -1151,7 +1135,8 @@ class TestPodmanContainerCreate:
         node.base_data_path = "/usr/lib/scylla"
         node.local_yaml_path = "/tmp/node1-conf"
         node.share_directories = []
-        node.log_thread = None
+        node._log_manager = None
+        node._event_monitor = None
         node.network_interfaces = {
             "storage": ("127.0.0.1", 7000),
             "binary": ("127.0.0.1", 9042),
@@ -1168,6 +1153,10 @@ class TestPodmanContainerCreate:
                     name="node1", network_interfaces={"storage": ("10.89.1.1", 7000)}
                 )
             ],
+            seeds=[SimpleNamespace(
+                name="node1",
+                network_interfaces={"storage": ("10.89.1.1", 7000)},
+            )],
         )
 
         def fake_run(cmd, **kwargs):
@@ -1190,12 +1179,6 @@ class TestPodmanContainerCreate:
         monkeypatch.setattr(node, "_jmx_service_name", lambda: None)
         monkeypatch.setattr(node, "service_stop", lambda service_name: None)
         monkeypatch.setattr(node, "_setup_routes", lambda: None)
-        monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.PodmanLogger",
-            lambda node_obj, log_path: SimpleNamespace(
-                start=lambda: None, stop=lambda: None
-            ),
-        )
 
         node.create_container([])
 
@@ -1216,11 +1199,9 @@ class TestPodmanContainerCreate:
             "storage": ("127.0.0.1", 7000),
             "binary": ("127.0.0.1", 9042),
         }
-        create_networks_calls = []
         node.cluster = SimpleNamespace(
             podman_image="docker.io/scylladb/scylla:2026.1",
             network_topology=SimpleNamespace(
-                create_networks=lambda: create_networks_calls.append(True),
                 get_node_network=lambda node_name: "ccm-testcluster-dc1-rack1",
             ),
             nodelist=lambda: [
@@ -1228,6 +1209,10 @@ class TestPodmanContainerCreate:
                     name="node1", network_interfaces={"storage": ("10.89.1.1", 7000)}
                 )
             ],
+            seeds=[SimpleNamespace(
+                name="node1",
+                network_interfaces={"storage": ("10.89.1.1", 7000)},
+            )],
         )
 
         monkeypatch.setattr(node, "_get_rack_ip", lambda: "10.89.1.1")
@@ -1242,7 +1227,6 @@ class TestPodmanContainerCreate:
 
         node.create_container([])
 
-        assert create_networks_calls == [True]
         assert node.pid == "container123"
         assert node.network_interfaces["storage"] == ("10.89.1.1", 7000)
 
@@ -1272,6 +1256,10 @@ class TestPodmanContainerCreate:
                     name="node1", network_interfaces={"storage": ("10.89.1.1", 7000)}
                 )
             ],
+            seeds=[SimpleNamespace(
+                name="node1",
+                network_interfaces={"storage": ("10.89.1.1", 7000)},
+            )],
         )
 
         monkeypatch.setattr(node, "_get_rack_ip", lambda: "10.89.1.1")
@@ -1402,7 +1390,8 @@ class TestPodmanNodeRemoveAndStatus:
         node = object.__new__(TestableScyllaPodmanNode)
         node.name = "node1"
         node.pid = "abc123"
-        node.log_thread = None
+        node._log_manager = None
+        node._event_monitor = None
         node.status = SimpleNamespace()  # placeholder
         node._cached_nodetool_support = {}
         node._cached_supervisor_programs = None
@@ -1450,12 +1439,12 @@ class TestPodmanNodeRemoveAndStatus:
         node.remove()
         assert calls == []  # no podman rm should have been called
 
-    def test_remove_stops_log_thread(self, monkeypatch):
-        """Verify remove() stops the log thread."""
+    def test_remove_stops_log_stream(self, monkeypatch):
+        """Verify remove() stops the log stream via the log manager."""
         node = self._make_node()
         stopped = {"called": False}
-        node.log_thread = SimpleNamespace(
-            stop=lambda: stopped.__setitem__("called", True)
+        node._log_manager = SimpleNamespace(
+            stop_stream=lambda cid: stopped.__setitem__("called", True)
         )
         monkeypatch.setattr(
             "ccmlib.scylla_podman_cluster.run",
@@ -1463,7 +1452,20 @@ class TestPodmanNodeRemoveAndStatus:
         )
         node.remove()
         assert stopped["called"]
-        assert node.log_thread is None
+
+    def test_remove_unregisters_from_event_monitor(self, monkeypatch):
+        """Verify remove() unregisters the container from the event monitor."""
+        node = self._make_node()
+        unregistered = {"called": False}
+        node._event_monitor = SimpleNamespace(
+            unregister=lambda cid: unregistered.__setitem__("called", True)
+        )
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.run",
+            lambda *a, **kw: SimpleNamespace(returncode=0),
+        )
+        node.remove()
+        assert unregistered["called"]
 
     def test_service_status_returns_down_when_pid_is_none(self):
         """Verify service_status() returns 'DOWN' when container is gone."""

--- a/tests/test_scylla_podman_cluster.py
+++ b/tests/test_scylla_podman_cluster.py
@@ -10,8 +10,10 @@ Run with: pytest tests/test_scylla_podman_cluster.py -v -m network_topology
 
 import re
 import os
+import signal
 import subprocess
 import tempfile
+import threading
 import pytest
 from collections import OrderedDict
 from types import SimpleNamespace
@@ -19,8 +21,14 @@ from unittest.mock import patch
 
 from ruamel.yaml import YAML
 
-from ccmlib.scylla_podman_cluster import PodmanNetworkTopology
-from ccmlib.scylla_podman_cluster import PodmanProcess
+from ccmlib.scylla_podman_cluster import (
+    PodmanNetworkTopology,
+    PodmanProcess,
+    ScyllaPodmanCluster,
+    ScyllaPodmanNode,
+    _copy_conf_dir,
+)
+from ccmlib.scylla_node import ScyllaNode
 from ccmlib import common
 
 
@@ -75,6 +83,23 @@ class TestPodmanNetworkTopology:
         )
         net = topo.get_node_network("node1")
         assert net == "ccm-my-cluster-v2-dc-1-us-east-rac-1"
+
+    def test_network_naming_uses_stable_fallback_for_empty_components(self):
+        """All-invalid names should still yield non-empty, distinct podman-safe names."""
+        topology = OrderedDict(
+            [
+                ("___", OrderedDict([("!!!", 1)])),
+                ("---", OrderedDict([("@@@", 1)])),
+            ]
+        )
+        topo = PodmanNetworkTopology(
+            cluster_name="...",
+            topology=topology,
+        )
+
+        names = [entry["network_name"] for entry in topo.rack_networks.values()]
+        assert all("ccm-unnamed-" in name for name in names)
+        assert names[0] != names[1]
 
     def test_custom_subnet_prefix(self):
         topology = OrderedDict([("DC1", OrderedDict([("RAC1", 2)]))])
@@ -155,6 +180,26 @@ class TestPodmanNetworkTopology:
         assert len(cmds) == 1
         assert "prio bands 4" in cmds[0]
 
+    def test_tc_commands_packet_loss_without_delay(self):
+        """Packet loss should be applied even when inter-DC delay is 0."""
+        topology = OrderedDict(
+            [
+                ("DC1", OrderedDict([("RAC1", 1)])),
+                ("DC2", OrderedDict([("RAC1", 1)])),
+            ]
+        )
+        topo = PodmanNetworkTopology(
+            cluster_name="test",
+            topology=topology,
+            inter_rack_delay_ms=0,
+            inter_dc_delay_ms=0,
+            packet_loss_percent=5.0,
+        )
+        cmds = topo.build_tc_commands("node1")
+        # Should have: root qdisc + netem with loss (no delay) + filter
+        assert any("loss 5.0%" in c for c in cmds), f"Missing packet loss in tc commands: {cmds}"
+        assert not any("delay" in c for c in cmds), f"Unexpected delay in tc commands: {cmds}"
+
     def test_client_ip(self, multi_dc_topology):
         topo = multi_dc_topology
         assert topo.get_client_ip() == "10.89.1.100"
@@ -229,6 +274,14 @@ class TestPodmanNetworkTopology:
         """First rack with >= 100 nodes should fail (client container IP collision)."""
         topology = OrderedDict([("dc1", OrderedDict([("RAC1", 100)]))])
         with pytest.raises(ValueError, match="client container"):
+            PodmanNetworkTopology(cluster_name="test", topology=topology)
+
+    def test_validation_first_rack_must_have_nodes(self):
+        """First rack with 0 nodes should fail (client container needs a co-located node)."""
+        topology = OrderedDict(
+            [("dc1", OrderedDict([("RAC1", 0), ("RAC2", 2)]))]
+        )
+        with pytest.raises(ValueError, match="at least 1 node"):
             PodmanNetworkTopology(cluster_name="test", topology=topology)
 
     def test_validation_too_many_nodes_gateway_collision(self):
@@ -366,6 +419,22 @@ class TestPodmanProcess:
         p.returncode = 42
         assert p.poll() == 42
 
+    def test_poll_treats_paused_container_as_alive(self, monkeypatch):
+        """A paused container should not be treated as an exited process."""
+        p = PodmanProcess("paused-container-id")
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=0,
+                stdout="paused:0\n",
+                stderr="",
+            ),
+        )
+
+        assert p.poll() is None
+        assert p.returncode is None
+
 
 class TestFilterArgs:
     """Unit tests for ScyllaPodmanNode.filter_args."""
@@ -418,6 +487,80 @@ class TestFilterArgs:
         idx = result.index("--developer-mode")
         assert result[idx + 1] == "1"
 
+    def test_filter_args_preserves_boolean_flags(self):
+        """Boolean flags should not consume the following flag as their value."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        args = [
+            "/path/to/scylla",
+            "--options-file",
+            "/path/to/scylla.yaml",
+            "--experimental",
+            "--smp",
+            "2",
+            "--disable-version-check",
+            "--memory",
+            "512M",
+        ]
+
+        result = ScyllaPodmanNode.filter_args(args)
+
+        assert result == [
+            "--experimental",
+            "--smp",
+            "2",
+            "--disable-version-check",
+            "--memory",
+            "512M",
+            "--io-setup",
+            "0",
+        ]
+
+    def test_filter_args_preserves_unknown_flags_for_forward_compatibility(self):
+        """Unknown Scylla flags should pass through rather than being dropped."""
+
+        args = [
+            "/path/to/scylla",
+            "--options-file",
+            "/path/to/scylla.yaml",
+            "--kernel-page-cache",
+            "1",
+            "--max-networking-io-control-blocks",
+            "1000",
+            "--log-to-stdout",
+            "1",
+        ]
+
+        result = ScyllaPodmanNode.filter_args(args)
+
+        assert result == [
+            "--kernel-page-cache",
+            "1",
+            "--max-networking-io-control-blocks",
+            "1000",
+            "--io-setup",
+            "0",
+        ]
+
+    def test_filter_args_always_injects_io_setup_0(self):
+        """--io-setup 0 is always present in output so iotune never runs."""
+
+        # Not present in input → injected
+        result = ScyllaPodmanNode.filter_args(["--smp", "2"])
+        assert "--io-setup" in result
+        assert result[result.index("--io-setup") + 1] == "0"
+
+        # Already present as 1 → overridden to 0
+        result = ScyllaPodmanNode.filter_args(["--smp", "2", "--io-setup", "1"])
+        assert result.count("--io-setup") == 1
+        assert result[result.index("--io-setup") + 1] == "0"
+
+        # Present as --io-setup=1 → replaced
+        result = ScyllaPodmanNode.filter_args(["--smp", "2", "--io-setup=1"])
+        assert "--io-setup=1" not in result
+        assert "--io-setup" in result
+        assert result[result.index("--io-setup") + 1] == "0"
+
 
 class TestPodmanNodeBehavior:
     def test_wait_for_binary_interface_checks_inside_container(self, monkeypatch):
@@ -464,11 +607,47 @@ class TestPodmanNodeBehavior:
                 "podman",
                 "exec",
                 "container-id",
-                "python3",
+                "bash",
                 "-c",
-                "import socket; sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM); sock.settimeout(1.0); sock.connect(('10.90.1.1', 9042)); sock.close()",
+                "echo > /dev/tcp/10.90.1.1/9042",
             ]
         ]
+
+    def test_wait_for_binary_interface_uses_remaining_timeout_after_log_wait(
+        self, monkeypatch
+    ):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.cluster = SimpleNamespace(version=lambda: "2026.1")
+        node.network_interfaces = {"binary": ("10.90.1.1", 9042)}
+        node.pid = "container-id"
+        node.name = "node1"
+
+        timeline = iter([100.0, 101.25, 101.25])
+        observed = {}
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.time.time",
+            lambda: next(timeline),
+        )
+        monkeypatch.setattr(node, "watch_log_for", lambda *args, **kwargs: True)
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0),
+        )
+
+        def fake_wait_for(func, timeout, first=0.0, step=1.0):
+            observed["timeout"] = timeout
+            return func()
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.common.wait_for", fake_wait_for
+        )
+
+        node.wait_for_binary_interface(timeout=5)
+
+        assert observed["timeout"] == pytest.approx(3.75)
 
     def test_wait_for_binary_interface_times_out_when_container_probe_fails(
         self, monkeypatch
@@ -499,6 +678,94 @@ class TestPodmanNodeBehavior:
         with pytest.raises(TimeoutError, match="10.90.1.1:9042"):
             node.wait_for_binary_interface(timeout=5)
 
+    def test_get_tool_raises_when_pid_is_none(self):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.pid = None
+
+        with pytest.raises(RuntimeError, match="no running container"):
+            node.get_tool("cqlsh")
+
+    def test_setup_routes_raises_on_failure(self, monkeypatch):
+        """Node-level _setup_routes() should raise RuntimeError on route failures."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.pid = "container-id"
+        node.cluster = SimpleNamespace(
+            network_topology=SimpleNamespace(
+                get_routes_for_node=lambda node_name: [
+                    ("10.89.2.0/24", "10.89.1.254"),
+                    ("10.89.3.0/24", "10.89.1.254"),
+                ]
+            )
+        )
+
+        call_count = {"n": 0}
+
+        def fake_nsenter(container_id, command):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return SimpleNamespace(returncode=0, stderr="")
+            return SimpleNamespace(returncode=1, stderr="RTNETLINK: File exists")
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster._nsenter_net_run", fake_nsenter
+        )
+
+        with pytest.raises(RuntimeError, match=r"1 route\(s\).*node1"):
+            node._setup_routes()
+
+    def test_start_scylla_refreshes_cpu_assignments_before_pinning(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.pid = None
+        node.log_thread = None
+        node.mark = 0
+
+        cluster = SimpleNamespace(pinning=True, _cpu_assignments={})
+
+        def refresh_cpu_assignments():
+            cluster._cpu_assignments = {"node1": [4, 5]}
+
+        cluster._refresh_cpu_assignments = refresh_cpu_assignments
+        node.cluster = cluster
+
+        observed = {}
+
+        monkeypatch.setattr(node, "filter_args", lambda args: args)
+
+        def fake_pinning(args):
+            observed["assignments"] = dict(cluster._cpu_assignments)
+            return args
+
+        monkeypatch.setattr(node, "_pinning_scylla_args", fake_pinning)
+        monkeypatch.setattr(
+            node,
+            "create_container",
+            lambda args: setattr(node, "pid", "container123"),
+        )
+        monkeypatch.setattr(node, "service_status", lambda service_name: "RUNNING")
+        monkeypatch.setattr(node, "_scylla_service_name", lambda: "scylla")
+        monkeypatch.setattr(node, "get_path", lambda: "/tmp/node1")
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.PodmanLogger",
+            lambda node_obj, log_path: SimpleNamespace(
+                start=lambda: None,
+                stop=lambda: None,
+            ),
+        )
+
+        process = node._start_scylla([], [], False, False, False, False, {})
+
+        assert observed["assignments"] == {"node1": [4, 5]}
+        assert process.pid == "container123"
+
 
 class TestPodmanClusterBehavior:
     def test_populate_retries_with_another_subnet_prefix_on_collision(
@@ -518,6 +785,8 @@ class TestPodmanClusterBehavior:
         cluster.use_vnodes = False
         cluster._config_options = {}
         cluster._scylla_manager = None
+        cluster.pinning = False
+        cluster._cpu_assignments = {}
 
         monkeypatch.setattr(
             cluster,
@@ -582,6 +851,8 @@ class TestPodmanClusterBehavior:
         cluster.use_vnodes = False
         cluster._config_options = {}
         cluster._scylla_manager = None
+        cluster.pinning = False
+        cluster._cpu_assignments = {}
 
         monkeypatch.setattr(
             cluster,
@@ -644,9 +915,11 @@ class TestPodmanClusterBehavior:
 
         cluster = object.__new__(ScyllaPodmanCluster)
         cluster.name = "testcluster"
+        cluster.path = "/tmp/.ccm"
         cluster.podman_image = "docker.io/scylladb/scylla:2026.1"
         cluster._client_container_id = None
         cluster.network_topology = SimpleNamespace(
+            node_assignments={"node1": {}},
             get_client_ip=lambda: "10.89.1.100",
             get_client_network=lambda: "ccm-testcluster-dc1-rack1",
             build_tc_commands=lambda node_name: [],
@@ -679,6 +952,42 @@ class TestPodmanClusterBehavior:
         assert f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}" in run_cmd
         assert not any(":ip=" in part for part in run_cmd)
 
+    def test_start_client_container_sanitizes_client_name(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.name = "test cluster/2026"
+        cluster.path = "/tmp/.ccm"
+        cluster.podman_image = "docker.io/scylladb/scylla:2026.1"
+        cluster._client_container_id = None
+        cluster.network_topology = SimpleNamespace(
+            node_assignments={"node1": {}},
+            get_client_ip=lambda: "10.89.1.100",
+            get_client_network=lambda: "ccm-testcluster-dc1-rack1",
+            build_tc_commands=lambda node_name: [],
+        )
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[:3] == ["podman", "run", "-d"]:
+                return SimpleNamespace(returncode=0, stdout="client123\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr(
+            cluster,
+            "_setup_container_routes",
+            lambda client_name, node_name: None,
+        )
+
+        cluster.start_client_container()
+
+        run_cmd = next(cmd for cmd in calls if cmd[:3] == ["podman", "run", "-d"])
+        name_idx = run_cmd.index("--name")
+        assert run_cmd[name_idx + 1] == "ccm-test-cluster-test-cluster-2026-client"
+
     def test_setup_container_routes_logs_failures(self, monkeypatch):
         from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
 
@@ -687,24 +996,76 @@ class TestPodmanClusterBehavior:
             get_routes_for_node=lambda node_name: [("10.89.2.0/24", "10.89.1.254")]
         )
 
-        warnings = []
-
         monkeypatch.setattr(
             "ccmlib.scylla_podman_cluster._nsenter_net_run",
             lambda container_id, command: SimpleNamespace(
                 returncode=1, stderr="route failed"
             ),
         )
-        monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.LOGGER.warning",
-            lambda *args: warnings.append(args[0] if len(args) == 1 else args[0] % args[1:]),
+
+        with pytest.raises(RuntimeError, match=r"1 route\(s\).*client123"):
+            cluster._setup_container_routes("client123", "node1")
+
+    def test_start_client_container_refuses_live_foreign_name_collision(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.name = "testcluster"
+        cluster.path = "/tmp/.ccm"
+        cluster.podman_image = "docker.io/scylladb/scylla:2026.1"
+        cluster._client_container_id = None
+        cluster.network_topology = SimpleNamespace(
+            get_client_ip=lambda: "10.89.1.100",
+            get_client_network=lambda: "ccm-testcluster-dc1-rack1",
+            node_assignments={"node1": {}},
         )
 
-        cluster._setup_container_routes("client123", "node1")
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster._inspect_container",
+            lambda name: {
+                "Id": "client-123",
+                "State": {"Status": "running"},
+                "Config": {
+                    "Labels": {"org.scylladb.ccm-owner-pid": str(os.getpid() + 1)}
+                },
+            },
+        )
+        with pytest.raises(RuntimeError, match="Refusing to remove running container"):
+            cluster.start_client_container()
 
-        assert warnings == [
-            "Failed to add route 10.89.2.0/24 via 10.89.1.254 in client123: route failed"
-        ]
+    def test_clear_preserves_topology_for_restart(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.network_topology = SimpleNamespace(destroy_networks=lambda: None)
+        cluster.nodes = OrderedDict(
+            node1=SimpleNamespace(name="node1", remove=lambda: None, clear=lambda: None)
+        )
+        cluster.stop_client_container = lambda: None
+
+        topology = cluster.network_topology
+        cluster.clear()
+
+        assert cluster.network_topology is topology
+
+    def test_create_networks_refuses_live_foreign_owner_collision(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import PodmanNetworkTopology
+
+        topo = PodmanNetworkTopology(
+            cluster_name="testcluster",
+            topology=OrderedDict([("dc1", OrderedDict([("rack1", 1)]))]),
+        )
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster._inspect_network",
+            lambda name: {
+                "labels": {"org.scylladb.ccm-owner-pid": str(os.getpid() + 1)},
+                "containers": {"abc": {"name": "some-live-container"}},
+            },
+        )
+
+        with pytest.raises(RuntimeError, match="containers still attached"):
+            topo.create_networks()
 
 
 class TestPodmanContainerCreate:
@@ -727,6 +1088,7 @@ class TestPodmanContainerCreate:
         node.cluster = SimpleNamespace(
             podman_image="docker.io/scylladb/scylla:2026.1",
             network_topology=SimpleNamespace(
+                create_networks=lambda: None,
                 get_node_network=lambda node_name: "ccm-testcluster-dc1-rack1"
             ),
             nodelist=lambda: [
@@ -777,6 +1139,151 @@ class TestPodmanContainerCreate:
         assert run_cmd[ip_idx + 1] == "10.89.1.1"
         assert f"{PODMAN_RESOURCE_OWNER_LABEL}={os.getpid()}" in run_cmd
         assert not any(":ip=" in part for part in run_cmd)
+
+    def test_create_container_clears_supervisor_cache_when_recreating(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.pid = "dead-container"
+        node.podman_name = "ccm-test-node1"
+        node.base_data_path = "/usr/lib/scylla"
+        node.local_yaml_path = "/tmp/node1-conf"
+        node.share_directories = []
+        node.log_thread = None
+        node.network_interfaces = {
+            "storage": ("127.0.0.1", 7000),
+            "binary": ("127.0.0.1", 9042),
+        }
+        node._cached_supervisor_programs = {"scylla-server"}
+        node.cluster = SimpleNamespace(
+            podman_image="docker.io/scylladb/scylla:2026.1",
+            network_topology=SimpleNamespace(
+                create_networks=lambda: None,
+                get_node_network=lambda node_name: "ccm-testcluster-dc1-rack1"
+            ),
+            nodelist=lambda: [
+                SimpleNamespace(
+                    name="node1", network_interfaces={"storage": ("10.89.1.1", 7000)}
+                )
+            ],
+        )
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:3] == ["podman", "inspect", "--format"]:
+                return SimpleNamespace(returncode=0, stdout="exited\n", stderr="")
+            if cmd[:2] == ["podman", "run"]:
+                return SimpleNamespace(returncode=0, stdout="container123\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.common.wait_for",
+            lambda func, timeout, step: True,
+        )
+        monkeypatch.setattr(node, "_prepare_bind_mounts", lambda: None)
+        monkeypatch.setattr(node, "_get_rack_ip", lambda: "10.89.1.1")
+        monkeypatch.setattr(node, "read_scylla_yaml", lambda: {})
+        monkeypatch.setattr(node, "get_path", lambda: "/tmp/node1")
+        monkeypatch.setattr(node, "_scylla_service_name", lambda: "scylla")
+        monkeypatch.setattr(node, "_jmx_service_name", lambda: None)
+        monkeypatch.setattr(node, "service_stop", lambda service_name: None)
+        monkeypatch.setattr(node, "_setup_routes", lambda: None)
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.PodmanLogger",
+            lambda node_obj, log_path: SimpleNamespace(
+                start=lambda: None, stop=lambda: None
+            ),
+        )
+
+        node.create_container([])
+
+        assert node._cached_supervisor_programs is None
+
+    def test_create_container_reuses_live_current_process_container(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.pid = None
+        node.podman_name = "ccm-test-node1"
+        node.base_data_path = "/usr/lib/scylla"
+        node.local_yaml_path = "/tmp/node1-conf"
+        node.share_directories = []
+        node.log_thread = None
+        node.network_interfaces = {
+            "storage": ("127.0.0.1", 7000),
+            "binary": ("127.0.0.1", 9042),
+        }
+        create_networks_calls = []
+        node.cluster = SimpleNamespace(
+            podman_image="docker.io/scylladb/scylla:2026.1",
+            network_topology=SimpleNamespace(
+                create_networks=lambda: create_networks_calls.append(True),
+                get_node_network=lambda node_name: "ccm-testcluster-dc1-rack1",
+            ),
+            nodelist=lambda: [
+                SimpleNamespace(
+                    name="node1", network_interfaces={"storage": ("10.89.1.1", 7000)}
+                )
+            ],
+        )
+
+        monkeypatch.setattr(node, "_get_rack_ip", lambda: "10.89.1.1")
+        monkeypatch.setattr(node, "read_scylla_yaml", lambda: {})
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster._remove_named_container_if_safe",
+            lambda name, allow_reuse_current_running=False: {
+                "Id": "container123",
+                "State": {"Status": "running"},
+            },
+        )
+
+        node.create_container([])
+
+        assert create_networks_calls == [True]
+        assert node.pid == "container123"
+        assert node.network_interfaces["storage"] == ("10.89.1.1", 7000)
+
+    def test_create_container_refuses_live_foreign_name_collision(self, monkeypatch):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.pid = None
+        node.podman_name = "ccm-test-node1"
+        node.base_data_path = "/usr/lib/scylla"
+        node.local_yaml_path = "/tmp/node1-conf"
+        node.share_directories = []
+        node.log_thread = None
+        node.network_interfaces = {
+            "storage": ("127.0.0.1", 7000),
+            "binary": ("127.0.0.1", 9042),
+        }
+        node.cluster = SimpleNamespace(
+            podman_image="docker.io/scylladb/scylla:2026.1",
+            network_topology=SimpleNamespace(
+                create_networks=lambda: None,
+                get_node_network=lambda node_name: "ccm-testcluster-dc1-rack1",
+            ),
+            nodelist=lambda: [
+                SimpleNamespace(
+                    name="node1", network_interfaces={"storage": ("10.89.1.1", 7000)}
+                )
+            ],
+        )
+
+        monkeypatch.setattr(node, "_get_rack_ip", lambda: "10.89.1.1")
+        monkeypatch.setattr(node, "read_scylla_yaml", lambda: {})
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster._remove_named_container_if_safe",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                RuntimeError("owned by live process 4242")
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="owned by live process 4242"):
+            node.create_container([])
 
 
 class TestPodmanConftestCleanup:
@@ -897,6 +1404,7 @@ class TestPodmanNodeRemoveAndStatus:
         node.log_thread = None
         node.status = SimpleNamespace()  # placeholder
         node._cached_nodetool_support = {}
+        node._cached_supervisor_programs = None
         return node
 
     def test_remove_clears_pid_before_podman_rm(self, monkeypatch):
@@ -1033,6 +1541,27 @@ class TestPodmanNodeRemoveAndStatus:
         assert "-c" in calls[1]
         kill_arg = calls[1][-1]
         assert "kill" in kill_arg
+        assert "-15" in kill_arg
+        assert "42" in kill_arg
+
+    def test_kill_handles_signal_enum(self, monkeypatch):
+        """Verify kill() works with signal.Signals enum values (Python 3.11+ compat)."""
+        node = self._make_node()
+        calls = []
+
+        def fake_run(cmd, stdout=None, stderr=None, text=False):
+            calls.append(cmd)
+            if "supervisorctl" in cmd and "pid" in cmd:
+                return SimpleNamespace(returncode=0, stdout="42\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr(node, "_scylla_service_name", lambda: "scylla")
+
+        node.kill(signal.SIGTERM)
+
+        kill_arg = calls[1][-1]
+        # Must produce "kill -15 42", not "kill -Signals.SIGTERM 42"
         assert "-15" in kill_arg
         assert "42" in kill_arg
 
@@ -1211,6 +1740,36 @@ class TestPodmanNodeRemoveAndStatus:
         # Should not raise, and should not try os.kill on a string pid
         node.wait_until_stopped(wait_seconds=5)
         assert not node.is_running()
+
+    def test_update_config_persists_zero_initial_token(self, tmp_path):
+        """A valid token value of 0 must survive node.conf persistence."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+        from ccmlib.node import Status
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.status = Status.DOWN
+        node.auto_bootstrap = False
+        node.network_interfaces = {
+            "storage": ("10.0.0.1", 7000),
+            "binary": ("10.0.0.1", 9042),
+        }
+        node.jmx_port = "7199"
+        node.pid = "container123"
+        node.podman_name = "ccm-test-node1"
+        node.initial_token = 0
+        node.remote_debug_port = "0"
+        node.data_center = None
+        node.rack = None
+        node.workload = None
+        node.get_path = lambda: str(tmp_path)
+
+        node._update_config()
+
+        with open(tmp_path / "node.conf") as f:
+            data = YAML().load(f)
+
+        assert data["initial_token"] == 0
 
 
 class TestPodmanClusterFactoryLoad:
@@ -1393,3 +1952,476 @@ class TestScyllaPodmanCluster:
         assert podman_cluster.is_docker()  # is_docker() returns True for compat
         for node in podman_cluster.nodelist():
             assert node.is_podman()
+
+
+
+# ============================================================================
+# Unit tests for CPU pinning feature (no podman required)
+# ============================================================================
+
+
+class TestCpuPinning:
+    """Unit tests for CPU pinning assignment, Scylla arg injection,
+    podman arg injection, and io_properties generation."""
+
+    def _make_cluster_with_nodes(
+        self, monkeypatch, num_nodes=3, smp=2, pinning=True, host_cpus=16
+    ):
+        """Helper: build a ScyllaPodmanCluster with mocked nodes for pinning tests."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.name = "test-pinning"
+        cluster.podman_image = "scylladb/scylla:latest"
+        cluster.pinning = pinning
+        cluster._cpu_assignments = {}
+        cluster.network_topology = None
+        cluster._client_container_id = None
+        cluster.inter_rack_delay_ms = 1
+        cluster.inter_dc_delay_ms = 50
+        cluster.packet_loss_percent = 0.0
+
+        # Build fake nodes
+        nodes = OrderedDict()
+        for i in range(1, num_nodes + 1):
+            node = SimpleNamespace(
+                name=f"node{i}",
+                smp=lambda _smp=smp: _smp,
+            )
+            nodes[f"node{i}"] = node
+        cluster.nodes = nodes
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.host_cpu_count",
+            lambda: host_cpus,
+        )
+        return cluster
+
+    def test_compute_assignments_basic(self, monkeypatch):
+        """3 nodes x 2 smp on a 16-core host -> 3 non-overlapping pairs."""
+        cluster = self._make_cluster_with_nodes(
+            monkeypatch, num_nodes=3, smp=2, host_cpus=16
+        )
+        cluster._compute_cpu_assignments()
+        assert cluster.pinning is True
+        assert cluster._cpu_assignments == {
+            "node1": [0, 1],
+            "node2": [2, 3],
+            "node3": [4, 5],
+        }
+
+    def test_compute_assignments_exact_fit(self, monkeypatch):
+        """4 nodes x 4 smp on a 16-core host -> exact fit, still valid."""
+        cluster = self._make_cluster_with_nodes(
+            monkeypatch, num_nodes=4, smp=4, host_cpus=16
+        )
+        cluster._compute_cpu_assignments()
+        assert cluster.pinning is True
+        assert len(cluster._cpu_assignments) == 4
+        # Verify no overlap
+        all_cpus = []
+        for cpus in cluster._cpu_assignments.values():
+            all_cpus.extend(cpus)
+        assert len(all_cpus) == len(set(all_cpus)) == 16
+
+    def test_compute_assignments_uses_each_node_smp(self, monkeypatch):
+        """Assignments must follow each node's actual smp(), not node1's only."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.name = "test-pinning"
+        cluster.podman_image = "scylladb/scylla:latest"
+        cluster.pinning = True
+        cluster._cpu_assignments = {}
+        cluster.network_topology = None
+        cluster._client_container_id = None
+        cluster.inter_rack_delay_ms = 1
+        cluster.inter_dc_delay_ms = 50
+        cluster.packet_loss_percent = 0.0
+        cluster.nodes = OrderedDict(
+            [
+                ("node1", SimpleNamespace(name="node1", smp=lambda: 1)),
+                ("node2", SimpleNamespace(name="node2", smp=lambda: 3)),
+                ("node3", SimpleNamespace(name="node3", smp=lambda: 2)),
+            ]
+        )
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.host_cpu_count",
+            lambda: 16,
+        )
+
+        cluster._compute_cpu_assignments()
+
+        assert cluster._cpu_assignments == {
+            "node1": [0],
+            "node2": [1, 2, 3],
+            "node3": [4, 5],
+        }
+
+    def test_compute_assignments_insufficient_cpus(self, monkeypatch):
+        """5 nodes x 4 smp on a 16-core host -> pinning disabled."""
+        cluster = self._make_cluster_with_nodes(
+            monkeypatch, num_nodes=5, smp=4, host_cpus=16
+        )
+        cluster._compute_cpu_assignments()
+        assert cluster.pinning is False
+        assert cluster._cpu_assignments == {}
+
+    def test_compute_assignments_not_implemented(self, monkeypatch):
+        """If host_cpu_count() raises NotImplementedError, pinning disabled."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = self._make_cluster_with_nodes(
+            monkeypatch, num_nodes=2, smp=2, host_cpus=8
+        )
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.host_cpu_count",
+            lambda: (_ for _ in ()).throw(NotImplementedError),
+        )
+        cluster._compute_cpu_assignments()
+        assert cluster.pinning is False
+        assert cluster._cpu_assignments == {}
+
+    def test_compute_assignments_empty_cluster(self, monkeypatch):
+        """No nodes -> empty assignments, pinning remains True."""
+        cluster = self._make_cluster_with_nodes(
+            monkeypatch, num_nodes=0, smp=2, host_cpus=16
+        )
+        cluster._compute_cpu_assignments()
+        assert cluster._cpu_assignments == {}
+
+    def test_pinning_container_args_when_pinned(self, monkeypatch):
+        """Node returns --cpuset-cpus flag when it has a CPU assignment."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.cluster = SimpleNamespace(_cpu_assignments={"node1": [0, 1, 2, 3]})
+
+        result = node._pinning_container_args()
+        assert result == ["--cpuset-cpus", "0,1,2,3"]
+
+    def test_pinning_container_args_when_not_pinned(self, monkeypatch):
+        """Node returns empty list when no CPU assignment."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.cluster = SimpleNamespace(_cpu_assignments={})
+
+        result = node._pinning_container_args()
+        assert result == []
+
+    def test_pinning_scylla_args_injects_cpuset_removes_overprovisioned(
+        self, monkeypatch, tmp_path
+    ):
+        """When pinned, --cpuset is added, --overprovisioned is removed."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.cluster = SimpleNamespace(_cpu_assignments={"node1": [4, 5]})
+        node.local_yaml_path = str(tmp_path)
+
+        input_args = [
+            "--smp",
+            "2",
+            "--memory",
+            "1G",
+            "--overprovisioned",
+            "1",
+            "--developer-mode",
+            "1",
+        ]
+        result = node._pinning_scylla_args(input_args)
+
+        assert "--cpuset" in result
+        cpuset_idx = result.index("--cpuset")
+        assert result[cpuset_idx + 1] == "4,5"
+        assert "--overprovisioned" not in result
+        assert "--io-setup" in result
+        io_idx = result.index("--io-setup")
+        assert result[io_idx + 1] == "0"
+        assert "--io-properties-file" in result
+
+    def test_pinning_scylla_args_does_not_mutate_input(self, monkeypatch, tmp_path):
+        """The original args list is not modified."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.cluster = SimpleNamespace(_cpu_assignments={"node1": [0, 1]})
+        node.local_yaml_path = str(tmp_path)
+
+        original = ["--smp", "2", "--overprovisioned", "1"]
+        original_copy = list(original)
+        node._pinning_scylla_args(original)
+        assert original == original_copy
+
+    def test_pinning_scylla_args_noop_when_not_pinned(self, monkeypatch):
+        """When not pinned, args pass through unchanged."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.cluster = SimpleNamespace(_cpu_assignments={})
+
+        input_args = ["--smp", "2", "--overprovisioned", "1"]
+        result = node._pinning_scylla_args(input_args)
+        assert result is input_args  # same object, not a copy
+
+    def test_pinning_scylla_args_replaces_existing_io_setup(
+        self, monkeypatch, tmp_path
+    ):
+        """If --io-setup is already in args, its value is replaced with 0."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.name = "node1"
+        node.cluster = SimpleNamespace(_cpu_assignments={"node1": [0]})
+        node.local_yaml_path = str(tmp_path)
+
+        input_args = ["--io-setup", "1", "--overprovisioned", "1"]
+        result = node._pinning_scylla_args(input_args)
+        io_idx = result.index("--io-setup")
+        assert result[io_idx + 1] == "0"
+
+    def test_write_io_properties(self, tmp_path):
+        """io_properties.yaml is written with correct structure and values."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.local_yaml_path = str(tmp_path)
+        node.base_data_path = "/usr/lib/scylla"
+
+        path = node._write_io_properties(4)
+
+        assert os.path.exists(path)
+        yaml = YAML()
+        with open(path) as f:
+            data = yaml.load(f)
+        assert "disks" in data
+        assert len(data["disks"]) == 1
+        disk = data["disks"][0]
+        assert disk["mountpoint"] == "/usr/lib/scylla"
+        assert disk["read_iops"] == 400000  # 100k * 4
+        assert disk["write_iops"] == 400000
+        assert disk["read_bandwidth"] == 1073741824 * 4
+        assert disk["write_bandwidth"] == 1073741824 * 4
+
+    def test_write_io_properties_single_cpu(self, tmp_path):
+        """io_properties.yaml for a single CPU has base values."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        node = object.__new__(ScyllaPodmanNode)
+        node.local_yaml_path = str(tmp_path)
+        node.base_data_path = "/usr/lib/scylla"
+
+        path = node._write_io_properties(1)
+        yaml = YAML()
+        with open(path) as f:
+            data = yaml.load(f)
+        disk = data["disks"][0]
+        assert disk["mountpoint"] == "/usr/lib/scylla"
+        assert disk["read_iops"] == 100000
+        assert disk["write_iops"] == 100000
+
+    def test_pinning_persisted_in_config(self, monkeypatch, tmp_path):
+        """The pinning flag is saved in cluster.conf."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.name = "test-pinning"
+        cluster.podman_image = "scylladb/scylla:latest"
+        cluster.pinning = True
+        cluster._cpu_assignments = {}
+        cluster.network_topology = None
+        cluster._client_container_id = None
+        cluster.partitioner = None
+        cluster._config_options = {}
+        cluster._dse_config_options = {}
+        cluster.use_vnodes = False
+        cluster.id = 0
+        cluster.ipprefix = "127.0.0."
+        cluster.nodes = OrderedDict()
+        cluster.seeds = []
+
+        monkeypatch.setattr(cluster, "get_path", lambda: str(tmp_path))
+
+        cluster._update_config()
+
+        yaml = YAML()
+        with open(tmp_path / "cluster.conf") as f:
+            data = yaml.load(f)
+        assert data["pinning"] is True
+
+    def test_pinning_false_persisted_in_config(self, monkeypatch, tmp_path):
+        """Pinning=False is also saved (not omitted)."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.name = "test-no-pinning"
+        cluster.podman_image = "scylladb/scylla:latest"
+        cluster.pinning = False
+        cluster._cpu_assignments = {}
+        cluster.network_topology = None
+        cluster._client_container_id = None
+        cluster.partitioner = None
+        cluster._config_options = {}
+        cluster._dse_config_options = {}
+        cluster.use_vnodes = False
+        cluster.id = 0
+        cluster.ipprefix = "127.0.0."
+        cluster.nodes = OrderedDict()
+        cluster.seeds = []
+
+        monkeypatch.setattr(cluster, "get_path", lambda: str(tmp_path))
+
+        cluster._update_config()
+
+        yaml = YAML()
+        with open(tmp_path / "cluster.conf") as f:
+            data = yaml.load(f)
+        assert data["pinning"] is False
+
+    def test_filter_args_passes_io_properties_file(self):
+        """--io-properties-file is in the whitelist and passes through filter_args."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
+
+        args = ["--smp", "2", "--io-properties-file", "/etc/scylla/io_properties.yaml"]
+        result = ScyllaPodmanNode.filter_args(args)
+        assert "--io-properties-file" in result
+        idx = result.index("--io-properties-file")
+        assert result[idx + 1] == "/etc/scylla/io_properties.yaml"
+
+
+class TestImageConfCache:
+    """Unit tests for the cluster-level image config cache.
+
+    Verifies that _get_image_conf_cache_dir() triggers _extract_image_conf
+    exactly once regardless of how many nodes call update_yaml(), and that
+    each node gets its own populated conf directory copied from the cache.
+    """
+
+    def test_extract_called_once_for_multiple_nodes(self, monkeypatch, tmp_path):
+        """_extract_image_conf is called once even when N nodes call the real update_yaml().
+
+        Drives the actual ScyllaPodmanNode.update_yaml() rather than reimplementing
+        its guard inline, so a regression in the wiring would be caught here.
+        """
+        # Build a minimal cluster stub
+        cluster_dir = str(tmp_path / "cluster")
+        os.makedirs(cluster_dir, exist_ok=True)
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.podman_image = "docker.io/scylladb/scylla:test"
+        cluster._image_conf_cache_lock = threading.Lock()
+        cluster.get_path = lambda: cluster_dir
+        cluster.network_topology = None
+
+        extract_calls = []
+
+        def fake_extract(image, dest_dir):
+            extract_calls.append(image)
+            os.makedirs(dest_dir, exist_ok=True)
+            with open(os.path.join(dest_dir, "scylla.yaml"), "w") as f:
+                f.write("cluster_name: test\n")
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster._extract_image_conf", fake_extract
+        )
+        # Stub out the parent's update_yaml and the per-node yaml customisation
+        # that needs a full ScyllaNode setup (seeds, tokens, data dirs, etc.).
+        # We only want to exercise the cache-lookup wiring inside
+        # ScyllaPodmanNode.update_yaml.
+        monkeypatch.setattr(ScyllaNode, "update_yaml", lambda self: None)
+        monkeypatch.setattr(ScyllaPodmanNode, "read_scylla_yaml", lambda self: {})
+        monkeypatch.setattr(ScyllaPodmanNode, "_get_rack_ip", lambda self: "127.0.0.1")
+
+        # Drive the real update_yaml() for three nodes.
+        for i in range(1, 4):
+            node_dir = str(tmp_path / f"node{i}")
+            node_conf_dir = os.path.join(node_dir, "conf")
+            os.makedirs(node_conf_dir, exist_ok=True)
+
+            node = object.__new__(ScyllaPodmanNode)
+            node.cluster = cluster
+            node.local_yaml_path = node_conf_dir
+            node.name = f"node{i}"
+            node.base_data_path = "/usr/lib/scylla"
+            node.network_interfaces = {
+                "storage": ("127.0.0.1", 7000),
+                "binary": ("127.0.0.1", 9042),
+            }
+            node.get_path = lambda nd=node_dir: nd
+
+            node.update_yaml()
+
+        assert len(extract_calls) == 1, (
+            f"_extract_image_conf should be called exactly once, got {len(extract_calls)}"
+        )
+
+    def test_each_node_gets_own_copy_of_conf(self, monkeypatch, tmp_path):
+        """Each node's conf dir is populated independently from the cache."""
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.podman_image = "docker.io/scylladb/scylla:test"
+        cluster._image_conf_cache_lock = threading.Lock()
+        cluster.get_path = lambda: str(tmp_path / "cluster")
+        os.makedirs(str(tmp_path / "cluster"), exist_ok=True)
+
+        def fake_extract(image, dest_dir):
+            os.makedirs(dest_dir, exist_ok=True)
+            with open(os.path.join(dest_dir, "scylla.yaml"), "w") as f:
+                f.write("cluster_name: shared-template\n")
+            with open(os.path.join(dest_dir, "cassandra-rackdc.properties"), "w") as f:
+                f.write("dc=dc1\nrack=RAC1\n")
+
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster._extract_image_conf", fake_extract
+        )
+
+        node_conf_dirs = []
+        for i in range(1, 4):
+            node_conf_dir = str(tmp_path / f"node{i}" / "conf")
+            os.makedirs(node_conf_dir, exist_ok=True)
+            cache = cluster._get_image_conf_cache_dir()
+            _copy_conf_dir(cache, node_conf_dir)
+            node_conf_dirs.append(node_conf_dir)
+
+        # Every node should have its own scylla.yaml
+        for conf_dir in node_conf_dirs:
+            assert os.path.exists(os.path.join(conf_dir, "scylla.yaml"))
+            assert os.path.exists(os.path.join(conf_dir, "cassandra-rackdc.properties"))
+
+        # They must be separate files (mutating one shouldn't affect another)
+        with open(os.path.join(node_conf_dirs[0], "scylla.yaml"), "w") as f:
+            f.write("cluster_name: modified-by-node1\n")
+        with open(os.path.join(node_conf_dirs[1], "scylla.yaml")) as f:
+            content = f.read()
+        assert "shared-template" in content, "node2's yaml was unexpectedly modified"
+
+    def test_cache_is_not_repopulated_on_second_populate(self, monkeypatch, tmp_path):
+        """If the cache already has scylla.yaml, _extract_image_conf is not called again."""
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.podman_image = "docker.io/scylladb/scylla:test"
+        cluster._image_conf_cache_lock = threading.Lock()
+        cluster_dir = str(tmp_path / "cluster")
+        os.makedirs(cluster_dir, exist_ok=True)
+        cluster.get_path = lambda: cluster_dir
+
+        # Pre-populate the cache (simulates a prior populate() run)
+        cache_dir = os.path.join(cluster_dir, "_image_conf_cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        with open(os.path.join(cache_dir, "scylla.yaml"), "w") as f:
+            f.write("cluster_name: pre-existing\n")
+
+        extract_calls = []
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster._extract_image_conf",
+            lambda image, dest_dir: extract_calls.append(image),
+        )
+
+        result = cluster._get_image_conf_cache_dir()
+
+        assert extract_calls == [], "_extract_image_conf must not be called when cache exists"
+        assert result == cache_dir

--- a/tests/test_scylla_podman_cluster.py
+++ b/tests/test_scylla_podman_cluster.py
@@ -424,12 +424,13 @@ class TestPodmanProcess:
         p = PodmanProcess("paused-container-id")
 
         monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.run",
-            lambda *args, **kwargs: SimpleNamespace(
-                returncode=0,
-                stdout="paused:0\n",
-                stderr="",
-            ),
+            "ccmlib.scylla_podman_cluster._get_container_host_pid",
+            lambda cid: 99999,
+        )
+        monkeypatch.setattr(
+            os.path,
+            "isdir",
+            lambda path: path == "/proc/99999",
         )
 
         assert p.poll() is None
@@ -704,19 +705,18 @@ class TestPodmanNodeBehavior:
             )
         )
 
-        call_count = {"n": 0}
-
-        def fake_nsenter(container_id, command):
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                return SimpleNamespace(returncode=0, stderr="")
-            return SimpleNamespace(returncode=1, stderr="RTNETLINK: File exists")
-
         monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster._nsenter_net_run", fake_nsenter
+            "ccmlib.scylla_podman_cluster._get_container_host_pid",
+            lambda container_id: 12345,
+        )
+        monkeypatch.setattr(
+            "ccmlib.scylla_podman_cluster.run",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=2, stderr="RTNETLINK: File exists"
+            ),
         )
 
-        with pytest.raises(RuntimeError, match=r"1 route\(s\).*node1"):
+        with pytest.raises(RuntimeError, match=r"2 route\(s\).*node1"):
             node._setup_routes()
 
     def test_start_scylla_refreshes_cpu_assignments_before_pinning(self, monkeypatch):
@@ -727,6 +727,7 @@ class TestPodmanNodeBehavior:
         node.pid = None
         node.log_thread = None
         node.mark = 0
+        node._fresh_container = False
 
         cluster = SimpleNamespace(pinning=True, _cpu_assignments={})
 
@@ -1572,84 +1573,25 @@ class TestPodmanNodeRemoveAndStatus:
         with pytest.raises(RuntimeError, match="no running container"):
             node.nodetool("status")
 
-    def test_nodetool_caches_supported_command_probe(self, monkeypatch):
-        """Supported native nodetool commands should only be probed once per node."""
+    def test_nodetool_dispatches_supported_command(self, monkeypatch):
+        """Verify nodetool command is dispatched with correct args via
+        ``get_tool``."""
         node = self._make_node()
-        check_calls = []
         run_calls = []
-
-        def fake_check_call(cmd, **kwargs):
-            check_calls.append(cmd)
-            return 0
 
         def fake_do_run_nodetool(cmd, capture_output, wait, timeout, verbose):
             run_calls.append(cmd)
             return "ok", ""
 
-        monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.subprocess.check_call", fake_check_call
-        )
         monkeypatch.setattr(node, "_do_run_nodetool", fake_do_run_nodetool)
 
         assert node.nodetool("status") == ("ok", "")
         assert node.nodetool("status") == ("ok", "")
 
-        assert len(check_calls) == 1
         assert len(run_calls) == 2
         assert run_calls[0] == [
-            "podman",
-            "exec",
-            "abc123",
-            "scylla",
-            "nodetool",
-            "-h",
-            "localhost",
-            "-p",
-            "10000",
-            "status",
-        ]
-
-    def test_nodetool_caches_unsupported_command_probe(self, monkeypatch):
-        """Unsupported native commands should only probe once before JMX fallback."""
-        node = self._make_node()
-        node._cached_supervisor_programs = {"scylla", "scylla-jmx"}
-        check_calls = []
-        run_calls = []
-
-        def fake_check_call(cmd, **kwargs):
-            check_calls.append(cmd)
-            raise subprocess.CalledProcessError(1, cmd)
-
-        def fake_do_run_nodetool(cmd, capture_output, wait, timeout, verbose):
-            run_calls.append(cmd)
-            return "fallback", ""
-
-        monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.subprocess.check_call", fake_check_call
-        )
-        monkeypatch.setattr(node, "_do_run_nodetool", fake_do_run_nodetool)
-
-        assert node.nodetool("cleanup") == ("fallback", "")
-        assert node.nodetool("cleanup") == ("fallback", "")
-
-        assert len(check_calls) == 1
-        assert run_calls == [
-            [
-                "podman",
-                "exec",
-                "abc123",
-                "nodetool",
-                "-Dcom.scylladb.apiPort=10000",
-                "cleanup",
-            ],
-            [
-                "podman",
-                "exec",
-                "abc123",
-                "nodetool",
-                "-Dcom.scylladb.apiPort=10000",
-                "cleanup",
-            ],
+            "/usr/bin/podman", "exec", "-i", "abc123", "nodetool",
+            "-h", "localhost", "-p", "10000", "status",
         ]
 
     def test_service_start_raises_on_failure(self, monkeypatch):

--- a/tests/test_scylla_podman_cluster.py
+++ b/tests/test_scylla_podman_cluster.py
@@ -8,6 +8,7 @@ These tests require:
 Run with: pytest tests/test_scylla_podman_cluster.py -v -m network_topology
 """
 
+import logging
 import re
 import os
 import signal
@@ -22,15 +23,47 @@ from ccmlib.node import TimeoutError
 
 from ruamel.yaml import YAML
 
+import ccmlib.scylla_podman_cluster as scylla_podman_cluster_module
+from ccmlib.container_client import ContainerClientError, PodmanClient
 from ccmlib.scylla_podman_cluster import (
+    CONTAINER_NET_INTERFACE,
     PodmanNetworkTopology,
     PodmanProcess,
     ScyllaPodmanCluster,
     ScyllaPodmanNode,
     _copy_conf_dir,
+    _get_container_host_pid,
+    _nsenter_net_run,
 )
 from ccmlib.scylla_node import ScyllaNode
 from ccmlib import common
+
+
+@pytest.fixture(autouse=True)
+def _stub_podman_client_singleton(monkeypatch):
+    """Seed the module-level PodmanClient singleton with a bare stub so no
+    test triggers a real `podman version` call, and test order can't affect
+    which tests see that extra call when asserting exact command lists.
+
+    Also stubs ``ccmlib.container_client.run`` -- the actual subprocess
+    entry point every ``ContainerClient``/``PodmanClient`` method (including
+    ones inherited from the base class that no individual test happens to
+    mock) funnels through via ``_run_command``. Without this, a test that
+    exercises an inherited method (e.g. ``inspect_container()`` via
+    ``PodmanProcess.poll()``) shells out to a real ``podman`` binary, making
+    this "unit" suite depend on podman being installed. Individual tests can
+    still override this with their own ``monkeypatch.setattr(...)``.
+    """
+    stub_client = object.__new__(PodmanClient)
+    stub_client.runtime_name = "podman"
+    stub_client.runtime_path = "podman"
+    monkeypatch.setattr(scylla_podman_cluster_module, "_PODMAN_CLIENT", stub_client)
+
+    def _default_fake_run(cmd, *args, **kwargs):
+        return subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr("ccmlib.container_client.run", _default_fake_run)
+    yield
 
 
 # ============================================================================
@@ -177,9 +210,8 @@ class TestPodmanNetworkTopology:
             inter_dc_delay_ms=0,
         )
         cmds = topo.build_tc_commands("node1")
-        # Only the root qdisc should be present
-        assert len(cmds) == 1
-        assert "prio bands 4" in cmds[0]
+        # No delay/loss configured: no tc commands at all
+        assert cmds == []
 
     def test_tc_commands_packet_loss_without_delay(self):
         """Packet loss should be applied even when inter-DC delay is 0."""
@@ -577,13 +609,13 @@ class TestPodmanNodeBehavior:
 
         def fake_run(cmd, stdout=None, stderr=None, **kwargs):
             seen["run"].append(cmd)
-            return SimpleNamespace(returncode=0)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         def fake_wait_for(func, timeout, first=0.0, step=1.0):
             seen["wait_for"] = True
             return func()
 
-        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr("ccmlib.container_client.run", fake_run)
         monkeypatch.setattr(
             "ccmlib.scylla_podman_cluster.common.wait_for", fake_wait_for
         )
@@ -614,16 +646,28 @@ class TestPodmanNodeBehavior:
         node.pid = "container-id"
         node.name = "node1"
 
-        timeline = iter([100.0, 101.25, 101.25])
+        # A fixed-length iterator here would be fragile: any incidental extra
+        # time.time() call elsewhere in the exercised code path (for example
+        # inside logging, which itself calls time.time() to timestamp
+        # records) would raise StopIteration despite being irrelevant to
+        # what this test verifies. Keep returning the last value once the
+        # scripted sequence is exhausted instead.
+        timeline = [100.0, 101.25, 101.25]
+
+        def fake_time():
+            if len(timeline) > 1:
+                return timeline.pop(0)
+            return timeline[0]
+
         observed = {}
 
         monkeypatch.setattr(
             "ccmlib.scylla_podman_cluster.time.time",
-            lambda: next(timeline),
+            fake_time,
         )
         monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.run",
-            lambda *args, **kwargs: SimpleNamespace(returncode=0),
+            "ccmlib.container_client.run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
         )
 
         def fake_wait_for(func, timeout, first=0.0, step=1.0):
@@ -649,8 +693,8 @@ class TestPodmanNodeBehavior:
         node.pid = "container-id"
 
         monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.run",
-            lambda *args, **kwargs: SimpleNamespace(returncode=1),
+            "ccmlib.container_client.run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr=""),
         )
         monkeypatch.setattr(
             "ccmlib.scylla_podman_cluster.common.wait_for",
@@ -736,13 +780,6 @@ class TestPodmanNodeBehavior:
         monkeypatch.setattr(node, "service_status", lambda service_name: "RUNNING")
         monkeypatch.setattr(node, "_scylla_service_name", lambda: "scylla")
         monkeypatch.setattr(node, "get_path", lambda: "/tmp/node1")
-        monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.PodmanLogManager",
-            lambda node_obj, log_path: SimpleNamespace(
-                start=lambda: None,
-                stop=lambda: None,
-            ),
-        )
 
         process = node._start_scylla([], [], False, False, False, False, {})
 
@@ -791,6 +828,7 @@ class TestPodmanClusterBehavior:
         monkeypatch.setattr(cluster, "_update_config", lambda *args, **kwargs: None)
         monkeypatch.setattr(cluster, "cluster_cleanup", lambda: None)
         monkeypatch.setattr(cluster, "_prepare_cluster_permissions", lambda: None)
+        monkeypatch.setattr(cluster, "_ensure_image_pulled", lambda: None)
 
         attempted_prefixes = []
         prefixes = iter(["10.89", "10.90"])
@@ -857,6 +895,7 @@ class TestPodmanClusterBehavior:
         monkeypatch.setattr(cluster, "new_node", lambda *args, **kwargs: None)
         monkeypatch.setattr(cluster, "_update_config", lambda *args, **kwargs: None)
         monkeypatch.setattr(cluster, "cluster_cleanup", lambda: None)
+        monkeypatch.setattr(cluster, "_ensure_image_pulled", lambda: None)
         monkeypatch.setenv("CCM_PODMAN_SUBNET_PREFIX", "10.123")
 
         def fake_create_networks(self):
@@ -919,7 +958,7 @@ class TestPodmanClusterBehavior:
                 return SimpleNamespace(returncode=0, stdout="client123\n", stderr="")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr("ccmlib.container_client.run", fake_run)
         monkeypatch.setattr(
             cluster,
             "_setup_container_routes",
@@ -961,7 +1000,7 @@ class TestPodmanClusterBehavior:
                 return SimpleNamespace(returncode=0, stdout="client123\n", stderr="")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr("ccmlib.container_client.run", fake_run)
         monkeypatch.setattr(
             cluster,
             "_setup_container_routes",
@@ -1025,7 +1064,7 @@ class TestPodmanClusterBehavior:
         cluster = object.__new__(ScyllaPodmanCluster)
         cluster.network_topology = SimpleNamespace(destroy_networks=lambda: None)
         cluster.nodes = OrderedDict(
-            node1=SimpleNamespace(name="node1", remove=lambda: None, clear=lambda: None)
+            node1=SimpleNamespace(name="node1", _detach_container=lambda: [], clear=lambda: None)
         )
         cluster.stop_client_container = lambda: None
 
@@ -1034,6 +1073,141 @@ class TestPodmanClusterBehavior:
 
         assert cluster.network_topology is topology
 
+    def test_remove_stops_event_monitor_and_log_manager(self, monkeypatch):
+        """Full cluster remove() must stop the event monitor and log
+        manager, otherwise each cluster leaks a background thread +
+        `podman events --stream` subprocess."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.network_topology = SimpleNamespace(destroy_networks=lambda: None)
+        cluster.nodes = OrderedDict(
+            node1=SimpleNamespace(name="node1", _detach_container=lambda: [])
+        )
+        cluster.stop_client_container = lambda: None
+
+        stopped = {"monitor": False, "log_manager": False}
+        cluster._event_monitor = SimpleNamespace(
+            stop=lambda: stopped.__setitem__("monitor", True)
+        )
+        cluster._log_manager = SimpleNamespace(
+            stop_all=lambda: stopped.__setitem__("log_manager", True)
+        )
+
+        monkeypatch.setattr(
+            "ccmlib.cluster.Cluster.remove", lambda self, **kwargs: None
+        )
+
+        cluster.remove()
+
+        assert stopped["monitor"] is True
+        assert stopped["log_manager"] is True
+
+    def test_remove_tolerates_missing_event_monitor_and_log_manager(self, monkeypatch):
+        """remove() must not crash when populate() never ran and
+        _event_monitor/_log_manager are still None."""
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.network_topology = None
+        cluster.nodes = OrderedDict()
+        cluster.stop_client_container = lambda: None
+        cluster._event_monitor = None
+        cluster._log_manager = None
+
+        monkeypatch.setattr(
+            "ccmlib.cluster.Cluster.remove", lambda self, **kwargs: None
+        )
+
+        cluster.remove()  # should not raise
+
+
+class TestPodmanClusterBatchRemove:
+    """Unit tests for _batch_remove_nodes(): batched `podman rm` instead of
+    one subprocess per node, with per-node fallback on batch failure."""
+
+    def _make_cluster_and_nodes(self, count):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        nodes = OrderedDict()
+        for i in range(1, count + 1):
+            name = f"node{i}"
+            nodes[name] = SimpleNamespace(
+                name=name,
+                _detach_container=lambda cid=f"cid{i}": [cid, f"podman-{cid}"],
+            )
+        cluster.nodes = nodes
+        return cluster
+
+    def test_batch_remove_calls_remove_containers_once_with_all_targets(self):
+        cluster = self._make_cluster_and_nodes(3)
+        calls = []
+        fake_client = SimpleNamespace(
+            remove_containers=lambda ids, **kw: calls.append((ids, kw)) or []
+        )
+        cluster.get_container_client = lambda: fake_client
+
+        cluster._batch_remove_nodes(cluster.nodes.values())
+
+        assert len(calls) == 1
+        ids, kwargs = calls[0]
+        assert set(ids) == {"cid1", "cid2", "cid3"}
+        assert kwargs == {"force": True, "volumes": True, "chunk_size": 10}
+
+    def test_batch_remove_falls_back_to_podman_name_on_failure(self):
+        cluster = self._make_cluster_and_nodes(2)
+        fallback_calls = []
+        fake_client = SimpleNamespace(
+            remove_containers=lambda ids, **kw: ["cid1"],  # cid1's batch entry failed
+            remove_container=lambda target, **kw: fallback_calls.append(target),
+        )
+        cluster.get_container_client = lambda: fake_client
+
+        cluster._batch_remove_nodes(cluster.nodes.values())
+
+        # Only the failed node's fallback (podman name) should be retried,
+        # not the node whose primary target already succeeded.
+        assert fallback_calls == ["podman-cid1"]
+
+    def test_batch_remove_logs_error_when_all_targets_fail(self, monkeypatch, caplog):
+        cluster = self._make_cluster_and_nodes(1)
+        fake_client = SimpleNamespace(
+            remove_containers=lambda ids, **kw: list(ids),
+            remove_container=lambda target, **kw: (_ for _ in ()).throw(
+                ContainerClientError("boom")
+            ),
+        )
+        cluster.get_container_client = lambda: fake_client
+
+        with caplog.at_level(logging.ERROR):
+            cluster._batch_remove_nodes(cluster.nodes.values())
+
+        assert any("Failed to remove container for node1" in r.message for r in caplog.records)
+
+    def test_batch_remove_with_no_nodes_is_noop(self):
+        cluster = self._make_cluster_and_nodes(0)
+        cluster.get_container_client = lambda: (_ for _ in ()).throw(
+            AssertionError("should not need a client when there are no nodes")
+        )
+
+        cluster._batch_remove_nodes(cluster.nodes.values())  # should not raise
+
+    def test_batch_remove_skips_client_when_nodes_have_no_targets(self):
+        from ccmlib.scylla_podman_cluster import ScyllaPodmanCluster
+
+        cluster = object.__new__(ScyllaPodmanCluster)
+        cluster.nodes = OrderedDict(
+            node1=SimpleNamespace(name="node1", _detach_container=lambda: [])
+        )
+        cluster.get_container_client = lambda: (_ for _ in ()).throw(
+            AssertionError("should not need a client when no node has a target")
+        )
+
+        cluster._batch_remove_nodes(cluster.nodes.values())  # should not raise
+
+
+class TestPodmanClusterCreateNetworks:
     def test_create_networks_refuses_live_foreign_owner_collision(self, monkeypatch):
         from ccmlib.scylla_podman_cluster import PodmanNetworkTopology
 
@@ -1099,7 +1273,7 @@ class TestPodmanContainerCreate:
                 return SimpleNamespace(returncode=0, stdout="", stderr="")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr("ccmlib.container_client.run", fake_run)
         monkeypatch.setattr(
             "ccmlib.scylla_podman_cluster.common.wait_for",
             lambda func, timeout, step: True,
@@ -1160,13 +1334,20 @@ class TestPodmanContainerCreate:
         )
 
         def fake_run(cmd, **kwargs):
-            if cmd[:3] == ["podman", "inspect", "--format"]:
-                return SimpleNamespace(returncode=0, stdout="exited\n", stderr="")
+            # Only the stale-container status check (by container ID) should
+            # report "exited". The by-name lookup used by
+            # _remove_named_container_if_safe() to check for a reusable
+            # container must fall through to "not found" (empty stdout) so
+            # it doesn't trip the resource-ownership-label checks.
+            if cmd[:3] == ["podman", "inspect", "dead-container"]:
+                return SimpleNamespace(
+                    returncode=0, stdout='[{"State": {"Status": "exited"}}]', stderr=""
+                )
             if cmd[:2] == ["podman", "run"]:
                 return SimpleNamespace(returncode=0, stdout="container123\n", stderr="")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr("ccmlib.container_client.run", fake_run)
         monkeypatch.setattr(
             "ccmlib.scylla_podman_cluster.common.wait_for",
             lambda func, timeout, step: True,
@@ -1195,6 +1376,9 @@ class TestPodmanContainerCreate:
         node.local_yaml_path = "/tmp/node1-conf"
         node.share_directories = []
         node.log_thread = None
+        # Stale caches from a prior container; reuse path must reset these.
+        node._cached_supervisor_programs = {"stale-program"}
+        node._cached_nodetool_support = {"stale": True}
         node.network_interfaces = {
             "storage": ("127.0.0.1", 7000),
             "binary": ("127.0.0.1", 9042),
@@ -1229,6 +1413,8 @@ class TestPodmanContainerCreate:
 
         assert node.pid == "container123"
         assert node.network_interfaces["storage"] == ("10.89.1.1", 7000)
+        assert node._cached_supervisor_programs is None
+        assert node._cached_nodetool_support == {}
 
     def test_create_container_refuses_live_foreign_name_collision(self, monkeypatch):
         from ccmlib.scylla_podman_cluster import ScyllaPodmanNode
@@ -1286,13 +1472,13 @@ class TestPodmanConftestCleanup:
             if cmd[:4] == ["podman", "ps", "-a", "--format"]:
                 return SimpleNamespace(
                     returncode=0,
-                    stdout='[{"Names":["ccm-live"],"State":"running","Labels":{"org.scylladb.ccm-owner-pid":"111"}},{"Names":["ccm-dead"],"State":"running","Labels":{"org.scylladb.ccm-owner-pid":"222"}}]',
+                    stdout='[{"Names":["ccm-live"],"State":"running","Labels":{"org.scylladb.ccm-owner-pid":"111","org.scylladb.ccm-test-session":"pytest"}},{"Names":["ccm-dead"],"State":"running","Labels":{"org.scylladb.ccm-owner-pid":"222","org.scylladb.ccm-test-session":"pytest"}}]',
                     stderr="",
                 )
             if cmd[:4] == ["podman", "network", "ls", "--format"]:
                 return SimpleNamespace(
                     returncode=0,
-                    stdout='[{"name":"ccm-live-net","labels":{"org.scylladb.ccm-owner-pid":"111"}},{"name":"ccm-dead-net","labels":{"org.scylladb.ccm-owner-pid":"222"}}]',
+                    stdout='[{"name":"ccm-live-net","labels":{"org.scylladb.ccm-owner-pid":"111","org.scylladb.ccm-test-session":"pytest"}},{"name":"ccm-dead-net","labels":{"org.scylladb.ccm-owner-pid":"222","org.scylladb.ccm-test-session":"pytest"}}]',
                     stderr="",
                 )
             if cmd[:3] == ["podman", "network", "inspect"]:
@@ -1311,6 +1497,7 @@ class TestPodmanConftestCleanup:
 
         monkeypatch.setattr(conftest, "run", fake_run)
         monkeypatch.setattr(conftest, "_pid_is_alive", lambda pid: pid == 111)
+        monkeypatch.setattr(conftest, "_THIS_TEST_SESSION_ID", "pytest")
 
         conftest._prune_stale_ccm_podman_resources()
 
@@ -1413,7 +1600,7 @@ class TestPodmanNodeRemoveAndStatus:
             call_order.append(("run", cmd, node.pid))
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr("ccmlib.container_client.run", fake_run)
 
         node.remove()
 
@@ -1477,7 +1664,7 @@ class TestPodmanNodeRemoveAndStatus:
         """Verify service_status() parses supervisorctl output correctly."""
         node = self._make_node()
         monkeypatch.setattr(
-            "ccmlib.scylla_podman_cluster.run",
+            "ccmlib.container_client.run",
             lambda *a, **kw: SimpleNamespace(
                 returncode=0, stdout="scylla RUNNING pid 123, uptime 0:01:00", stderr=""
             ),
@@ -1524,13 +1711,13 @@ class TestPodmanNodeRemoveAndStatus:
         node = self._make_node()
         calls = []
 
-        def fake_run(cmd, stdout=None, stderr=None, text=False):
+        def fake_run(cmd, **kwargs):
             calls.append(cmd)
             if "supervisorctl" in cmd and "pid" in cmd:
                 return SimpleNamespace(returncode=0, stdout="42\n", stderr="")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr("ccmlib.container_client.run", fake_run)
         # Need _scylla_service_name to work
         monkeypatch.setattr(node, "_scylla_service_name", lambda: "scylla")
 
@@ -1552,13 +1739,13 @@ class TestPodmanNodeRemoveAndStatus:
         node = self._make_node()
         calls = []
 
-        def fake_run(cmd, stdout=None, stderr=None, text=False):
+        def fake_run(cmd, **kwargs):
             calls.append(cmd)
             if "supervisorctl" in cmd and "pid" in cmd:
                 return SimpleNamespace(returncode=0, stdout="42\n", stderr="")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr("ccmlib.container_client.run", fake_run)
         monkeypatch.setattr(node, "_scylla_service_name", lambda: "scylla")
 
         node.kill(signal.SIGTERM)
@@ -1592,7 +1779,7 @@ class TestPodmanNodeRemoveAndStatus:
 
         assert len(run_calls) == 2
         assert run_calls[0] == [
-            "/usr/bin/podman", "exec", "-i", "abc123", "nodetool",
+            "podman", "exec", "-i", "abc123", "nodetool",
             "-h", "localhost", "-p", "10000", "status",
         ]
 
@@ -1611,11 +1798,11 @@ class TestPodmanNodeRemoveAndStatus:
             # Second call is supervisorctl start — fail
             return SimpleNamespace(returncode=1, stdout="", stderr="boom")
 
-        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr("ccmlib.container_client.run", fake_run)
         with pytest.raises(RuntimeError, match="failed to start.*boom"):
             node.service_start("scylla")
 
-        assert run_kwargs[1]["text"] is True
+        assert run_kwargs[1]["universal_newlines"] is True
 
     def test_service_start_clears_fatal_before_start(self, monkeypatch):
         """Verify service_start() clears FATAL state before starting."""
@@ -1630,7 +1817,7 @@ class TestPodmanNodeRemoveAndStatus:
             # clear and start both succeed
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr("ccmlib.container_client.run", fake_run)
         node.service_start("scylla")
 
         # Should have 3 calls: status, clear, start
@@ -1678,7 +1865,7 @@ class TestPodmanNodeRemoveAndStatus:
                 returncode=0, stdout="scylla RUNNING pid 42, uptime 0:01:00", stderr=""
             )
 
-        monkeypatch.setattr("ccmlib.scylla_podman_cluster.run", fake_run)
+        monkeypatch.setattr("ccmlib.container_client.run", fake_run)
         # Stub out _update_config since it needs a full cluster/filesystem
         monkeypatch.setattr(ScyllaPodmanNode, "_update_config", lambda self: None)
         # Should not raise, and should not try os.kill on a string pid
@@ -1882,13 +2069,48 @@ class TestScyllaPodmanCluster:
         assert node2.is_running()
 
     def test_08_network_isolation(self, podman_cluster):
-        """Verify that nodes are on different podman networks per rack."""
+        """Verify nodes are on different podman networks per rack, and that
+        the advertised tc/netem latency rules are actually installed.
+
+        Checking network names alone would pass even if `_apply_tc_rules()`
+        silently failed (it only logs a warning on failure -- see
+        ScyllaPodmanNode._apply_tc_rules), so also inspect each node's live
+        qdisc state via `tc qdisc show`.
+        """
         topo = podman_cluster.network_topology
         # Each rack should have its own network
         networks = set()
         for node in podman_cluster.nodelist():
             networks.add(topo.get_node_network(node.name))
         assert len(networks) == 3, f"Expected 3 distinct networks, got {networks}"
+
+        checked_any_netem = False
+        for node in podman_cluster.nodelist():
+            expected_commands = topo.build_tc_commands(node.name)
+            if not any("netem" in cmd for cmd in expected_commands):
+                # This node has no foreign rack/DC subnets to shape (for
+                # example the only rack in its DC with no other DCs) --
+                # nothing to verify for it.
+                continue
+            checked_any_netem = True
+            host_pid = _get_container_host_pid(node.pid)
+            res = _nsenter_net_run(
+                node.pid,
+                ["tc", "qdisc", "show", "dev", CONTAINER_NET_INTERFACE],
+                host_pid=host_pid,
+            )
+            assert res.returncode == 0, (
+                f"tc qdisc show failed on {node.name}: {res.stderr}"
+            )
+            assert "netem" in res.stdout, (
+                f"Expected a netem qdisc on {node.name} (dev {CONTAINER_NET_INTERFACE}) "
+                f"but none was found; tc qdisc show output: {res.stdout!r}"
+            )
+        assert checked_any_netem, (
+            "No node in this topology has foreign rack/DC subnets to shape; "
+            "test fixture topology may have changed -- update this test"
+        )
+
 
     def test_09_is_podman(self, podman_cluster):
         """Verify cluster and nodes report as podman."""


### PR DESCRIPTION
Lots of AI blurb below, TL;DR: this is supposed to let us run a multi-DC scenario, with latency and packet drop between the DCs, on a single host, using podman. It includes mainly the setup of the network topology to mimic such setups. The motivation is to be able to test LWT workload, for example. CC @calebxyz 

---

## V4 changes

Fixes for the 10 issues flagged by the automated Copilot review of the previous commit (`faa02a5`), amended into the same commit.

**Correctness (3 fixes):**

1. **`destroy_networks()` could delete an unowned network**: unlike `create_networks()`, it force-removed a same-named network even without our ownership label. Now skips (warns + continues) instead, matching `create_networks()`'s existing refusal.
2. **`PodmanEventMonitor.stop()` didn't unblock a quiet event stream**: setting the stop flag doesn't interrupt a thread blocked in `for line in process.stdout`. `stop()` now terminates the active `podman events` subprocess first, so the blocking read gets EOF.
3. **`wait_for()` regression added 5s/node to every cluster start**: `first=5` in the shared `ScyllaNode.start()` unconditionally sleeps before the *first* `is_running()` check, for all cluster types (not just podman). Changed to `first=0` (checks immediately, as before this PR), keeping the improved `timeout=30`/`step=0.5` and the new failure-raising behavior.

**Test-suite safety / accuracy (4 fixes):**

4. **Stale-resource pruning could delete a live user cluster**: `tests/conftest.py`'s pytest-session pruning treated any `ccm-`-named container with a dead owner PID as stale, but a normal `ccm create ... -s` CLI invocation exits right after startup while its cluster keeps running. Added a `CCM_PODMAN_TEST_SESSION` label (set by conftest.py, read by `ScyllaPodmanCluster`) so pruning is scoped to resources a test session actually created.
5. **`test_08_network_isolation` never checked that tc/netem was applied**: only verified rack networks have distinct names. Since `_apply_tc_rules()` only logs and continues on failure, this could pass even with zero latency simulation. Now also asserts a `netem` qdisc via `tc qdisc show` (through `nsenter`).
6. **`SKILL.md` / `run_big_cluster.py` bypass `start_nodes()`, so tc/netem was never applied**: both start nodes concurrently via their own `ThreadPoolExecutor` over `node.start()`, skipping the only place that calls `_apply_tc_rules()`. Added `ScyllaPodmanCluster.apply_network_shaping()` (factored out of `start_nodes()`); both now call it explicitly after their pool completes.
7. **`SCYLLA_PODMAN_IMAGE` didn't actually fall back to `SCYLLA_DOCKER_IMAGE`**: contradicted the V2 changelog below -- it still hardcoded `"scylladb/scylla:latest"`. Fixed.

**Minor / docs (3 fixes):**

8. **`run_big_cluster.py --nodes`/`--concurrency` were documented but never parsed**: topology and concurrency were hardcoded. Added `argparse`.
9. **Docs had a doubled subnet prefix**: `subnet_prefix` already includes the leading `"10."` (e.g. `10.89`), so `10.{prefix}...`/`10.<prefix>...` rendered as `10.10.89.1.0/24`. Fixed all 14 occurrences to `{subnet_prefix}`/`<subnet_prefix>`.
10. **Docs overstated the CPU-pinning default and formula**: `ScyllaPodmanNode` defaults `smp=1`, not 2, and required capacity is the *sum of each node's own* `smp` (heterogeneous-safe), not `total_nodes * smp`. Fixed in both the docs and the Requirements section below.

**Also fixed (found via CI, not flagged by the review):** a fragile test mock in `test_wait_for_binary_interface_uses_remaining_timeout_after_log_wait` patched the *global* `time.time` (since `scylla_podman_cluster` does a bare `import time`), so an incidental extra `time.time()` call from the previous commit's added debug logging exhausted its fixed-length fake timeline and failed CI (`build (3.12)`) with `StopIteration`, cascading to cancel the 3.11/3.13/3.14 jobs. The fake now repeats its last value instead of raising once exhausted.

**Test results after V4:**
```
191 passed  (test_scylla_podman_cluster.py + test_container_client.py + test_config.py)
321 passed, 14 skipped  (rest of the suite that doesn't require a live container runtime)
```

---

## V3 changes

Fixes found during in-depth review cycles 47–48. All amended into the existing review-fix commit — no new commits added.

**Medium severity (2 fixes):**

1. **CPU pinning refresh on start**: `_compute_cpu_assignments()` was only called in `populate()`. After loading a saved cluster from disk or changing node `smp()` values, pinning assignments were never recomputed. Added `_refresh_cpu_assignments()` called from `populate()`, `start_nodes()`, and `_start_scylla()`. Also switched from assuming all nodes share `nodes[0].smp()` to using each node's actual `smp()` value.

2. **Interactive tool path for `os.execve`**: `get_tool()` returned bare `"podman"` which works for `subprocess` (PATH lookup) but fails for `os.execve()` in inherited code paths like `Node.run_cqlsh(cmds=None)`. Now uses `shutil.which("podman")` to resolve the full path.

**Low severity (3 fixes — fixed now per request):**

3. **`initial_token=0` not persisted**: `_update_config()` used `if self.initial_token:` which drops the valid token value `0`. Changed to `if self.initial_token is not None:`.

4. **Paused containers treated as dead**: `PodmanProcess.poll()` only considered `"running"` and `"created"` as alive, but the module already defines `_RUNNING_CONTAINER_STATES = ("running", "created", "paused")`. Now uses the shared constant.

5. **Stale `clear()` docstring**: Still claimed `clear()` removes networks, but previous cycles intentionally changed it to preserve topology for restartability. Updated to match actual behavior.

**Hardening (from cycle 47):**

6. **Load-order invariant comment**: Added protective comment in `cluster_factory.py` explaining why `'network_topology'` must be checked before `'docker_image'` in `ClusterFactory.load()`.

7. **CLI validation reorder**: Moved `--podman-image`/`--docker-image` mutual-exclusion check before the podman-specific option validation block in `cluster_cmds.py`.

**New regression tests added:** `test_poll_treats_paused_container_as_alive`, `test_start_scylla_refreshes_cpu_assignments_before_pinning`, `test_update_config_persists_zero_initial_token`, `test_compute_assignments_uses_each_node_smp`.

**Test results after V3:**
```
92 passed, 9 deselected in 0.75s   (unit tests)
101 passed in 489.29s (0:08:09)    (full suite incl. integration)
```

---

## V2 changes

**Critical bug fix**: `ccm create --scylla --podman-image ... -n 1 -s` crashed with `"Cannot create existing node node1"`.

**Root cause**: `ScyllaPodmanCluster.__init__()` accepted a `topology=` kwarg and called `self.populate(topology)` during construction. The CLI then called `cluster.populate()` a second time at `cluster_cmds.py:299` (the standard pattern for all cluster types), hitting the duplicate-node guard. The aggressive error cleanup then destroyed all networks and nodes, making the failure hard to diagnose.

**Fixes applied (all amended into original commits — no extra fixup commits):**

1. **Removed `topology=` kwarg from `ScyllaPodmanCluster.__init__()`** — `populate()` is now called only once by the caller, matching `ScyllaDockerCluster` and all other cluster types.
2. **Removed `topology=` from CLI constructor call** in `cluster_cmds.py` (and the now-unused `parse_populate_count` call above it).
3. **Updated `conftest.py` fixture** to call `cluster.populate()` separately instead of passing `topology=` to the constructor.
4. **Updated `FakeCluster` mock** in test to include a `populate()` method.
5. **Added `LOGGER.warning()`/`LOGGER.debug()` to populate() error cleanup** — failures now log what's being cleaned up instead of silently destroying everything.
6. **Fixed `SCYLLA_PODMAN_IMAGE` default** — now falls back to `SCYLLA_DOCKER_IMAGE` env var (matching the test docstring) instead of a hardcoded `"scylladb/scylla:latest"`.

---

## Motivation

CCM currently supports Docker-based Scylla clusters (`ScyllaDockerCluster`), but these lack realistic multi-datacenter network topology simulation. Real ScyllaDB deployments span multiple DCs and availability zones with measurable inter-DC and inter-rack latencies that affect Raft consensus, CQL timeouts, and replication behavior.

This PR adds **podman-based container support** with **per-rack network isolation** and **`tc`/`netem` latency simulation**, enabling developers to test ScyllaDB behavior under realistic network conditions — including inter-DC delays, inter-rack delays, and packet loss — all on a single host using rootless podman.

Additionally, an optional **CPU pinning** feature is included to assign dedicated host CPU cores to each Scylla node, eliminating noisy-neighbor effects in performance-sensitive testing.

## What this PR does

### Core implementation (`ScyllaPodmanCluster` / `ScyllaPodmanNode`)
- New `ScyllaPodmanCluster` and `ScyllaPodmanNode` classes alongside the existing Docker ones (no changes to Docker behavior)
- **Per-rack podman networks**: each rack gets its own isolated `/24` subnet (e.g., `10.0.1.0/24` for dc1-rack1, `10.0.2.0/24` for dc1-rack2, `10.1.1.0/24` for dc2-rack1)
- **Rootless podman**: no root privileges required for container management
- **`nsenter`-based `tc`/`netem` latency simulation**: inter-DC and inter-rack delays applied from the host via `nsenter -t <pid> --user --net` using the host's `tc` binary — no networking tools needed inside containers
- **`ip route add` via `nsenter`**: cross-rack/cross-DC routing set up the same way — no `iproute` package inside containers
- **CQL client container** on Rack1's network with routes to all other racks
- **PID-based resource ownership**: containers and networks are labeled with `org.scylladb.ccm-owner-pid` so concurrent CCM sessions don't interfere with each other
- **Deferred `tc`/`netem` rules**: applied AFTER cluster startup to avoid Raft bootstrap hangs from 40ms+ delays during topology negotiation

### CPU pinning (optional)
- Off by default; enabled via `--pinning` CLI flag or `pinning=True` Python API parameter
- Assigns `smp` contiguous host CPU cores per node using `--cpuset-cpus` (podman) and `--cpuset` (Scylla)
- Generates `io_properties.yaml` with generous per-core I/O values and passes `--io-setup 0` to skip iotune
- Gracefully handles insufficient CPUs with a clear error message

### CLI integration
- `--podman-image`: create a podman-based cluster (e.g., `--podman-image scylladb/scylla:latest`)
- `--inter-rack-delay`: simulated latency in ms between racks in the same DC (default: 1ms)
- `--inter-dc-delay`: simulated latency in ms between DCs (default: 50ms)
- `--packet-loss`: simulated packet loss percentage for cross-DC traffic (default: 0%)
- `--pinning`: pin each node to dedicated CPU cores

### `ClusterFactory.load()` support
- Clusters are discriminated by `network_topology` key in `cluster.conf` (not `podman_image`)
- Full serialization/deserialization roundtrip: topology, delays, packet loss, pinning

### Bug fix (pre-existing)
- Fixed `cluster.__log_level` → `cluster._Cluster__log_level` in `ClusterFactory.load()` (Python name mangling bug)

## Files changed

### New files
| File | Description |
|------|-------------|
| `ccmlib/scylla_podman_cluster.py` | Core implementation (~2500 lines) |
| `tests/test_scylla_podman_cluster.py` | 92 unit + 9 integration tests (~2100 lines) |
| `tests/test_config.py` | `SCYLLA_PODMAN_IMAGE` config constant |
| `docs/podman-network-topology.md` | Documentation with examples, `nodetool status` output, CPU pinning section |

### Modified files (functional changes only, zero formatting changes)
| File | Change |
|------|--------|
| `ccmlib/cluster.py` | Added `is_podman()` static method (returns `False`) |
| `ccmlib/node.py` | Added `is_podman()` static method (returns `False`) |
| `ccmlib/cluster_factory.py` | Import `ScyllaPodmanCluster`/`PodmanNetworkTopology`, load logic for `network_topology` key, `__log_level` name mangling fix, `pinning` parameter |
| `ccmlib/cmds/cluster_cmds.py` | CLI options: `--podman-image`, `--inter-rack-delay`, `--inter-dc-delay`, `--packet-loss`, `--pinning`; validation; `ccm add` rejection for podman clusters |
| `pyproject.toml` | Added `network_topology` pytest marker |
| `tests/conftest.py` | Stale resource prune fixture (PID-based ownership), `podman_cluster` session fixture |

## Testing

### Unit tests (92 tests, ~0.75s)
- `PodmanNetworkTopology`: IP assignment, subnet ranges, routing, `tc` command generation, serialization roundtrip, topology validation, 2DC×3AZ layout
- `PodmanProcess`: poll behavior, caching, paused-container handling, error handling
- `FilterArgs`: argument filtering for container-incompatible flags
- `ScyllaPodmanNode`: binary interface probing, service lifecycle, `nodetool` caching, kill signal dispatch, zero-token persistence
- `ScyllaPodmanCluster`: populate with subnet collision retry, container creation flags, route failure handling, factory load roundtrip, clear preserves topology
- `CpuPinning`: assignment computation (including per-node smp), refresh before start, container args, Scylla args injection, `io_properties.yaml` generation, config persistence
- Conftest cleanup: PID-based prune logic, fixture error handling

### Integration tests (9 tests, ~5min, `scylladb/scylla:latest`)
All tests run against a 3-node cluster (dc1: rack1, rack2; dc2: rack1), with 40ms inter-DC and 1ms inter-rack delay.

| # | Test | What it verifies |
|---|------|------------------|
| 1 | `test_01_cluster_topology` | Correct DC/rack assignment for all 3 nodes |
| 2 | `test_02_all_nodes_up` | All nodes report UP/NORMAL via `nodetool status` |
| 3 | `test_03_nodetool_status` | `nodetool status` output is parseable and correct |
| 4 | `test_04_cqlsh` | CQL queries work through the client container |
| 5 | `test_05_cross_dc_query` | Cross-DC replication with `NetworkTopologyStrategy` |
| 6 | `test_06_stop_and_start_node` | Graceful stop/start via `supervisorctl` |
| 7 | `test_07_stop_ungently` | `SIGKILL` stop and recovery |
| 8 | `test_08_network_isolation` | `tc`/`netem` rules are applied and visible via `tc qdisc show` |
| 9 | `test_09_is_podman` | `is_podman()` returns `True` for podman clusters |

### Test results
```
92 passed, 9 deselected in 0.75s   (unit tests)
101 passed in 489.29s (0:08:09)    (full suite incl. integration)
0 leaked containers/networks       (verified after both success and failure)
```

## Requirements
- **Podman 4.0+** (tested on 5.8.1)
- **Linux host** with `tc` (iproute2) and `nsenter` (util-linux)
- **`scylladb/scylla:latest`** container image (or any ScyllaDB image)
- For CPU pinning: enough host CPUs (≥ sum of each node's `smp`, which defaults to 1 per node)


---

### New skill

Added `skills/podman-cluster/SKILL.md` — an opencode skill to start a multi-DC podman cluster with configurable topology, latency simulation, packet loss, CPU pinning, and concurrent node startup.

Usage:
```
/podman-cluster --topology "dc1:rack1:2;dc2:rack1:2" --inter-dc-delay 50
```

