### PR TITLE
fix(stop_scylla_manager_agent): wait for process exit before returning

### DIFF
--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -627,11 +627,13 @@ class ScyllaNode(Node):
         if gently:
             try:
                 self._process_agent.terminate()
+                self._process_agent.wait(timeout=30)
             except OSError:
                 pass
         else:
             try:
                 self._process_agent.kill()
+                self._process_agent.wait(timeout=30)
             except OSError:
                 pass
 


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/DTEST-202

`stop_scylla_manager_agent()` was sending SIGTERM without waiting for the process to exit, allowing `check_socket_listening()` in the subsequent `start_scylla_manager_agent()` to connect to the dying agent's still-open port and return success prematurely.

Add `process.wait(timeout=30)` after `terminate()`/`kill()` to ensure the old agent fully exits and frees its port before the new agent is spawned.

### Testing
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/dtest-manager-no-tablets/17/
- [x] https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/mikita/job/manager-master-clone/job/dtest-manager-with-tablets/6/