### PR TITLE
PM-342: point call_jira_sync.yml at github-automation main

### DIFF
--- a/.github/workflows/call_jira_sync.yml
+++ b/.github/workflows/call_jira_sync.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   jira-sync:
-    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@09fedfc0b53451f79337bb85f952c422f33ce1df # main
+    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@main
     with:
       caller_action: ${{ github.event.action }}
     secrets:


### PR DESCRIPTION
`.github/workflows/call_jira_sync.yml` pinned the reusable Jira-sync workflow to commit `09fedfc`, so fixes merged to `scylladb/github-automation` main never reached this repository.

This points it at `@main` instead:

```diff
-    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@09fedfc0b53451f79337bb85f952c422f33ce1df # main
+    uses: scylladb/github-automation/.github/workflows/main_pr_events_jira_sync.yml@main
```

Only that one line changes — the `on:` triggers, `permissions:`, the `caller_action` input and the `caller_jira_auth` secret are all untouched, so no repository configuration is needed.

Fixes: PM-342

Part of PM-336.