### PR TITLE
run_cqlsh: log stderr as warning instead of treating as error

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -973,9 +973,9 @@ class Node(object):
                         self.error(f"(EE) <stdout> {err}")
                 raise e
 
-            for err in output[1].split('\n'):
-                if err.strip():
-                    common.print_if_standalone(f"(EE) {err}", debug_callback=self.debug, end='')
+            for line in output[1].split('\n'):
+                if line.strip():
+                    common.print_if_standalone(f"(cqlsh stderr) {line}", debug_callback=self.warning, end='')
 
             if show_output:
                 common.print_if_standalone(output[0], debug_callback=self.debug, end='')


### PR DESCRIPTION
## Summary

- Change `run_cqlsh` to log stderr lines at WARNING level (always visible in test logs) instead of DEBUG level
- Rename prefix from `(EE)` to `(cqlsh stderr)` since these are not necessarily errors
- cqlsh and cqlsh-rs may emit informational warnings to stderr that do not indicate actual errors

## Motivation

cqlsh-rs emits warnings to stderr (e.g. about driver configuration, replication factor warnings). These are not errors but were previously labeled `(EE)` and logged at debug level, making them both misleading and hard to find for investigation.

With this change, stderr output is:
1. Always visible in test logs (WARNING level vs DEBUG)
2. Clearly labeled as cqlsh stderr rather than errors

## Changes

`ccmlib/node.py` line ~976:
- `(EE)` → `(cqlsh stderr)` prefix
- `self.debug` → `self.warning` callback
- `err` → `line` loop variable (clarity)

## Related

Companion dtest PR removes `assert err == ""` assertions that fail on cqlsh-rs stderr warnings.