### PR TITLE
fix: CI compatibility with setup-uv v8 and nix-action v31

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,14 +52,13 @@ jobs:
     - name: Download versions
       if: steps.cache-versions.outputs.cache-hit != 'true'
       run: |
-        source ${{ env.VIRTUAL_ENV }}/bin/activate
         normalized=$(echo ${{ inputs.reloc_version }} | tr ':' '_')
         if [ ! -f ~/.ccm/scylla-repository/unstable/master/$normalized ]; then
-          ./ccm create temp -n 1 --scylla --version unstable/master:${{ inputs.reloc_version }}
-          ./ccm remove
+          uv run ./ccm create temp -n 1 --scylla --version unstable/master:${{ inputs.reloc_version }}
+          uv run ./ccm remove
         fi
-        ./ccm create temp-cas -n 1 --version 3.11.4 > /dev/null
-        ./ccm remove
+        uv run ./ccm create temp-cas -n 1 --version 3.11.4 > /dev/null
+        uv run ./ccm remove
 
     - name: Test with pytest
       run: |

--- a/tests/test_effective_workdir.py
+++ b/tests/test_effective_workdir.py
@@ -38,17 +38,23 @@ def symlink_tracker():
 
 class TestGetEffectiveWorkdir:
 
-    def test_short_path_returns_unchanged(self, tmp_path):
+    def test_short_path_returns_unchanged(self):
         """When the path is short enough, it is returned as-is."""
-        node_path = str(tmp_path / "node1")
-        os.makedirs(node_path, exist_ok=True)
-        node = _make_node(node_path)
+        # Use /tmp directly to guarantee a short base path regardless of
+        # the test runner environment (e.g. nix-shell adds long prefixes
+        # to pytest's tmp_path which can exceed UNIX_SOCKET_PATH_MAX).
+        with tempfile.TemporaryDirectory(dir='/tmp') as short_tmp:
+            node_path = os.path.join(short_tmp, "node1")
+            os.makedirs(node_path, exist_ok=True)
+            assert len(os.path.join(node_path, 'cql.m')) <= UNIX_SOCKET_PATH_MAX, \
+                f"Test setup error: path already too long ({len(os.path.join(node_path, 'cql.m'))} > {UNIX_SOCKET_PATH_MAX})"
+            node = _make_node(node_path)
 
-        result = node._get_effective_workdir()
+            result = node._get_effective_workdir()
 
-        assert result == node_path
-        symlink_path = ScyllaNode._workdir_symlink_path(node_path)
-        assert not os.path.islink(symlink_path)
+            assert result == node_path
+            symlink_path = ScyllaNode._workdir_symlink_path(node_path)
+            assert not os.path.islink(symlink_path)
 
     def test_long_path_creates_symlink(self, tmp_path, symlink_tracker):
         """When the path is too long, a symlink is created in /tmp."""
@@ -126,14 +132,15 @@ class TestGetEffectiveWorkdir:
         node._cleanup_workdir_symlink()
         assert not os.path.islink(result)
 
-    def test_cleanup_ignores_short_path(self, tmp_path):
+    def test_cleanup_ignores_short_path(self):
         """_cleanup_workdir_symlink does nothing for short paths."""
-        node_path = str(tmp_path / "node1")
-        os.makedirs(node_path, exist_ok=True)
-        node = _make_node(node_path)
+        with tempfile.TemporaryDirectory(dir='/tmp') as short_tmp:
+            node_path = os.path.join(short_tmp, "node1")
+            os.makedirs(node_path, exist_ok=True)
+            node = _make_node(node_path)
 
-        # Should not raise
-        node._cleanup_workdir_symlink()
+            # Should not raise
+            node._cleanup_workdir_symlink()
 
     def test_hash_uses_12_hex_chars(self, tmp_path):
         """Symlink name uses 12 hex chars from the MD5 hash."""

--- a/tests/test_scylla_cmds.py
+++ b/tests/test_scylla_cmds.py
@@ -28,9 +28,8 @@ cluster_params = pytest.mark.parametrize(
 )
 
 
-def copy_cluster_data(request: FixtureRequest):
-    cluster_dir = request.getfixturevalue('cluster_under_test').cluster_dir
-    test_dir = request.getfixturevalue('test_dir')
+def copy_cluster_data(request: FixtureRequest, cluster_under_test, test_dir):
+    cluster_dir = cluster_under_test.cluster_dir
     scope_id = f'-{str(datetime.now().strftime("%H%M%S%s"))}' if request.scope == 'class' else ''
     test_name = f'{request.node.name}{scope_id}'
     user = getpass.getuser()
@@ -52,13 +51,13 @@ def copy_cluster_data(request: FixtureRequest):
 class TestCCMCreateCluster:
     @staticmethod
     @pytest.fixture(scope="function", autouse=True)
-    def base_setup(request, cluster_under_test):
+    def base_setup(request, cluster_under_test, test_dir):
         try:
             yield
         finally:
             cluster_under_test.run_command(cluster_under_test.get_stop_cmd())
             cluster_under_test.process.wait()
-            copy_cluster_data(request=request)
+            copy_cluster_data(request, cluster_under_test, test_dir)
             cluster_under_test.run_command(cluster_under_test.get_remove_cmd())
             cluster_under_test.process.wait()
             if os.path.exists(cluster_under_test.cluster_dir):
@@ -85,7 +84,7 @@ class TestCCMClusterStatus:
 
     @staticmethod
     @pytest.fixture(scope="class", autouse=True)
-    def base_setup(request, cluster_under_test):
+    def base_setup(request, cluster_under_test, test_dir):
         try:
             cluster_under_test.run_command(cluster_under_test.get_create_cmd(args=['-n', '1']))
             cluster_under_test.validate_command_result()
@@ -93,7 +92,7 @@ class TestCCMClusterStatus:
         finally:
             cluster_under_test.run_command(cluster_under_test.get_stop_cmd())
             cluster_under_test.process.wait()
-            copy_cluster_data(request)
+            copy_cluster_data(request, cluster_under_test, test_dir)
             cluster_under_test.run_command(cluster_under_test.get_remove_cmd())
             cluster_under_test.process.wait()
             if os.path.exists(cluster_under_test.cluster_dir):
@@ -115,13 +114,13 @@ class TestCCMClusterStart:
 
     @staticmethod
     @pytest.fixture(autouse=True)
-    def base_setup(request, cluster_under_test):
+    def base_setup(request, cluster_under_test, test_dir):
         try:
             yield
         finally:
             cluster_under_test.run_command(cluster_under_test.get_stop_cmd())
             cluster_under_test.process.wait()
-            copy_cluster_data(request)
+            copy_cluster_data(request, cluster_under_test, test_dir)
             cluster_under_test.run_command(cluster_under_test.get_remove_cmd())
             cluster_under_test.process.wait()
             if os.path.exists(cluster_under_test.cluster_dir):
@@ -156,7 +155,7 @@ class TestCCMClusterNodetool:
 
     @staticmethod
     @pytest.fixture(scope="class", autouse=True)
-    def base_setup_with_2_nodes(request, cluster_under_test):
+    def base_setup_with_2_nodes(request, cluster_under_test, test_dir):
         try:
             cluster_under_test.run_command(cluster_under_test.get_create_cmd(args=['-n', '2']))
             cluster_under_test.validate_command_result()
@@ -170,7 +169,7 @@ class TestCCMClusterNodetool:
         finally:
             cluster_under_test.run_command(cluster_under_test.get_stop_cmd())
             cluster_under_test.process.wait()
-            copy_cluster_data(request)
+            copy_cluster_data(request, cluster_under_test, test_dir)
             cluster_under_test.run_command(cluster_under_test.get_remove_cmd())
             cluster_under_test.process.wait()
             if os.path.exists(cluster_under_test.cluster_dir):
@@ -213,7 +212,7 @@ class TestCCMClusterNodetool:
 class TestCCMClusterManagerSctool:
     @staticmethod
     @pytest.fixture(scope="class", autouse=True)
-    def base_setup(request, cluster_under_test):
+    def base_setup(request, cluster_under_test, test_dir):
         try:
             cluster_under_test.run_command(cluster_under_test.get_create_cmd(args=['-n', '3',
                 '--scylla-manager-package',
@@ -229,7 +228,7 @@ class TestCCMClusterManagerSctool:
         finally:
             cluster_under_test.run_command(cluster_under_test.get_stop_cmd())
             cluster_under_test.process.wait()
-            copy_cluster_data(request)
+            copy_cluster_data(request, cluster_under_test, test_dir)
             cluster_under_test.run_command(cluster_under_test.get_remove_cmd())
             cluster_under_test.process.wait()
             if os.path.exists(cluster_under_test.cluster_dir):


### PR DESCRIPTION
## Problem

PR #737 pins GitHub Actions to commit SHAs but also bumps major versions (`setup-uv` v5→v8, `install-nix-action` v20→v31) which introduces two CI failures:

### 1. Integration tests: `/bin/activate: No such file or directory`

`setup-uv` v8 no longer exports the `VIRTUAL_ENV` environment variable to GitHub Actions env. The workflow step `source ${{ env.VIRTUAL_ENV }}/bin/activate` evaluates to `source /bin/activate` and crashes.

### 2. Nix tests: `test_short_path_returns_unchanged` assertion failure

`install-nix-action` v31 creates a longer temp directory path (`nix-shell.midvsd/...`) causing pytest's `tmp_path` + `node1/cql.m` to exceed `UNIX_SOCKET_PATH_MAX` (107 chars on Linux), triggering the symlink shortening logic when the test expects the path to remain unchanged.

## Fix

- **integration-tests.yml**: Remove `source $VIRTUAL_ENV/bin/activate` and use `uv run ./ccm` prefix instead (consistent with the pytest step which already uses `uv run`).
- **test_effective_workdir.py**: Tests requiring short paths now use `tempfile.TemporaryDirectory(dir='/tmp')` directly instead of relying on pytest's `tmp_path` fixture, which can have arbitrarily long prefixes depending on the test runner environment.

## Validation

- All 8 tests in `test_effective_workdir.py` pass locally
- YAML syntax validated
- Python syntax validated

Ref: #737