### PR TITLE
cluster_factory: fix __log_level name mangling in ClusterFactory.load()

### DIFF
--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -49,7 +49,7 @@ class ClusterFactory():
             if 'config_options' in data:
                 cluster._config_options = data['config_options']
             if 'log_level' in data:
-                cluster.__log_level = data['log_level']
+                cluster._Cluster__log_level = data['log_level']
             if 'use_vnodes' in data:
                 cluster.use_vnodes = data['use_vnodes']
             if 'ipprefix' in data:


### PR DESCRIPTION
cluster.__log_level silently creates a new attribute on the cluster instance instead of setting the private Cluster.__log_level field, because Python's name mangling rewrites double-underscore attributes using the *defining* class name. Use cluster._Cluster__log_level to correctly restore the log level when loading a cluster from disk.