### PR TITLE
fix(cluster_cmds): auto-detect Scylla cluster in ClusterAddCmd

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -354,7 +354,7 @@ class ClusterAddCmd(Cmd):
 
     def run(self):
         try:
-            if self.options.scylla_node:
+            if self.options.scylla_node or isinstance(self.cluster, (ScyllaCluster, ScyllaDockerCluster)):
                 if self.cluster.is_docker():
                     node_class = ScyllaDockerNode
                 else:


### PR DESCRIPTION
## Problem

When `ccm add` is called **without** the `--scylla` flag (as done by the gocql driver's `internal/ccm/ccm.go` helper), `ClusterAddCmd.run()` falls through to the `else` branch and constructs a plain `Node()` instead of `ScyllaNode()`. This causes a `FileNotFoundError` when ccmlib tries to open `cassandra.yaml`, which does not exist in a Scylla installation.

This manifests as a test infrastructure failure in the gocql driver matrix pipeline for the `scylla-2025.1` branch, where this CCM branch is used.

## Fix

Extend the existing Scylla node check with an `isinstance()` guard:

```python
# Before:
if self.options.scylla_node:

# After:
if self.options.scylla_node or isinstance(self.cluster, (ScyllaCluster, ScyllaDockerCluster)):
```

`ScyllaCluster` and `ScyllaDockerCluster` are already imported in this file. The existing code path that follows already correctly handles Docker vs non-Docker cluster detection and constructs the right node type (`ScyllaNode` / `ScyllaDockerNode`).

## Impact

- **One line changed**, no new imports, no new logic.
- Callers that already pass `--scylla` are unaffected (condition is unchanged for them).
- Callers that omit `--scylla` but operate on a Scylla cluster now get the correct node type automatically.