### PR TITLE
utils/download: raise a clear error instead of crashing on missing ETag

### DIFF
--- a/ccmlib/utils/download.py
+++ b/ccmlib/utils/download.py
@@ -189,10 +189,19 @@ def get_url_hash(url: str) -> str:
 
     try:
         metadata = s3_client.head_object(Bucket=bucket_name, Key=download_path)
-        return metadata.get('ETag')[1:-1]
-    except botocore.client.ClientError:
+        etag = metadata.get('ETag')
+        if not etag:
+            raise RuntimeError(f"S3 HeadObject for {url} returned no ETag; cannot compute hash")
+        return etag[1:-1]
+    except botocore.client.ClientError as e:
         # fallback to http
-        return requests.head(url).headers.get('ETag')[1:-1]
+        etag = requests.head(url).headers.get('ETag')
+        if not etag:
+            raise RuntimeError(
+                f"Could not get a hash for {url}: S3 HeadObject failed ({e}) "
+                "and the HTTP fallback returned no ETag header"
+            ) from e
+        return etag[1:-1]
 
 
 def save_source_file(source_file: str, version: str, url: str, url_hash: str):

--- a/tests/test_caching_hash.py
+++ b/tests/test_caching_hash.py
@@ -126,8 +126,41 @@ class TestGetUrlHash:
         
         url = "https://example.com/path/to/package.tar.gz"
         url_hash = get_url_hash(url)
-        
+
         assert url_hash == "http_etag_value"
+
+    @patch('ccmlib.utils.download.requests')
+    @patch('ccmlib.utils.download.Session')
+    def test_get_url_hash_raises_clear_error_when_http_fallback_has_no_etag(self, mock_session, mock_requests):
+        """S3 failing (e.g. 403) and the HTTP fallback having no ETag header used to
+        crash with a confusing 'NoneType' object is not subscriptable' TypeError.
+        It should raise a clear error mentioning both failures instead."""
+        mock_s3_client = MagicMock()
+        mock_s3_client.head_object.side_effect = botocore.client.ClientError(
+            {'Error': {'Code': '403', 'Message': 'Forbidden'}},
+            'head_object'
+        )
+        mock_session.return_value.client.return_value = mock_s3_client
+
+        mock_response = MagicMock()
+        mock_response.headers.get.return_value = None
+        mock_requests.head.return_value = mock_response
+
+        url = "https://example.com/path/to/package.tar.gz"
+        with pytest.raises(RuntimeError, match="Forbidden.*no ETag"):
+            get_url_hash(url)
+
+    @patch('ccmlib.utils.download.Session')
+    def test_get_url_hash_raises_clear_error_when_s3_has_no_etag(self, mock_session):
+        """S3 succeeding but returning no ETag used to crash with an uncaught
+        TypeError instead of a clear error."""
+        mock_s3_client = MagicMock()
+        mock_s3_client.head_object.return_value = {}
+        mock_session.return_value.client.return_value = mock_s3_client
+
+        url = "http://s3.amazonaws.com/bucket/path/to/package.tar.gz"
+        with pytest.raises(RuntimeError, match="no ETag"):
+            get_url_hash(url)
 
 
 class TestSourceFileOperations:


### PR DESCRIPTION
## Motivation

`get_url_hash()` tries an S3 `HeadObject` first and falls back to a plain
HTTP `HEAD` request if that fails. Both paths did `.get('ETag')[1:-1]`
unconditionally, so a response with no `ETag` header crashed with a
confusing `TypeError: 'NoneType' object is not subscriptable` instead of
surfacing what actually went wrong. In practice this hid the real cause:
an S3 403 (access denied) is swallowed by the bare
`except botocore.client.ClientError`, execution falls through to the HTTP
fallback, that also has no `ETag`, and the resulting `TypeError` gives no
indication that the original problem was an S3 permissions/access issue.
This was found while investigating CI failures on two unrelated PRs
(#772, #773) that were both blocked by this exact crash pattern.

## Change

- Both the S3 and HTTP-fallback paths now check for a missing `ETag`
  and raise a clear `RuntimeError` naming the URL, instead of crashing
  with an unrelated `TypeError`.
- When the HTTP fallback also fails, the error chains in the original
  S3 exception (`raise ... from e`), so the real root cause (e.g. a 403)
  is visible instead of being silently discarded.

## Test

- New tests in `tests/test_caching_hash.py`:
  - `test_get_url_hash_raises_clear_error_when_http_fallback_has_no_etag`:
    S3 fails (403) and the HTTP fallback has no `ETag` → clear
    `RuntimeError` mentioning both the S3 failure and the missing ETag.
  - `test_get_url_hash_raises_clear_error_when_s3_has_no_etag`: S3
    succeeds but returns no `ETag` → clear `RuntimeError` instead of an
    uncaught `TypeError`.
- All existing tests in `tests/test_caching_hash.py` still pass (25
  passed, 3 skipped).
- Confirmed no regressions: the same 7 pre-existing, network-dependent
  failures in `tests/test_scylla_repository.py` (real S3 calls hitting
  live data, unrelated to this change) occur identically on unmodified
  `origin/master`.