### PR TITLE
cluster: make remove_dir_with_retry() actually retry

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -440,7 +440,7 @@ class Cluster(object):
         if os.path.exists(path):
             while not removed:
                 try:
-                    common.rmdirs(path)
+                    common.rmdirs(path, ignore_errors=False)
                     removed = True
                 except Exception:
                     tries = tries + 1

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -330,12 +330,12 @@ def replaces_or_add_into_file_tail(file, replacement_list):
     shutil.move(file_tmp, file)
 
 
-def rmdirs(path):
+def rmdirs(path, ignore_errors=True):
     if is_win():
         # Handle Windows 255 char limit
-        shutil.rmtree("\\\\?\\" + path, ignore_errors=True)
+        shutil.rmtree("\\\\?\\" + path, ignore_errors=ignore_errors)
     else:
-        shutil.rmtree(path, ignore_errors=True)
+        shutil.rmtree(path, ignore_errors=ignore_errors)
 
 
 def make_cassandra_env(install_dir, node_path, update_conf=True, hardcode_java_version: Optional[str] = None):

--- a/tests/test_remove_dir_with_retry.py
+++ b/tests/test_remove_dir_with_retry.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+import pytest
+
+from ccmlib import cluster as cluster_module
+from ccmlib.cluster import Cluster
+
+
+def _bare_cluster():
+    with patch.object(Cluster, '__init__', lambda self, *a, **kw: None):
+        return Cluster(None)
+
+
+def test_remove_dir_with_retry_removes_existing_dir(tmp_path):
+    target = tmp_path / "somedir"
+    target.mkdir()
+    (target / "file.txt").write_text("data")
+
+    _bare_cluster().remove_dir_with_retry(str(target))
+
+    assert not target.exists()
+
+
+def test_remove_dir_with_retry_raises_instead_of_silently_leaking(tmp_path, monkeypatch):
+    """common.rmdirs() used to default to ignore_errors=True, so a persistent
+    removal failure (e.g. rootless-podman subuid-owned files) was silently
+    swallowed and remove_dir_with_retry() reported success without actually
+    removing anything. It must now retry and finally raise."""
+    target = tmp_path / "somedir"
+    target.mkdir()
+
+    calls = []
+
+    def fake_rmdirs(path, ignore_errors=True):
+        calls.append(ignore_errors)
+        raise PermissionError(f"denied: {path}")
+
+    monkeypatch.setattr(cluster_module.common, "rmdirs", fake_rmdirs)
+    monkeypatch.setattr(cluster_module.time, "sleep", lambda _s: None)
+
+    with pytest.raises(PermissionError):
+        _bare_cluster().remove_dir_with_retry(str(target))
+
+    assert calls == [False] * 5


### PR DESCRIPTION
## Motivation

`Cluster.remove_dir_with_retry()` is designed to retry directory removal
up to 5 times and then raise (see CASSANDRA-10075), but
`common.rmdirs()` always calls `shutil.rmtree(path, ignore_errors=True)`.
That means the very first attempt "succeeds" regardless of whether
anything was actually removed, so the retry loop never engages and
failures are silently swallowed. In practice this lets a cluster
teardown leak disk: e.g. a rootless-Podman bind-mounted directory whose
files are owned by a mapped subuid, or a chmod-before-rmtree step that
itself failed, is left behind while `cluster.remove()` reports teardown
as complete.

## Change

- `common.rmdirs()` gains an `ignore_errors` parameter, defaulting to
  `True` so its ~20 other call sites are unaffected.
- `Cluster.remove_dir_with_retry()` now calls
  `rmdirs(path, ignore_errors=False)`, so its existing retry-then-raise
  loop sees real exceptions, retries, and raises after 5 attempts
  instead of silently no-op'ing.

## Test

- New `tests/test_remove_dir_with_retry.py`: normal removal still
  succeeds; a persistently-failing `rmdirs` is retried exactly 5 times
  and then re-raised, instead of being silently swallowed.
- Confirmed no regressions: `tests/test_common.py` and
  `tests/test_cluster_cleanup.py` pass unchanged.