### PR TITLE
test: align SNAPSHOT assertion with new manager package naming

### DIFF
--- a/tests/test_scylla_repository.py
+++ b/tests/test_scylla_repository.py
@@ -400,9 +400,9 @@ class TestGetManagerFunctions:
         master_version = get_manager_latest_reloc_url(architecture=architecture)
         # the URL looks like
         # https://s3.amazonaws.com/downloads.scylladb.com/manager/
-        #   relocatable/unstable/master/2023-11-20T21:55:21Z/scylla-manager_3.2.3-0.20231115.6f5dc312-SNAPSHOT_linux_x86_64.tar.gz
+        #   relocatable/unstable/master/2026-06-28T21:54:42Z/scylla-manager_3.12.0-dev.0.20260628.d78e5dcc9.SNAPSHOT_linux_x86_64.tar.gz
         assert 'relocatable/unstable/master' in master_version
-        assert '-SNAPSHOT' in master_version
+        assert 'SNAPSHOT' in master_version
         assert architecture in master_version
 
         branch_version = get_manager_latest_reloc_url('branch-3.1', architecture=architecture)


### PR DESCRIPTION
## Problem

CI failure in `test_get_manager_latest_reloc_url[x86_64]`:

```
AssertionError: assert '-SNAPSHOT' in 'https://s3.amazonaws.com/downloads.scylladb.com/manager/relocatable/unstable/master/2026-06-28T21:54:42Z/scylla-manager_3.12.0-dev.0.20260628.d78e5dcc9.SNAPSHOT_linux_x86_64.tar.gz'
```

The manager package naming changed from `-SNAPSHOT` (hyphen separator) to `.SNAPSHOT` (dot separator).

## Fix

Relax the assertion to check for `'SNAPSHOT'` without assuming the preceding separator character. Updated the example URL in the comment to reflect the current format.

Ref: https://github.com/scylladb/scylla-ccm/actions/runs/28375734771/job/84064746651?pr=744