### PR TITLE
ssl_utils: generate trust.pem, required by enable_internode_ssl

### DIFF
--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -265,6 +265,11 @@ class ScyllaCluster(Cluster):
         self._update_config()
 
     def enable_internode_ssl(self, node_ssl_path, internode_encryption='all'):
+        # Validate required SSL files exist before copying
+        for required_file in ['trust.pem', 'ccm_node.pem', 'ccm_node.key']:
+            file_path = os.path.join(node_ssl_path, required_file)
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"Required SSL file not found: {file_path}")
         shutil.copyfile(os.path.join(node_ssl_path, 'trust.pem'), os.path.join(self.get_path(), 'internode-trust.pem'))
         shutil.copyfile(os.path.join(node_ssl_path, 'ccm_node.pem'), os.path.join(self.get_path(), 'internode-ccm_node.pem'))
         shutil.copyfile(os.path.join(node_ssl_path, 'ccm_node.key'), os.path.join(self.get_path(), 'internode-ccm_node.key'))

--- a/ccmlib/utils/ssl_utils.py
+++ b/ccmlib/utils/ssl_utils.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import logging
 
@@ -62,6 +63,9 @@ def generate_ssl_stores(base_dir, passphrase='cassandra', dns_names=None):
     subprocess.check_call(['openssl', 'rsa', '-in', os.path.join(base_dir, 'ccm_node.tmp'),
                            '-passin', f'pass:{passphrase}',
                            '-out', os.path.join(base_dir, 'ccm_node.key')])
+    # enable_internode_ssl() (scylla_cluster.py) expects a 'trust.pem' trust
+    # anchor; ccm_node.pem (cert only, no key) is exactly that.
+    shutil.copyfile(os.path.join(base_dir, 'ccm_node.pem'), os.path.join(base_dir, 'trust.pem'))
 
 
 if __name__ == "__main__":

--- a/tests/test_scylla_cluster_ssl.py
+++ b/tests/test_scylla_cluster_ssl.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+
+import pytest
+
+from ccmlib.scylla_cluster import ScyllaCluster
+from ccmlib.utils.ssl_utils import generate_ssl_stores
+
+
+def _bare_scylla_cluster(cluster_dir):
+    """A ScyllaCluster instance with just enough state for enable_internode_ssl()."""
+    with patch.object(ScyllaCluster, '__init__', lambda self, *a, **kw: None):
+        cluster = ScyllaCluster(None)
+    cluster._config_options = {}
+    cluster._update_config = lambda *a, **kw: None
+    cluster.get_path = lambda: str(cluster_dir)
+    return cluster
+
+
+def test_enable_internode_ssl_succeeds_with_generated_stores(tmp_path):
+    ssl_dir = tmp_path / "ssl"
+    ssl_dir.mkdir()
+    generate_ssl_stores(str(ssl_dir))
+
+    cluster_dir = tmp_path / "cluster"
+    cluster_dir.mkdir()
+    cluster = _bare_scylla_cluster(cluster_dir)
+
+    cluster.enable_internode_ssl(str(ssl_dir))
+
+    assert (cluster_dir / "internode-trust.pem").exists()
+    assert (cluster_dir / "internode-ccm_node.pem").exists()
+    assert (cluster_dir / "internode-ccm_node.key").exists()
+    ssl_options = cluster._config_options["server_encryption_options"]
+    assert ssl_options["internode_encryption"] == "all"
+
+
+def test_enable_internode_ssl_raises_clear_error_when_trust_pem_missing(tmp_path):
+    ssl_dir = tmp_path / "ssl"
+    ssl_dir.mkdir()
+    (ssl_dir / "ccm_node.pem").write_text("cert")
+    (ssl_dir / "ccm_node.key").write_text("key")
+
+    cluster_dir = tmp_path / "cluster"
+    cluster_dir.mkdir()
+    cluster = _bare_scylla_cluster(cluster_dir)
+
+    with pytest.raises(FileNotFoundError, match="trust.pem"):
+        cluster.enable_internode_ssl(str(ssl_dir))

--- a/tests/test_ssl_utils.py
+++ b/tests/test_ssl_utils.py
@@ -1,0 +1,23 @@
+import filecmp
+import os
+
+from ccmlib.utils.ssl_utils import generate_ssl_stores
+
+
+def test_generate_ssl_stores_creates_trust_pem(tmp_path):
+    """enable_internode_ssl() (scylla_cluster.py) requires a 'trust.pem' file;
+    generate_ssl_stores() must produce one alongside the other cert/key files."""
+    generate_ssl_stores(str(tmp_path))
+
+    trust_pem = tmp_path / "trust.pem"
+    ccm_node_pem = tmp_path / "ccm_node.pem"
+    assert trust_pem.exists()
+    assert ccm_node_pem.exists()
+    assert filecmp.cmp(trust_pem, ccm_node_pem, shallow=False)
+
+
+def test_generate_ssl_stores_is_noop_when_keystore_exists(tmp_path):
+    (tmp_path / "keystore.jks").write_bytes(b"existing")
+    generate_ssl_stores(str(tmp_path))
+
+    assert not os.path.exists(tmp_path / "trust.pem")


### PR DESCRIPTION
## Motivation

`ScyllaCluster.enable_internode_ssl()` unconditionally copies a `trust.pem`
file from the given SSL store directory, but `generate_ssl_stores()` never
produces one — it only writes `ccm_node.cer/.pem/.key/.p12`. As a result,
enabling internode encryption on any freshly generated SSL store fails
immediately with `FileNotFoundError`, regardless of cluster backend
(native, Docker, or Podman).

## Change

- `generate_ssl_stores()` now also writes `trust.pem`, a copy of
  `ccm_node.pem` (the cert-only PEM export with no private key — exactly
  what a trust anchor should contain).
- `enable_internode_ssl()` validates that its required files exist up
  front and raises a clear `FileNotFoundError` naming the missing file,
  mirroring the check that already exists in the sibling `enable_ssl()`
  method, instead of failing deeper in `shutil.copyfile` with a bare
  traceback.

## Test

- New `tests/test_ssl_utils.py`: `generate_ssl_stores()` produces a
  `trust.pem` identical to `ccm_node.pem`; the no-op path (pre-existing
  keystore) correctly leaves it absent.
- New `tests/test_scylla_cluster_ssl.py`: `enable_internode_ssl()`
  succeeds end-to-end against real generated stores, and raises a clear
  `FileNotFoundError` mentioning `trust.pem` when it's missing.
- Live verification: brought up a real 45-node Podman cluster (3 DCs x 3
  racks x 5 nodes) with client + internode TLS enabled end-to-end using
  this fix — all 45 nodes reached UP in 115s.