### PR TITLE
scylla: add integrated monitoring stack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Requirements
 - **Java 8+** - only required for:
   - Using Cassandra clusters
   - Using older Scylla versions (< 6.0)
-- **Docker** (optional) - for Docker-based clusters
+- **Docker** (optional) - for Docker-based clusters and [integrated monitoring](docs/monitoring.md)
 - **Multiple loopback interfaces** - CCM runs nodes on 127.0.0.X addresses
   - On Linux: Usually available by default
   - On Mac OS X: Create aliases manually:
@@ -193,8 +193,18 @@ Requirements
     ```
 
 By default ccm will look for Java in `/usr/lib/jvm` directory. If you have a custom Java installation directory,
-you can provide `CUSTOM_JAVA_HOME` env variable. When this environment, ccm will assume Java binary is available
-under `$CUSTOM_JAVA_HOME/bin/java` path.  
+you can provide `CUSTOM_JAVA_HOME` env variable. When this environment variable is set, ccm will assume Java binary is available
+under `$CUSTOM_JAVA_HOME/bin/java` path.
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `CCM_MONITORING` | When non-empty and not `0`, enable automatic monitoring for all newly created clusters (same as `--monitoring`). |
+| `SCYLLA_MONITORING_DIR` | Path to the [scylla-monitoring](https://github.com/scylladb/scylla-monitoring) checkout. Used as default for `--monitoring-dir`. |
+| `CUSTOM_JAVA_HOME` | Custom Java installation directory. |
+| `SCYLLA_EXT_OPTS` | Extra Scylla command-line options passed to every node. |
+| `SCYLLA_EXT_ENV` | Extra environment variables for Scylla processes. |
 
 Known Issues
 ------------
@@ -288,6 +298,7 @@ ccm start                       # Start all nodes
 ccm stop                        # Stop all nodes
 ccm remove                      # Remove current cluster
 ccm clear                       # Clear cluster data but keep config
+ccm monitoring <subcmd>         # Manage monitoring stack (start/stop/enable/disable/sync/status)
 ```
 
 ### Node Management
@@ -308,6 +319,42 @@ ccm add node4 -i 127.0.0.4      # Add a new node to cluster
 ```
 
 For complete command reference, run `ccm --help` or `ccm <command> --help`.
+
+Integrated Monitoring
+---------------------
+
+CCM can start and maintain a [scylla-monitoring](https://github.com/scylladb/scylla-monitoring) stack
+(Prometheus + Grafana) alongside your cluster. See [docs/monitoring.md](docs/monitoring.md) for full details.
+
+### Quick start — automatic mode
+```bash
+# Create a cluster with monitoring enabled
+ccm create mycluster --scylla -n 3 -v release:2024.2 --monitoring --monitoring-dir=/path/to/scylla-monitoring -s
+
+# Monitoring is now running and auto-updates on topology changes
+ccm monitoring status
+# Grafana:    http://localhost:3000
+# Prometheus: http://localhost:9090
+
+ccm add node4 --scylla   # targets updated automatically
+ccm stop                  # monitoring stops automatically
+```
+
+### Quick start — environment variable
+```bash
+# Enable monitoring for all new clusters without passing --monitoring every time
+export CCM_MONITORING=1
+ccm create mycluster --scylla -n 3 -v release:2024.2 -s
+```
+
+### Quick start — manual mode
+```bash
+ccm create mycluster --scylla -n 3 -v release:2024.2 -s
+ccm monitoring start --monitoring-dir=/path/to/scylla-monitoring
+ccm add node4 --scylla
+ccm monitoring sync      # manually refresh targets
+ccm monitoring stop
+```
 
 Working with Cassandra
 ----------------------

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -41,6 +41,19 @@ class Cluster(object):
         self._debug = []
         self._trace = []
 
+        # Monitoring stack integration (Scylla-only).
+        # These fields are initialized here so they're always present on any
+        # Cluster instance (simplifies config persistence and CLI).  Actual
+        # monitoring auto-start only happens in ScyllaCluster.
+        # CCM_MONITORING env var is only checked at cluster creation time
+        # in ClusterCreateCmd.run(), not here.
+        self.monitoring_enabled = False
+        self.monitoring_stack = None  # runtime only, not persisted
+        self.monitoring_dir = None
+        self.grafana_port = 3000
+        self.prometheus_port = 9090
+        self.alertmanager_port = 9093
+
         if self.name.lower() == "current":
             raise RuntimeError("Cannot name a cluster 'current'.")
 
@@ -226,6 +239,31 @@ class Cluster(object):
     def cassandra_version(self):
         return self.version()
 
+    def _reconnect_monitoring_stack(self):
+        """Reconnect to a monitoring stack from a previous process.
+
+        Base implementation is a no-op.  ScyllaCluster overrides this to
+        probe Docker containers and re-attach monitoring_stack.
+        """
+
+    def _notify_topology_change(self):
+        """Called after any operation that changes which nodes are UP.
+
+        Only updates targets if automatic monitoring is enabled AND running.
+        Each ccm CLI invocation is a separate process, so monitoring_stack
+        starts as None after loading from disk.  We must reconnect before
+        checking whether targets need updating.
+        """
+        if not self.monitoring_enabled:
+            return
+        if not self.monitoring_stack:
+            self._reconnect_monitoring_stack()
+        if self.monitoring_stack and self.monitoring_stack.is_running():
+            try:
+                self.monitoring_stack.update_targets()
+            except Exception as e:
+                self.warning(f"Failed to update monitoring targets: {e}")
+
     def add(self, node: ScyllaNode, is_seed, data_center=None, rack=None):
         if node.name in self.nodes:
             raise common.ArgumentError(f'Cannot create existing node {node.name}')
@@ -233,7 +271,7 @@ class Cluster(object):
         if is_seed:
             self.seeds.append(node)
         self._update_config()
-        
+
         # If data_center is not specified, infer it from existing nodes
         if data_center is None and len(self.nodes) > 1:
             # Get datacenter from the first existing node (excluding the one we just added)
@@ -243,7 +281,7 @@ class Cluster(object):
                     if rack is None and existing_node.rack is not None:
                         rack = existing_node.rack
                     break
-        
+
         node.data_center = data_center
         node.rack = rack
         node.set_log_level(self.__log_level)
@@ -257,6 +295,7 @@ class Cluster(object):
             self.debug(f"{node.name}: data_center={node.data_center} rack={node.rack} snitch={self.snitch}")
             self.__update_topology_files()
         node._save()
+        self._notify_topology_change()
         return self
 
     # nodes can be provided in multiple notations, determining the cluster topology:
@@ -410,7 +449,7 @@ class Cluster(object):
         tokens.extend(new_tokens)
         return tokens
 
-    def remove(self, node: ScyllaNode=None, wait_other_notice=False, other_nodes=None, remove_node_dir=True):
+    def remove(self, node: ScyllaNode=None, wait_other_notice=False, other_nodes=None, remove_node_dir=True, keep_monitoring=False):
         if node is not None:
             if node.name not in self.nodes:
                 return
@@ -420,13 +459,15 @@ class Cluster(object):
                 self.seeds.remove(node)
             self._update_config()
             node.stop(gently=False, wait_other_notice=wait_other_notice, other_nodes=other_nodes)
-            if hasattr(node, '_cleanup_workdir_symlink'):
-                node._cleanup_workdir_symlink()
+            self._notify_topology_change()
+        if hasattr(node, '_cleanup_workdir_symlink'):
+            node._cleanup_workdir_symlink()
         else:
             for n in list(self.nodes.values()):
                 if hasattr(n, '_cleanup_workdir_symlink'):
                     n._cleanup_workdir_symlink()
-            self.stop(gently=False, wait_other_notice=wait_other_notice, other_nodes=other_nodes)
+            self.stop(gently=False, wait_other_notice=wait_other_notice, other_nodes=other_nodes,
+                      keep_monitoring=keep_monitoring)
 
         if remove_node_dir:
             node_path = node.get_path() if node is not None else self.get_path()
@@ -544,7 +585,7 @@ class Cluster(object):
 
         return started
 
-    def stop(self, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=127):
+    def stop(self, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=127, keep_monitoring=False):
         not_running = []
         for node in list(self.nodes.values()):
             if not node.stop(wait, gently=gently, wait_other_notice=wait_other_notice, other_nodes=other_nodes, wait_seconds=wait_seconds):
@@ -705,7 +746,12 @@ class Cluster(object):
                 'log_level': self.__log_level,
                 'use_vnodes': self.use_vnodes,
                 'id': self.id,
-                'ipprefix': self.ipprefix
+                'ipprefix': self.ipprefix,
+                'monitoring_enabled': self.monitoring_enabled,
+                'monitoring_dir': self.monitoring_dir,
+                'grafana_port': self.grafana_port,
+                'prometheus_port': self.prometheus_port,
+                'alertmanager_port': self.alertmanager_port,
             }
 
         with open(filename, 'w') as f:

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -55,6 +55,17 @@ class ClusterFactory():
             if 'ipprefix' in data:
                 cluster.ipprefix = data['ipprefix']
 
+            # Restore monitoring settings
+            if 'monitoring_enabled' in data:
+                cluster.monitoring_enabled = data['monitoring_enabled']
+            if 'monitoring_dir' in data:
+                cluster.monitoring_dir = data['monitoring_dir']
+            if 'grafana_port' in data:
+                cluster.grafana_port = data['grafana_port']
+            if 'prometheus_port' in data:
+                cluster.prometheus_port = data['prometheus_port']
+            if 'alertmanager_port' in data:
+                cluster.alertmanager_port = data['alertmanager_port']
 
         except KeyError as k:
             raise common.LoadError("Error Loading " + filename + ", missing property:" + str(k))

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -10,6 +10,7 @@ from ccmlib.common import ArgumentError
 from ccmlib.dse_cluster import DseCluster
 from ccmlib.scylla_cluster import ScyllaCluster
 from ccmlib.scylla_docker_cluster import ScyllaDockerCluster, ScyllaDockerNode
+from ccmlib.scylla_monitoring import MonitoringStack
 from ccmlib.scylla_node import ScyllaNode
 from ccmlib.dse_node import DseNode
 from ccmlib.node import Node, NodeError
@@ -46,7 +47,8 @@ def cluster_cmds():
         "checklogerror",
         "showlastlog",
         "jconsole",
-        "sctool"
+        "sctool",
+        "monitoring"
     ]
 
 
@@ -140,6 +142,18 @@ class ClusterCreateCmd(Cmd):
 
         parser.add_option('--scylla-unified-package-uri', type="string", dest="scylla_unified_package_uri",
                           help="The path scylla relocatable unified package", default=None)
+
+        parser.add_option('--monitoring', action="store_true", dest="monitoring",
+                          help="Enable automatic monitoring (scylla-monitoring stack) for this cluster", default=False)
+        parser.add_option('--monitoring-dir', type="string", dest="monitoring_dir",
+                          help="Path to scylla-monitoring checkout (default: SCYLLA_MONITORING_DIR env var)", default=None)
+        parser.add_option('--grafana-port', type="int", dest="grafana_port",
+                          help="Grafana port for monitoring [default: %default]", default=3000)
+        parser.add_option('--prometheus-port', type="int", dest="prometheus_port",
+                          help="Prometheus port for monitoring [default: %default]", default=9090)
+        parser.add_option('--alertmanager-port', type="int", dest="alertmanager_port",
+                          help="Alertmanager port for monitoring [default: %default]", default=9093)
+
 
         parser.epilog = """
         
@@ -246,6 +260,36 @@ class ClusterCreateCmd(Cmd):
             import traceback
             print(f'Cannot create cluster: {str(e)}\n{traceback.format_exc()}', file=sys.stderr)
             sys.exit(1)
+
+        # CCM_MONITORING env var acts as a default for --monitoring at cluster creation time.
+        # Once persisted to cluster.conf, the env var is no longer consulted.
+        if not self.options.monitoring:
+            ccm_monitoring = os.environ.get('CCM_MONITORING', '')
+            if ccm_monitoring and ccm_monitoring != '0':
+                self.options.monitoring = True
+
+        if self.options.monitoring:
+            if not isinstance(cluster, ScyllaCluster):
+                print("Warning: --monitoring is only supported for Scylla clusters, ignoring.", file=sys.stderr)
+            else:
+                cluster.monitoring_enabled = True
+                cluster.monitoring_dir = self.options.monitoring_dir
+                # Auto-assign ports from cluster ID if user didn't specify custom ports
+                grafana_port = self.options.grafana_port
+                prometheus_port = self.options.prometheus_port
+                alertmanager_port = self.options.alertmanager_port
+                if self.options.id and self.options.id != 0:
+                    defaults = MonitoringStack.default_ports(self.options.id)
+                    if grafana_port == 3000:
+                        grafana_port = defaults['grafana_port']
+                    if prometheus_port == 9090:
+                        prometheus_port = defaults['prometheus_port']
+                    if alertmanager_port == 9093:
+                        alertmanager_port = defaults['alertmanager_port']
+                cluster.grafana_port = grafana_port
+                cluster.prometheus_port = prometheus_port
+                cluster.alertmanager_port = alertmanager_port
+                cluster._update_config()
 
         if self.options.partitioner:
             cluster.set_partitioner(self.options.partitioner)
@@ -505,6 +549,9 @@ class ClusterRemoveCmd(Cmd):
     def get_parser(self):
         usage = "usage: ccm remove [options] [cluster_name]"
         parser = self._get_default_parser(usage, self.description())
+        parser.add_option('--keep-monitoring', action="store_true", dest="keep_monitoring",
+                          help="Keep the monitoring stack (Prometheus, Grafana, Alertmanager) running after removing the cluster",
+                          default=False)
         return parser
 
     def validate(self, parser, options, args):
@@ -527,13 +574,13 @@ class ClusterRemoveCmd(Cmd):
         if self.other_cluster:
             # Remove the specified cluster:
             cluster = ClusterFactory.load(self.path, self.other_cluster)
-            cluster.remove()
+            cluster.remove(keep_monitoring=self.options.keep_monitoring)
             # Remove CURRENT flag if the specified cluster is the current cluster:
             if self.other_cluster == common.current_cluster_name(self.path):
                 os.remove(os.path.join(self.path, 'CURRENT'))
         else:
             # Remove the current cluster:
-            self.cluster.remove()
+            self.cluster.remove(keep_monitoring=self.options.keep_monitoring)
             os.remove(os.path.join(self.path, 'CURRENT'))
 
 
@@ -1066,3 +1113,215 @@ class ClusterSctoolCmd(Cmd):
         stdout, stderr = self.cluster.sctool(self.sctool_options)
         print(stderr)
         print(stdout)
+
+
+class ClusterMonitoringCmd(Cmd):
+
+    def description(self):
+        return "Manage the scylla-monitoring stack for the current cluster"
+
+    def get_parser(self):
+        usage = "usage: ccm monitoring <subcommand> [options]\n\nSubcommands: start, stop, enable, disable, sync, status"
+        parser = self._get_default_parser(usage, self.description())
+        parser.add_option('--monitoring-dir', type="string", dest="monitoring_dir",
+                          help="Path to scylla-monitoring checkout (default: SCYLLA_MONITORING_DIR env var)", default=None)
+        parser.add_option('--grafana-port', type="int", dest="grafana_port",
+                          help="Grafana port [default: cluster setting or 3000]", default=None)
+        parser.add_option('--prometheus-port', type="int", dest="prometheus_port",
+                          help="Prometheus port [default: cluster setting or 9090]", default=None)
+        parser.add_option('--alertmanager-port', type="int", dest="alertmanager_port",
+                          help="Alertmanager port [default: cluster setting or 9093]", default=None)
+        return parser
+
+    def validate(self, parser, options, args):
+        Cmd.validate(self, parser, options, args, load_cluster=True)
+        if not isinstance(self.cluster, ScyllaCluster):
+            print("Monitoring is only supported for Scylla clusters.", file=sys.stderr)
+            sys.exit(1)
+        if len(args) == 0:
+            print("Missing monitoring subcommand (start, stop, enable, disable, sync, status)", file=sys.stderr)
+            parser.print_help()
+            sys.exit(1)
+        self.subcmd = args[0]
+        if self.subcmd not in ('start', 'stop', 'enable', 'disable', 'sync', 'status'):
+            print(f"Unknown monitoring subcommand: {self.subcmd}", file=sys.stderr)
+            parser.print_help()
+            sys.exit(1)
+
+    def run(self):
+        subcmd = self.subcmd
+        cluster = self.cluster
+
+        if subcmd == 'start':
+            self._do_start(cluster)
+        elif subcmd == 'stop':
+            self._do_stop(cluster)
+        elif subcmd == 'enable':
+            self._do_enable(cluster)
+        elif subcmd == 'disable':
+            self._do_disable(cluster)
+        elif subcmd == 'sync':
+            self._do_sync(cluster)
+        elif subcmd == 'status':
+            self._do_status(cluster)
+
+    @staticmethod
+    def _print_stack_info(stack):
+        """Print Grafana and Prometheus host/port details."""
+        grafana_host, grafana_port = stack.grafana_address()
+        prometheus_host, prometheus_port = stack.prometheus_address()
+        print(f"  Grafana:    {stack.grafana_url()} (host={grafana_host}, port={grafana_port})")
+        print(f"  Prometheus: {stack.prometheus_url()} (host={prometheus_host}, port={prometheus_port})")
+
+    def _get_or_create_stack(self, cluster):
+        if cluster.monitoring_stack:
+            return cluster.monitoring_stack
+        monitoring_dir = self.options.monitoring_dir or cluster.monitoring_dir
+        grafana_port = self.options.grafana_port or cluster.grafana_port
+        prometheus_port = self.options.prometheus_port or cluster.prometheus_port
+        alertmanager_port = self.options.alertmanager_port or cluster.alertmanager_port
+        cluster.monitoring_stack = MonitoringStack(
+            cluster,
+            monitoring_dir=monitoring_dir,
+            grafana_port=grafana_port,
+            prometheus_port=prometheus_port,
+            alertmanager_port=alertmanager_port,
+        )
+        return cluster.monitoring_stack
+
+    def _do_start(self, cluster):
+        """Start monitoring for running cluster (manual mode)."""
+        stack = self._get_or_create_stack(cluster)
+        if stack.is_running():
+            print("Monitoring is already running.")
+            print(f"  Grafana:    {stack.grafana_url()}")
+            print(f"  Prometheus: {stack.prometheus_url()}")
+            return
+        try:
+            stack.start()
+            print("Monitoring started.")
+            print(f"  Grafana:    {stack.grafana_url()}")
+            print(f"  Prometheus: {stack.prometheus_url()}")
+        except Exception as e:
+            print(f"Error starting monitoring: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    def _do_stop(self, cluster):
+        """Stop monitoring."""
+        # Reconnect to containers left by a previous process
+        if not cluster.monitoring_stack or not cluster.monitoring_stack.is_running():
+            stack = MonitoringStack(
+                cluster,
+                monitoring_dir=cluster.monitoring_dir,
+                grafana_port=cluster.grafana_port,
+                prometheus_port=cluster.prometheus_port,
+                alertmanager_port=cluster.alertmanager_port,
+            )
+            if stack.is_running():
+                cluster.monitoring_stack = stack
+        if not cluster.monitoring_stack or not cluster.monitoring_stack.is_running():
+            print("Monitoring is not running.")
+            return
+        try:
+            cluster.monitoring_stack.stop()
+            print("Monitoring stopped.")
+        except Exception as e:
+            print(f"Error stopping monitoring: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    def _do_enable(self, cluster):
+        """Set auto mode, start monitoring if cluster has running nodes, sync targets."""
+        cluster.monitoring_enabled = True
+        # Persist monitoring dir and port overrides
+        if self.options.monitoring_dir:
+            cluster.monitoring_dir = self.options.monitoring_dir
+        if self.options.grafana_port is not None:
+            cluster.grafana_port = self.options.grafana_port
+        if self.options.prometheus_port is not None:
+            cluster.prometheus_port = self.options.prometheus_port
+        if self.options.alertmanager_port is not None:
+            cluster.alertmanager_port = self.options.alertmanager_port
+        # Auto-assign ports from cluster ID if still at defaults
+        if hasattr(cluster, 'id') and cluster.id and cluster.id != 0:
+            defaults = MonitoringStack.default_ports(cluster.id)
+            if cluster.grafana_port == 3000:
+                cluster.grafana_port = defaults['grafana_port']
+            if cluster.prometheus_port == 9090:
+                cluster.prometheus_port = defaults['prometheus_port']
+            if cluster.alertmanager_port == 9093:
+                cluster.alertmanager_port = defaults['alertmanager_port']
+        cluster._update_config()
+
+        # Start monitoring if any nodes are running
+        running_nodes = [n for n in cluster.nodes.values() if n.is_running()]
+        if running_nodes:
+            stack = self._get_or_create_stack(cluster)
+            if not stack.is_running():
+                try:
+                    stack.start()
+                except Exception as e:
+                    print(f"Warning: Failed to start monitoring: {e}", file=sys.stderr)
+            stack.update_targets()
+            print("Automatic monitoring enabled and running.")
+            print(f"  Grafana:    {stack.grafana_url()}")
+            print(f"  Prometheus: {stack.prometheus_url()}")
+        else:
+            print("Automatic monitoring enabled. Will start when cluster starts.")
+
+    def _do_disable(self, cluster):
+        """Unset auto mode, stop monitoring."""
+        cluster.monitoring_enabled = False
+        cluster._update_config()
+
+        if cluster.monitoring_stack and cluster.monitoring_stack.is_running():
+            try:
+                cluster.monitoring_stack.stop()
+            except Exception as e:
+                print(f"Warning: Failed to stop monitoring: {e}", file=sys.stderr)
+
+        print("Automatic monitoring disabled.")
+
+    def _do_sync(self, cluster):
+        """Force-regenerate targets from current cluster state."""
+        cluster._reconnect_monitoring_stack()
+        if not cluster.monitoring_stack or not cluster.monitoring_stack.is_running():
+            print("Monitoring is not running. Use 'ccm monitoring start' first.", file=sys.stderr)
+            sys.exit(1)
+        cluster.monitoring_stack.update_targets()
+        print("Monitoring targets synced.")
+
+    def _do_status(self, cluster):
+        """Show monitoring status."""
+        print(f"Automatic monitoring: {'enabled' if cluster.monitoring_enabled else 'disabled'}")
+        if cluster.monitoring_stack and cluster.monitoring_stack.is_running():
+            stack = cluster.monitoring_stack
+            print(f"Monitoring stack:     running")
+            self._print_stack_info(stack)
+        else:
+            # Check if containers might still be running from a previous session
+            stack = MonitoringStack(
+                cluster,
+                monitoring_dir=cluster.monitoring_dir,
+                grafana_port=cluster.grafana_port,
+                prometheus_port=cluster.prometheus_port,
+                alertmanager_port=cluster.alertmanager_port,
+            )
+            if stack.is_running():
+                print(f"Monitoring stack:     running (from previous session)")
+                self._print_stack_info(stack)
+                # Reconnect the stack
+                cluster.monitoring_stack = stack
+            else:
+                print(f"Monitoring stack:     not running")
+
+        # Show target count
+        targets_file = os.path.join(cluster.get_path(), 'monitoring', 'prometheus', 'targets', 'scylla_servers.yml')
+        if os.path.exists(targets_file):
+            import json
+            try:
+                with open(targets_file) as f:
+                    targets = json.load(f)
+                total = sum(len(entry.get('targets', [])) for entry in targets)
+                print(f"  Targets:    {total} node(s)")
+            except Exception as e:
+                print(f"Warning: could not read monitoring targets: {e}", file=sys.stderr)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1455,6 +1455,7 @@ class Node(object):
         self.nodetool("decommission")
         self.status = Status.DECOMMISSIONED
         self._update_config()
+        self.cluster._notify_topology_change()
 
     def hostid(self, timeout=60, force_refresh=False):
         if self.node_hostid and not force_refresh:

--- a/ccmlib/scylla_cluster.py
+++ b/ccmlib/scylla_cluster.py
@@ -1,6 +1,7 @@
 # ccm clusters
 import os
 import shutil
+import sys
 import time
 import subprocess
 import signal
@@ -16,6 +17,7 @@ from ccmlib.cluster import Cluster
 from ccmlib.scylla_node import ScyllaNode
 from ccmlib.node import NodeError
 from ccmlib import scylla_repository
+from ccmlib.scylla_monitoring import MonitoringStack
 from ccmlib.utils.version import ComparableScyllaVersion
 
 SNITCH = 'org.apache.cassandra.locator.GossipingPropertyFileSnitch'
@@ -174,6 +176,51 @@ class ScyllaCluster(Cluster):
 
         return started
 
+    def _reconnect_monitoring_stack(self):
+        """Reconnect to a monitoring stack that may still be running from a previous process.
+
+        Each ccm invocation is a separate process, so monitoring_stack is always
+        None after loading from disk.  This probes the expected ports and, if
+        monitoring containers are still alive, re-attaches monitoring_stack so
+        that stop() / remove() can tear them down properly.
+        """
+        if self.monitoring_stack and self.monitoring_stack.is_running():
+            return  # already connected
+        stack = MonitoringStack(
+            self,
+            monitoring_dir=self.monitoring_dir,
+            grafana_port=self.grafana_port,
+            prometheus_port=self.prometheus_port,
+            alertmanager_port=self.alertmanager_port,
+        )
+        if stack.is_running():
+            self.monitoring_stack = stack
+
+    def _ensure_monitoring_started(self):
+        """Start monitoring if enabled but not yet running. Blocks until ready.
+
+        Called automatically from start() when monitoring_enabled is True.
+        In automatic mode, failures are logged as warnings but do not prevent
+        the cluster from starting. See docs/monitoring.md for details.
+        """
+        if not self.monitoring_enabled:
+            return
+        # Reconnect to containers left by a previous process
+        self._reconnect_monitoring_stack()
+        if self.monitoring_stack and self.monitoring_stack.is_running():
+            return
+        try:
+            self.monitoring_stack = MonitoringStack(
+                self,
+                monitoring_dir=self.monitoring_dir,
+                grafana_port=self.grafana_port,
+                prometheus_port=self.prometheus_port,
+                alertmanager_port=self.alertmanager_port,
+            )
+            self.monitoring_stack.start()  # blocks until ready
+        except Exception as e:
+            print(f"Warning: Failed to start monitoring stack: {e}", file=sys.stderr)
+
     # override cluster
     def start(self, no_wait=False, verbose=False, wait_for_binary_proto=None,
               wait_other_notice=None, jvm_args=None, profile_options=None,
@@ -183,6 +230,10 @@ class ScyllaCluster(Cluster):
         started = self.start_nodes(**kwargs)
         if self._scylla_manager and not self.skip_manager_server:
             self._scylla_manager.start()
+
+        # Auto-start monitoring if enabled
+        self._ensure_monitoring_started()
+        self._notify_topology_change()
 
         return started
 
@@ -209,11 +260,22 @@ class ScyllaCluster(Cluster):
 
         return [node for node in nodes if not node.is_running()]
 
-    def stop(self, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=None):
+    def stop(self, wait=True, gently=True, wait_other_notice=False, other_nodes=None, wait_seconds=None, keep_monitoring=False):
+        # Reconnect to monitoring containers left by a previous process,
+        # then stop them before nodes go down (unless asked to keep them).
+        if not keep_monitoring:
+            self._reconnect_monitoring_stack()
+            if self.monitoring_stack and self.monitoring_stack.is_running():
+                try:
+                    self.monitoring_stack.stop()
+                except Exception as e:
+                    print(f"Warning: Failed to stop monitoring stack: {e}", file=sys.stderr)
+
         if self._scylla_manager and not self.skip_manager_server:
             self._scylla_manager.stop(gently)
         kwargs = dict(**locals())
         del kwargs['self']
+        del kwargs['keep_monitoring']
         return self.stop_nodes(**kwargs)
 
     def get_scylla_mode(self):

--- a/ccmlib/scylla_monitoring.py
+++ b/ccmlib/scylla_monitoring.py
@@ -1,0 +1,879 @@
+"""Manages a scylla-monitoring stack for a CCM cluster."""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+import urllib.request
+import urllib.error
+
+from ccmlib.common import logger
+
+SCYLLA_MONITORING_REPO = 'https://github.com/scylladb/scylla-monitoring.git'
+
+# Datasource UID used in built-in (fallback) dashboards.
+_DATASOURCE_UID = 'ccm-prometheus'
+
+# Default location where scylla-monitoring is cloned.
+_DEFAULT_MONITORING_DIR = os.path.expanduser('~/.ccm/scylla-monitoring')
+
+
+def _relabel_for_container(path):
+    """Best-effort SELinux relabel so a container process can read *path*.
+
+    Bind mounts are labeled ``container_file_t`` via the ``:z`` volume option
+    at mount time, but files written into a mounted directory afterwards get
+    the host's default label and become unreadable to the container.
+    """
+    try:
+        subprocess.run(
+            ['chcon', '-t', 'container_file_t', path],
+            check=False, capture_output=True, timeout=10,
+        )
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Port availability
+# ---------------------------------------------------------------------------
+
+def _is_port_available(port):
+    """Check whether *port* on localhost is free to bind."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('127.0.0.1', port))
+            return True
+    except OSError:
+        return False
+
+
+def _find_available_port(start_port, max_attempts=100):
+    """Return *start_port* if it is free, otherwise try successive ports.
+
+    Raises ``RuntimeError`` after *max_attempts* failed probes.
+    """
+    for offset in range(max_attempts):
+        port = start_port + offset
+        if _is_port_available(port):
+            return port
+    raise RuntimeError(
+        f"Could not find a free port starting from {start_port} "
+        f"(tried {max_attempts} ports)")
+
+
+# ---------------------------------------------------------------------------
+# scylla-monitoring repo & dashboard generation
+# ---------------------------------------------------------------------------
+
+def _clone_monitoring_repo(target_dir):
+    """Shallow-clone the scylla-monitoring repo.  Returns *True* on success."""
+    try:
+        result = subprocess.run(
+            ['git', 'clone', '--depth', '1', SCYLLA_MONITORING_REPO, target_dir],
+            capture_output=True, text=True, timeout=300)
+        if result.returncode == 0:
+            return True
+        logger.warning(
+            f"git clone scylla-monitoring failed (exit {result.returncode}): "
+            f"{result.stderr.strip()}")
+    except FileNotFoundError:
+        logger.warning("git is not installed; cannot clone scylla-monitoring")
+    except subprocess.TimeoutExpired:
+        logger.warning("git clone scylla-monitoring timed out")
+    except Exception as e:
+        logger.warning(f"Failed to clone scylla-monitoring: {e}")
+    return False
+
+
+_DS_OBJ = {"type": "prometheus", "uid": _DATASOURCE_UID}
+
+
+def _fix_dashboard_datasources(dashboard):
+    """Walk a dashboard dict and normalise every Prometheus datasource
+    reference to the explicit ``{"type": "prometheus", "uid": "<ours>"}``
+    object form.
+
+    String-based references (``"datasource": "prometheus"``) are unreliable
+    in modern Grafana when dashboards are loaded via file provisioning, so
+    every prometheus ref is rewritten to the UID-based object.
+
+    Non-prometheus datasources (``null``, ``"grafana"``, etc.) are left
+    untouched.
+    """
+    if isinstance(dashboard, dict):
+        for key in list(dashboard.keys()):
+            val = dashboard[key]
+            if key == 'datasource':
+                if val == 'prometheus':
+                    dashboard[key] = dict(_DS_OBJ)
+                elif isinstance(val, dict) and val.get('type') == 'prometheus':
+                    val['uid'] = _DATASOURCE_UID
+                # null, "grafana", other types → leave alone
+            else:
+                _fix_dashboard_datasources(val)
+    elif isinstance(dashboard, list):
+        for item in dashboard:
+            _fix_dashboard_datasources(item)
+
+
+def _postprocess_dashboards(output_dir):
+    """Fix datasource references in all generated dashboard JSON files."""
+    for fname in os.listdir(output_dir):
+        if not fname.endswith('.json'):
+            continue
+        fpath = os.path.join(output_dir, fname)
+        try:
+            with open(fpath, 'r') as f:
+                dashboard = json.load(f)
+            _fix_dashboard_datasources(dashboard)
+            with open(fpath, 'w') as f:
+                json.dump(dashboard, f, indent=2)
+                f.write('\n')
+        except Exception as e:
+            logger.warning(f"Failed to post-process dashboard {fname}: {e}")
+
+
+def _generate_dashboards(monitoring_dir, output_dir):
+    """Run *make_dashboards.py* from a scylla-monitoring checkout to produce
+    real Grafana dashboard JSON files in *output_dir*.
+
+    Returns the number of dashboards generated (0 on total failure).
+    """
+    make_dashboards = os.path.join(monitoring_dir, 'make_dashboards.py')
+    types_file = os.path.join(monitoring_dir, 'grafana', 'types.json')
+    templates_dir = os.path.join(monitoring_dir, 'grafana')
+
+    if not os.path.isfile(make_dashboards) or not os.path.isfile(types_file):
+        logger.warning(
+            f"scylla-monitoring checkout at {monitoring_dir} is missing "
+            f"make_dashboards.py or grafana/types.json")
+        return 0
+
+    os.makedirs(output_dir, exist_ok=True)
+    generated = 0
+
+    for fname in sorted(os.listdir(templates_dir)):
+        if not fname.endswith('.template.json'):
+            continue
+        template_path = os.path.join(templates_dir, fname)
+        try:
+            cmd = [
+                sys.executable, make_dashboards,
+                '-t', types_file,
+                '-d', template_path,
+                '-af', output_dir,
+                # generate-dashboards.sh always substitutes these
+                # placeholders; without them they are left literally in
+                # the JSON and Grafana rejects the dashboard (e.g.
+                # "parsing refresh duration \"__REFRESH_INTERVAL__\"").
+                '-R', '__REFRESH_INTERVAL__=5m',
+                '-R', '__MONITOR_VERSION__=master',
+                '-R', '__MONITOR_BRANCH_VERSION=master',
+                # __SCYLLA_VERSION_DASHED__ is derived internally from
+                # __SCYLLA_VERSION_DOT__ (make_dashboards.py); both must be
+                # covered or they're left literal in uids/tags/variables.
+                '-R', '__SCYLLA_VERSION_DOT__=master',
+                '-V', 'master',
+            ]
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=30)
+            if result.returncode == 0:
+                generated += 1
+            else:
+                logger.warning(
+                    f"make_dashboards.py failed for {fname}: "
+                    f"{result.stderr.strip()}")
+        except Exception as e:
+            logger.warning(f"make_dashboards.py failed for {fname}: {e}")
+
+    if generated:
+        _postprocess_dashboards(output_dir)
+
+    return generated
+
+
+# ---------------------------------------------------------------------------
+# Fallback: minimal built-in overview dashboard
+# ---------------------------------------------------------------------------
+
+def _make_panel(title, expr, legend, unit, grid_pos, datasource, y_max=None):
+    """Build a Grafana timeseries panel definition."""
+    panel = {
+        "type": "timeseries",
+        "title": title,
+        "gridPos": {"x": grid_pos[0], "y": grid_pos[1],
+                     "w": grid_pos[2], "h": grid_pos[3]},
+        "targets": [{
+            "expr": expr,
+            "legendFormat": legend,
+            "datasource": datasource,
+        }],
+        "fieldConfig": {
+            "defaults": {
+                "unit": unit,
+                "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                },
+            },
+            "overrides": [],
+        },
+        "options": {
+            "tooltip": {"mode": "multi"},
+            "legend": {"displayMode": "table", "placement": "bottom"},
+        },
+    }
+    if y_max is not None:
+        panel["fieldConfig"]["defaults"]["max"] = y_max
+    return panel
+
+
+def _scylla_overview_dashboard():
+    """Return a minimal built-in Scylla Overview dashboard (fallback)."""
+    ds = {"type": "prometheus", "uid": _DATASOURCE_UID}
+    return {
+        "id": None,
+        "uid": "scylla-overview-ccm",
+        "title": "Scylla Overview",
+        "tags": ["scylla", "ccm"],
+        "editable": True,
+        "graphTooltip": 1,
+        "schemaVersion": 39,
+        "version": 1,
+        "time": {"from": "now-1h", "to": "now"},
+        "refresh": "30s",
+        "panels": [
+            _make_panel(
+                title="CPU Utilization",
+                expr="avg by (instance) (scylla_reactor_utilization)",
+                legend="{{instance}}",
+                unit="percentunit", y_max=1,
+                grid_pos=(0, 0, 12, 8), datasource=ds,
+            ),
+            _make_panel(
+                title="CQL Requests / sec",
+                expr="sum by (instance) (rate(scylla_transport_requests_served[1m]))",
+                legend="{{instance}}",
+                unit="ops",
+                grid_pos=(12, 0, 12, 8), datasource=ds,
+            ),
+            _make_panel(
+                title="Memory Free",
+                expr="sum by (instance) (scylla_memory_free_memory)",
+                legend="{{instance}}",
+                unit="bytes",
+                grid_pos=(0, 8, 12, 8), datasource=ds,
+            ),
+            _make_panel(
+                title="Active CQL Connections",
+                expr="sum by (instance) (scylla_transport_current_connections)",
+                legend="{{instance}}",
+                unit="short",
+                grid_pos=(12, 8, 12, 8), datasource=ds,
+            ),
+            _make_panel(
+                title="Total Reads / sec",
+                expr="sum by (instance) (rate(scylla_cql_reads[1m]))",
+                legend="{{instance}}",
+                unit="ops",
+                grid_pos=(0, 16, 12, 8), datasource=ds,
+            ),
+            _make_panel(
+                title="Total Writes / sec",
+                expr="sum by (instance) (rate(scylla_cql_inserts[1m]))",
+                legend="{{instance}}",
+                unit="ops",
+                grid_pos=(12, 16, 12, 8), datasource=ds,
+            ),
+        ],
+    }
+
+
+_BUILTIN_DASHBOARDS = {
+    'scylla-overview.json': _scylla_overview_dashboard,
+}
+
+
+# ---------------------------------------------------------------------------
+# Resolve monitoring directory
+# ---------------------------------------------------------------------------
+
+def _resolve_monitoring_dir(monitoring_dir=None, cluster_dir=None):
+    """Resolve the scylla-monitoring directory from multiple sources.
+
+    Checks in order:
+    1. Explicit monitoring_dir argument
+    2. SCYLLA_MONITORING_DIR environment variable
+    3. <cluster_dir>/scylla-monitoring/ (if cluster_dir provided)
+    4. ~/.ccm/scylla-monitoring/
+
+    Returns the resolved path, or None if not found.
+    """
+    if monitoring_dir and os.path.isdir(monitoring_dir):
+        return monitoring_dir
+
+    env_dir = os.environ.get('SCYLLA_MONITORING_DIR')
+    if env_dir and os.path.isdir(env_dir):
+        return env_dir
+
+    if cluster_dir:
+        cluster_local = os.path.join(cluster_dir, 'scylla-monitoring')
+        if os.path.isdir(cluster_local):
+            return cluster_local
+
+    default_dir = os.path.expanduser('~/.ccm/scylla-monitoring')
+    if os.path.isdir(default_dir):
+        return default_dir
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# MonitoringStack
+# ---------------------------------------------------------------------------
+
+class MonitoringStack:
+    """Manages a scylla-monitoring stack for a CCM cluster.
+
+    Runs Prometheus, Grafana, and Alertmanager as Docker containers
+    with --net=host, configuring per-service listen ports to allow
+    multiple simultaneous monitoring stacks.
+    """
+
+    def __init__(self, cluster, monitoring_dir=None, grafana_port=3000,
+                 prometheus_port=9090, alertmanager_port=9093,
+                 start_alertmanager=True):
+        self.cluster = cluster
+        self.monitoring_dir = _resolve_monitoring_dir(monitoring_dir)
+        self.grafana_port = grafana_port
+        self.prometheus_port = prometheus_port
+        self.alertmanager_port = alertmanager_port
+        # Alertmanager only matters if something is configured to route
+        # alerts somewhere; skip it for ad-hoc/test clusters that just want
+        # Grafana dashboards.
+        self.start_alertmanager = start_alertmanager
+        self._working_dir = os.path.join(cluster.get_path(), 'monitoring')
+        self._home_dashboard_filename = None
+
+    @staticmethod
+    def default_ports(cluster_id=0):
+        """Compute default ports offset by cluster ID to avoid conflicts."""
+        return {
+            'grafana_port': 3000 + cluster_id * 10,
+            'prometheus_port': 9090 + cluster_id * 10,
+            'alertmanager_port': 9093 + cluster_id * 10,
+        }
+
+    def _container_name(self, service):
+        """Return the Docker container name for a service."""
+        return f'ccm-{self.cluster.name}-{service}'
+
+    # ------------------------------------------------------------------
+    # Port resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_ports(self):
+        """Ensure every service port is available, bumping to the next
+        free port when necessary.  Updates both *self* and the owning
+        cluster so the chosen ports are persisted."""
+        for attr in ('grafana_port', 'prometheus_port', 'alertmanager_port'):
+            requested = getattr(self, attr)
+            actual = _find_available_port(requested)
+            if actual != requested:
+                logger.info(
+                    f"Port {requested} in use, using {actual} for "
+                    f"{attr.replace('_port', '')}")
+            setattr(self, attr, actual)
+            if hasattr(self.cluster, attr):
+                setattr(self.cluster, attr, actual)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self):
+        """Start the monitoring stack containers.
+
+        Writes initial targets, generates Prometheus and Grafana configs,
+        starts containers via docker run, and blocks until healthy.
+
+        Before starting, each service port is checked for availability.
+        If a port is already in use the next free port is chosen
+        automatically and the cluster object is updated so the new port
+        is persisted.
+        """
+        self._resolve_ports()
+
+        # Create working directory structure.
+        # Docker containers run as non-root users (Prometheus as nobody/65534,
+        # Grafana as grafana/472), so all bind-mounted paths must be
+        # world-readable, and data directories must be world-writable.
+        targets_dir = os.path.join(self._working_dir, 'prometheus', 'targets')
+        data_dir = os.path.join(self._working_dir, 'data', 'prometheus_data')
+        os.makedirs(targets_dir, exist_ok=True)
+        os.makedirs(data_dir, exist_ok=True)
+        os.chmod(data_dir, 0o777)
+        os.chmod(targets_dir, 0o777)
+
+        # Ensure we have a scylla-monitoring checkout for dashboards
+        if not self.monitoring_dir:
+            self._ensure_monitoring_repo()
+
+        # Generate and write initial targets
+        self.update_targets()
+
+        # Generate prometheus.yml
+        self._write_prometheus_config()
+
+        # Generate Grafana provisioning + dashboards
+        self._write_grafana_provisioning()
+
+        # Stop any existing containers with these names
+        self._stop_containers()
+
+        # Start containers
+        self._start_prometheus(targets_dir, data_dir)
+        self._start_grafana()
+        if self.start_alertmanager:
+            self._start_alertmanager()
+
+        self._wait_until_ready(timeout=60)
+        logger.info(
+            f"Monitoring started: Grafana {self.grafana_url()}, "
+            f"Prometheus {self.prometheus_url()}"
+        )
+
+    def stop(self):
+        """Stop all monitoring stack containers."""
+        logger.info(f"Stopping monitoring stack for cluster {self.cluster.name}")
+        self._stop_containers()
+
+    # ------------------------------------------------------------------
+    # Repo / dashboard generation
+    # ------------------------------------------------------------------
+
+    def _ensure_monitoring_repo(self):
+        """Clone scylla-monitoring to the default location if not present."""
+        if os.path.isdir(os.path.join(_DEFAULT_MONITORING_DIR, 'grafana')):
+            self.monitoring_dir = _DEFAULT_MONITORING_DIR
+            return
+
+        logger.info(
+            f"Cloning scylla-monitoring to {_DEFAULT_MONITORING_DIR} "
+            f"(one-time setup for dashboards)...")
+        if _clone_monitoring_repo(_DEFAULT_MONITORING_DIR):
+            self.monitoring_dir = _DEFAULT_MONITORING_DIR
+        else:
+            logger.warning(
+                "Could not clone scylla-monitoring; "
+                "using built-in fallback dashboard")
+
+    # ------------------------------------------------------------------
+    # Config generation
+    # ------------------------------------------------------------------
+
+    def _write_prometheus_config(self):
+        """Write a minimal prometheus.yml configuration."""
+        config_dir = os.path.join(self._working_dir, 'prometheus')
+        os.makedirs(config_dir, exist_ok=True)
+        config_file = os.path.join(config_dir, 'prometheus.yml')
+
+        content = (
+            "global:\n"
+            "  scrape_interval: 20s\n"
+            "  evaluation_interval: 20s\n"
+            "\n"
+            "scrape_configs:\n"
+            "  - job_name: 'scylla'\n"
+            "    file_sd_configs:\n"
+            "      - files:\n"
+            "          - '/etc/prometheus/targets/scylla_servers.yml'\n"
+            "        refresh_interval: 10s\n"
+            "    relabel_configs:\n"
+            "      - source_labels: [__address__]\n"
+            "        regex: '(.*)'\n"
+            "        target_label: __address__\n"
+            "        replacement: '${1}:9180'\n"
+            "      - source_labels: [__address__]\n"
+            "        target_label: instance\n"
+        )
+
+        with open(config_file, 'w') as f:
+            f.write(content)
+
+    def _write_grafana_provisioning(self):
+        """Write Grafana provisioning files for datasource and dashboards.
+
+        Attempts to generate the full set of scylla-monitoring dashboards
+        from templates.  Falls back to a minimal built-in overview dashboard
+        when generation is not possible (no repo, missing pyyaml, etc.).
+        """
+        # --- datasource ---
+        datasources_dir = os.path.join(
+            self._working_dir, 'grafana', 'provisioning', 'datasources')
+        os.makedirs(datasources_dir, exist_ok=True)
+
+        datasource_file = os.path.join(datasources_dir, 'prometheus.yml')
+        content = (
+            "apiVersion: 1\n"
+            "datasources:\n"
+            "  - name: prometheus\n"
+            f"    uid: {_DATASOURCE_UID}\n"
+            "    type: prometheus\n"
+            "    access: proxy\n"
+            f"    url: http://localhost:{self.prometheus_port}\n"
+            "    isDefault: true\n"
+        )
+        with open(datasource_file, 'w') as f:
+            f.write(content)
+
+        # --- dashboards ---
+        dashboards_dir = os.path.join(self._working_dir, 'grafana', 'dashboards')
+        os.makedirs(dashboards_dir, exist_ok=True)
+
+        generated = 0
+
+        # 1. Generate from scylla-monitoring templates (the real dashboards)
+        if self.monitoring_dir:
+            generated = _generate_dashboards(self.monitoring_dir, dashboards_dir)
+            if generated:
+                logger.info(
+                    f"Generated {generated} dashboards from scylla-monitoring")
+
+        # 2. Fallback: write minimal built-in dashboards
+        if not generated:
+            logger.info("Using built-in fallback dashboards")
+            self._write_builtin_dashboards(dashboards_dir)
+
+        # Land on the Overview dashboard instead of Grafana's empty default
+        # Home page -- pick the generated "overview" file, or the built-in
+        # fallback's fixed name if templates weren't available.
+        for fname in sorted(os.listdir(dashboards_dir)):
+            if fname.startswith('scylla-overview') and fname.endswith('.json'):
+                self._home_dashboard_filename = fname
+                break
+
+        # --- dashboard provisioning config ---
+        prov_dashboards_dir = os.path.join(
+            self._working_dir, 'grafana', 'provisioning', 'dashboards')
+        os.makedirs(prov_dashboards_dir, exist_ok=True)
+
+        dashboard_config = os.path.join(prov_dashboards_dir, 'dashboards.yml')
+        config_content = (
+            "apiVersion: 1\n"
+            "providers:\n"
+            "  - name: 'scylla'\n"
+            "    type: file\n"
+            "    allowUiUpdates: true\n"
+            "    options:\n"
+            "      path: /var/lib/grafana/dashboards\n"
+        )
+        with open(dashboard_config, 'w') as f:
+            f.write(config_content)
+
+    def _write_builtin_dashboards(self, dest_dir):
+        """Write built-in Scylla dashboard JSON files to *dest_dir*."""
+        for filename, dashboard_fn in _BUILTIN_DASHBOARDS.items():
+            filepath = os.path.join(dest_dir, filename)
+            with open(filepath, 'w') as f:
+                json.dump(dashboard_fn(), f, indent=2)
+                f.write('\n')
+
+    # ------------------------------------------------------------------
+    # Container management
+    # ------------------------------------------------------------------
+
+    def _start_prometheus(self, targets_dir, data_dir):
+        """Start the Prometheus container."""
+        name = self._container_name('prometheus')
+        prometheus_config = os.path.join(
+            self._working_dir, 'prometheus', 'prometheus.yml')
+
+        cmd = [
+            'docker', 'run', '-d',
+            '--name', name,
+            '--net=host',
+        ]
+        cmd.extend([
+            '-v', f'{prometheus_config}:/etc/prometheus/prometheus.yml:z',
+            '-v', f'{targets_dir}:/etc/prometheus/targets:z',
+            '-v', f'{data_dir}:/prometheus:z',
+            'prom/prometheus',
+            f'--web.listen-address=:{self.prometheus_port}',
+            '--config.file=/etc/prometheus/prometheus.yml',
+            '--storage.tsdb.path=/prometheus',
+        ])
+
+        logger.info(f"Starting Prometheus: {' '.join(cmd)}")
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=60)
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to start Prometheus container (exit {result.returncode}):\n"
+                    f"stdout: {result.stdout}\nstderr: {result.stderr}")
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("Docker run for Prometheus timed out")
+
+    def _start_grafana(self):
+        """Start the Grafana container."""
+        name = self._container_name('grafana')
+        provisioning_dir = os.path.join(
+            self._working_dir, 'grafana', 'provisioning')
+        dashboards_dir = os.path.join(
+            self._working_dir, 'grafana', 'dashboards')
+
+        cmd = [
+            'docker', 'run', '-d',
+            '--name', name,
+            '--net=host',
+        ]
+        cmd.extend([
+            '-e', f'GF_SERVER_HTTP_PORT={self.grafana_port}',
+            '-e', 'GF_AUTH_ANONYMOUS_ENABLED=true',
+            '-e', 'GF_AUTH_ANONYMOUS_ORG_ROLE=Admin',
+            '-v', f'{provisioning_dir}:/etc/grafana/provisioning:z',
+            '-v', f'{dashboards_dir}:/var/lib/grafana/dashboards:z',
+        ])
+        if self._home_dashboard_filename:
+            cmd.extend([
+                '-e',
+                'GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH='
+                f'/var/lib/grafana/dashboards/{self._home_dashboard_filename}',
+            ])
+
+        # Mount scylla plugin if available
+        if self.monitoring_dir:
+            plugins_dir = os.path.join(self.monitoring_dir, 'grafana', 'plugins')
+            if os.path.isdir(plugins_dir):
+                cmd.extend([
+                    '-v', f'{plugins_dir}:/var/lib/grafana/plugins:z',
+                    '-e', 'GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=scylladb-scylla-datasource',
+                ])
+
+        cmd.append('grafana/grafana')
+
+        logger.info(f"Starting Grafana: {' '.join(cmd)}")
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=60)
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to start Grafana container (exit {result.returncode}):\n"
+                    f"stdout: {result.stdout}\nstderr: {result.stderr}")
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("Docker run for Grafana timed out")
+
+    def _write_alertmanager_config(self):
+        """Write a minimal alertmanager.yml configuration."""
+        config_dir = os.path.join(self._working_dir, 'alertmanager')
+        os.makedirs(config_dir, exist_ok=True)
+        config_file = os.path.join(config_dir, 'alertmanager.yml')
+
+        content = (
+            "route:\n"
+            "  receiver: 'default'\n"
+            "receivers:\n"
+            "  - name: 'default'\n"
+        )
+
+        with open(config_file, 'w') as f:
+            f.write(content)
+
+    def _start_alertmanager(self):
+        """Start the Alertmanager container."""
+        self._write_alertmanager_config()
+        name = self._container_name('alertmanager')
+        alertmanager_config = os.path.join(
+            self._working_dir, 'alertmanager', 'alertmanager.yml')
+
+        cmd = [
+            'docker', 'run', '-d',
+            '--name', name,
+            '--net=host',
+        ]
+        cmd.extend([
+            '-v', f'{alertmanager_config}:/etc/alertmanager/alertmanager.yml:z',
+            'prom/alertmanager',
+            f'--web.listen-address=:{self.alertmanager_port}',
+            '--config.file=/etc/alertmanager/alertmanager.yml',
+        ])
+
+        logger.info(f"Starting Alertmanager: {' '.join(cmd)}")
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=60)
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to start Alertmanager container (exit {result.returncode}):\n"
+                    f"stdout: {result.stdout}\nstderr: {result.stderr}")
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("Docker run for Alertmanager timed out")
+
+    def _stop_containers(self):
+        """Stop and remove all monitoring containers for this cluster."""
+        for service in ('prometheus', 'grafana', 'alertmanager'):
+            name = self._container_name(service)
+            try:
+                subprocess.run(
+                    ['docker', 'stop', name],
+                    capture_output=True, timeout=30)
+            except Exception as e:
+                logger.debug("Failed to stop container %s: %s", name, e)
+            try:
+                subprocess.run(
+                    ['docker', 'rm', '-f', name],
+                    capture_output=True, timeout=10)
+            except Exception as e:
+                logger.debug("Failed to remove container %s: %s", name, e)
+
+    # ------------------------------------------------------------------
+    # Health / status
+    # ------------------------------------------------------------------
+
+    def is_running(self):
+        """Check if the monitoring stack is healthy by probing Prometheus."""
+        # Fast path: HTTP probe
+        try:
+            url = f"http://localhost:{self.prometheus_port}/-/ready"
+            req = urllib.request.Request(url, method='GET')
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                return resp.status == 200
+        except Exception:
+            pass
+        # Fallback: check if container exists
+        try:
+            result = subprocess.run(
+                ['docker', 'ps', '-q', '-f',
+                 f'name=^{self._container_name("prometheus")}$'],
+                capture_output=True, text=True, timeout=5)
+            return bool(result.stdout.strip())
+        except Exception:
+            return False
+
+    def update_targets(self):
+        """Regenerate scylla_servers.yml from current cluster state."""
+        targets = self._generate_targets_yaml()
+        self._write_targets_file(targets)
+
+    def _generate_targets_yaml(self):
+        """Build the Prometheus targets list from cluster nodes.
+
+        Output format (matches scylla-monitoring's scylla_servers.yml):
+        [
+            {
+                "targets": ["127.0.0.1"],
+                "labels": {"cluster": "test", "dc": "dc1"}
+            }
+        ]
+
+        Includes any node whose container is running, regardless of gossip
+        status - the IP is known and scrapable as soon as the process starts,
+        without waiting for it to join the ring.
+        """
+        dc_targets = {}
+        for node in self.cluster.nodelist():
+            if not node.is_running():
+                continue
+            dc = node.data_center or "datacenter1"
+            dc_targets.setdefault(dc, []).append(node.address())
+
+        return [
+            {"targets": targets, "labels": {"cluster": self.cluster.name, "dc": dc}}
+            for dc, targets in dc_targets.items()
+        ]
+
+    def _write_targets_file(self, targets):
+        """Atomic write targets to the file that Prometheus watches."""
+        targets_dir = os.path.join(self._working_dir, 'prometheus', 'targets')
+        os.makedirs(targets_dir, exist_ok=True)
+
+        targets_file = os.path.join(targets_dir, 'scylla_servers.yml')
+
+        # Write to temp file then atomically rename.
+        # Prometheus runs as nobody (uid 65534) so the file must be
+        # world-readable.
+        fd, tmp_path = tempfile.mkstemp(
+            dir=targets_dir, prefix='.scylla_servers_', suffix='.yml.tmp'
+        )
+        try:
+            with os.fdopen(fd, 'w') as f:
+                json.dump(targets, f, indent=2)
+                f.write('\n')
+            os.chmod(tmp_path, 0o644)
+            os.replace(tmp_path, targets_file)
+            _relabel_for_container(targets_file)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass  # Best-effort cleanup of temp file
+            raise
+
+    def _wait_until_ready(self, timeout=60):
+        """Block until Prometheus and Grafana health endpoints respond.
+
+        Raises TimeoutError if not ready within timeout seconds.
+        """
+        deadline = time.time() + timeout
+
+        # Wait for Prometheus
+        while time.time() < deadline:
+            try:
+                url = f"http://localhost:{self.prometheus_port}/-/ready"
+                req = urllib.request.Request(url, method='GET')
+                with urllib.request.urlopen(req, timeout=2) as resp:
+                    if resp.status == 200:
+                        break
+            except Exception:
+                logger.debug("Prometheus not ready yet at port %s", self.prometheus_port)
+            time.sleep(1)
+        else:
+            raise TimeoutError(
+                f"Prometheus not ready at localhost:{self.prometheus_port} "
+                f"after {timeout}s"
+            )
+
+        # Wait for Grafana
+        while time.time() < deadline:
+            try:
+                url = f"http://localhost:{self.grafana_port}/api/health"
+                req = urllib.request.Request(url, method='GET')
+                with urllib.request.urlopen(req, timeout=2) as resp:
+                    if resp.status == 200:
+                        break
+            except Exception:
+                logger.debug("Grafana not ready yet at port %s", self.grafana_port)
+            time.sleep(1)
+        else:
+            raise TimeoutError(
+                f"Grafana not ready at localhost:{self.grafana_port} "
+                f"after {timeout}s"
+            )
+
+    # ------------------------------------------------------------------
+    # Convenience accessors
+    # ------------------------------------------------------------------
+
+    def grafana_address(self):
+        """Return (host, port) tuple for Grafana."""
+        return ('localhost', self.grafana_port)
+
+    def prometheus_address(self):
+        """Return (host, port) tuple for Prometheus."""
+        return ('localhost', self.prometheus_port)
+
+    def grafana_url(self):
+        host, port = self.grafana_address()
+        return f"http://{host}:{port}"
+
+    def prometheus_url(self):
+        host, port = self.prometheus_address()
+        return f"http://{host}:{port}"

--- a/ccmlib/scylla_node.py
+++ b/ccmlib/scylla_node.py
@@ -898,6 +898,8 @@ class ScyllaNode(Node):
 
         if self.scylla_manager and self.scylla_manager.is_agent_available:
             self.start_scylla_manager_agent()
+
+        self.cluster._notify_topology_change()
         return scylla_process
 
     def start_dse(self,
@@ -1140,6 +1142,7 @@ class ScyllaNode(Node):
         if wait or wait_other_notice:
             self.wait_until_stopped(wait_seconds, marks, dump_core=gently)
 
+        self.cluster._notify_topology_change()
         return was_running
 
     def import_config_files(self):

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,267 @@
+# Integrated Monitoring Stack
+
+CCM can start and maintain a monitoring stack (Prometheus, Grafana, Alertmanager)
+alongside the cluster it manages. When a cluster undergoes topology changes
+(add node, remove node, decommission, start, stop), the monitoring stack's
+scrape targets are kept in sync.
+
+## Prerequisites
+
+- **Docker** — CCM runs Prometheus, Grafana, and Alertmanager as Docker
+  containers with `--net=host`.
+- **scylla-monitoring checkout** (optional) — a local clone of the
+  [scylla-monitoring](https://github.com/scylladb/scylla-monitoring) repository,
+  only needed for importing pre-built Grafana dashboards. Basic monitoring
+  (Prometheus + Grafana with datasource) works without it.
+
+## Two Modes of Operation
+
+### Automatic mode
+
+Enabled at cluster creation time with `--monitoring`, or on an existing cluster
+with `ccm monitoring enable`. Once set, **every** operation that changes node
+topology automatically updates the monitoring stack's targets. The flag is
+persisted in `cluster.conf` so all future operations honour it.
+
+```bash
+ccm create mycluster --scylla -n 3 -v release:2024.2 --monitoring -s
+# monitoring starts automatically with the cluster
+
+ccm add node4 --scylla        # targets updated automatically
+ccm node4 start               # targets updated automatically
+ccm node2 stop                # targets updated automatically
+ccm stop                      # monitoring stops automatically
+ccm start                     # monitoring restarts automatically
+```
+
+The flag can also be toggled on an existing cluster:
+
+```bash
+ccm monitoring enable          # sets the flag, starts monitoring, syncs targets
+ccm add node5 --scylla         # from now on, auto-updates
+
+ccm monitoring disable         # clears the flag, stops monitoring
+```
+
+### Manual mode
+
+The default — no monitoring unless explicitly requested. Start and sync on
+demand; no automatic updates happen on topology changes.
+
+```bash
+ccm create mycluster --scylla -n 3 -v release:2024.2 -s
+# ... some time later ...
+ccm monitoring start           # starts monitoring, syncs current state
+ccm add node4 --scylla         # monitoring is NOT updated
+ccm monitoring sync            # manually refresh targets
+ccm monitoring stop            # stops monitoring
+```
+
+## Multiple Simultaneous Clusters
+
+When running multiple clusters with monitoring, each cluster automatically gets
+unique ports based on its cluster ID to avoid conflicts:
+
+```bash
+ccm create cluster-a --scylla -n 3 --id 0 --monitoring -v release:2024.2 -s
+# Grafana: 3000, Prometheus: 9090, Alertmanager: 9093
+
+ccm create cluster-b --scylla -n 3 --id 1 --monitoring -v release:2024.2 -s
+# Grafana: 3010, Prometheus: 9100, Alertmanager: 9103
+```
+
+Port assignment formula: `base_port + cluster_id * 10`. Explicit
+`--grafana-port` / `--prometheus-port` / `--alertmanager-port` flags override
+the auto-assigned values.
+
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `CCM_MONITORING` | When non-empty and not `0`, every newly created cluster behaves as if `--monitoring` was passed. Equivalent to `ccm create ... --monitoring`. Example: `export CCM_MONITORING=1`. |
+| `SCYLLA_MONITORING_DIR` | Path to the scylla-monitoring checkout. Used for importing dashboards into Grafana. Not required for basic monitoring. |
+
+## CLI Reference
+
+### `ccm create` flags
+
+| Flag | Description |
+|---|---|
+| `--monitoring` | Enable automatic monitoring for this cluster. |
+| `--monitoring-dir=PATH` | Path to scylla-monitoring checkout (for dashboards). |
+| `--grafana-port=PORT` | Grafana port (default: auto from cluster ID). |
+| `--prometheus-port=PORT` | Prometheus port (default: auto from cluster ID). |
+| `--alertmanager-port=PORT` | Alertmanager port (default: auto from cluster ID). |
+
+### `ccm monitoring` subcommands
+
+| Subcommand | Description |
+|---|---|
+| `start` | Start the monitoring stack for the current cluster (manual mode). Blocks until Prometheus and Grafana are healthy. |
+| `stop` | Stop the monitoring stack. |
+| `enable` | Set automatic mode, persist the flag, start monitoring if the cluster is running, and sync targets. |
+| `disable` | Unset automatic mode and stop monitoring. |
+| `sync` | Force-regenerate Prometheus targets from current cluster state. Requires monitoring to be running. |
+| `status` | Show whether automatic mode is enabled, whether the stack is running, URLs, and target count. |
+
+All subcommands accept `--monitoring-dir`, `--grafana-port`, `--prometheus-port`,
+and `--alertmanager-port` overrides.
+
+## How It Works
+
+### Container management
+
+CCM manages Docker containers directly using `docker run` with `--net=host`:
+
+- **Prometheus** (`prom/prometheus`): listens on `--web.listen-address=:{port}`,
+  reads targets from a bind-mounted `scylla_servers.yml`
+- **Grafana** (`grafana/grafana`): configured via `GF_SERVER_HTTP_PORT` env var,
+  with provisioned Prometheus datasource
+- **Alertmanager** (`prom/alertmanager`): listens on `--web.listen-address=:{port}`
+
+Container naming: `ccm-{cluster_name}-{service}` (e.g., `ccm-mycluster-prometheus`).
+Host networking is required because CCM nodes bind to `127.0.0.x` loopback
+addresses, which are unreachable from Docker bridge networks.
+
+### Target generation
+
+CCM generates a `scylla_servers.yml` file in the Prometheus `file_sd_configs`
+format. Prometheus watches this file and automatically reloads targets when it
+changes — no container restart or API call needed.
+
+Targets are grouped by datacenter:
+
+```json
+[
+  {
+    "targets": ["127.0.0.1", "127.0.0.2"],
+    "labels": {"cluster": "mycluster", "dc": "dc1"}
+  },
+  {
+    "targets": ["127.0.0.3"],
+    "labels": {"cluster": "mycluster", "dc": "dc2"}
+  }
+]
+```
+
+Only nodes with status **UP** or **DECOMMISSIONED** (still running, still
+scrapeable) are included. **DOWN** and **UNINITIALIZED** nodes are excluded.
+
+### Prometheus configuration
+
+CCM generates a minimal `prometheus.yml` with a single `scylla` scrape job that:
+- Uses `file_sd_configs` to watch `scylla_servers.yml`
+- Appends `:9180` to target addresses (Scylla's Prometheus port)
+- Sets `scrape_interval` and `evaluation_interval` to 20s
+
+### Grafana provisioning
+
+CCM generates a Grafana provisioning config that:
+- Configures Prometheus as the default datasource pointing to `localhost:{prometheus_port}`
+- Enables anonymous admin access for local development
+- Optionally mounts dashboards from a scylla-monitoring checkout
+
+### Topology change hooks
+
+In automatic mode, a lightweight hook (`_notify_topology_change()`) fires after
+every topology mutation:
+
+| Operation | When hook fires |
+|---|---|
+| `cluster.start()` | After all nodes are UP |
+| `cluster.stop()` | Monitoring stopped before nodes shut down |
+| `node.start()` | After the node is UP |
+| `node.stop()` | After the node is DOWN |
+| `cluster.add(node)` | After the node is registered |
+| `cluster.remove(node)` | After the node is removed |
+| `node.decommission()` | After decommission completes |
+
+The hook is a no-op when automatic mode is disabled or monitoring is not running.
+
+### Configuration persistence
+
+Monitoring settings are stored in the existing `cluster.conf` YAML file:
+
+```yaml
+monitoring_enabled: true
+monitoring_dir: /path/to/scylla-monitoring
+grafana_port: 3000
+prometheus_port: 9090
+alertmanager_port: 9093
+```
+
+On `ClusterFactory.load()`, these fields are restored. The monitoring stack
+itself is **not** auto-started on load — it starts when `cluster.start()` is
+called (if `monitoring_enabled` is true) or when the user runs
+`ccm monitoring start`.
+
+### Directory structure
+
+```
+~/.ccm/<cluster>/
+├── cluster.conf                          # monitoring_enabled, ports, etc.
+├── node1/
+├── node2/
+└── monitoring/                           # created on first monitoring start
+    ├── prometheus/
+    │   ├── prometheus.yml                # auto-generated Prometheus config
+    │   └── targets/
+    │       └── scylla_servers.yml        # auto-generated, watched by Prometheus
+    ├── grafana/
+    │   └── provisioning/
+    │       └── datasources/
+    │           └── prometheus.yml        # auto-generated Grafana datasource
+    └── data/
+        └── prometheus_data/              # persistent Prometheus TSDB data
+```
+
+## Programmatic Usage
+
+```python
+from ccmlib.scylla_cluster import ScyllaCluster
+from ccmlib.scylla_monitoring import MonitoringStack
+
+# Create cluster with monitoring enabled
+cluster = ScyllaCluster('.', 'test', version='release:2024.2')
+cluster.monitoring_enabled = True
+cluster.populate(3).start()
+# monitoring is now running, targets auto-update
+
+# Or start monitoring manually (no scylla-monitoring checkout needed)
+stack = MonitoringStack(cluster)
+stack.start()                 # blocks until healthy
+print(stack.grafana_url())    # http://localhost:3000
+print(stack.prometheus_url()) # http://localhost:9090
+
+# With custom ports for multi-cluster setups
+ports = MonitoringStack.default_ports(cluster_id=1)
+stack = MonitoringStack(cluster, **ports)
+stack.start()
+print(stack.grafana_url())    # http://localhost:3010
+
+# After topology changes, sync manually
+stack.update_targets()
+
+# Stop
+stack.stop()
+```
+
+## Edge Cases
+
+- **Port conflicts**: Ports are auto-assigned from cluster ID. Use explicit
+  `--grafana-port` / `--prometheus-port` / `--alertmanager-port` to override.
+- **Multiple clusters**: Each cluster's containers are named
+  `ccm-{cluster_name}-{service}`, preventing conflicts.
+- **Docker not available**: `docker run` fails with a clear error.
+- **Prometheus scraping delay**: After targets are written, Prometheus discovers
+  them within seconds but the first scrape may take up to `scrape_interval`
+  (default 20s).
+- **Cluster loaded from disk**: `monitoring_enabled` and ports are restored,
+  but monitoring is not auto-started until `cluster.start()` or
+  `ccm monitoring start`. If containers from a previous session are still
+  running, `ccm monitoring status` detects and reconnects them.
+- **Monitoring failures in automatic mode**: Logged as warnings, never fail the
+  cluster operation. Monitoring is auxiliary.
+- **scylla-monitoring dir not required**: Basic monitoring works without a
+  scylla-monitoring checkout. The checkout is only needed for importing
+  pre-built Grafana dashboards.

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@ localhost.";
       prepare_python_requirements = python: python.withPackages (ps: with ps; [
         pytest
         ruamel-yaml
+        pyyaml
         psutil
         six
         requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "ruamel-yaml",
+    "pyyaml",
     "psutil",
     "requests",
     "packaging",
@@ -66,7 +67,8 @@ markers = [
   "reloc: Run tests with relocatable packages",
   "cassandra: Run tests with cassandra binaries",
   "repo_tests: Run test for testing get versions",
-  "slow: Run slow tests that take longer to execute"
+  "slow: Run slow tests that take longer to execute",
+  "integration: Slow integration tests requiring Docker and real Scylla"
 ]
 filterwarnings = ["error", "ignore::ResourceWarning"]
 

--- a/tests/test_add_node_without_datacenter.py
+++ b/tests/test_add_node_without_datacenter.py
@@ -35,11 +35,18 @@ def mock_cluster(temp_dir):
     cluster._Cluster__log_level = 'INFO'
     cluster._debug = []
     cluster._trace = []
-    
+    cluster.monitoring_enabled = False
+    cluster.monitoring_stack = None
+    cluster.monitoring_dir = None
+    cluster.grafana_port = 3000
+    cluster.prometheus_port = 9090
+    cluster.alertmanager_port = 9093
+
     # Mock methods
     cluster._update_config = Mock()
     cluster.debug = Mock()
-    
+    cluster.warning = Mock()
+
     return cluster
 
 

--- a/tests/test_monitoring_integration.py
+++ b/tests/test_monitoring_integration.py
@@ -1,0 +1,497 @@
+"""Integration tests for the monitoring stack with a real Scylla cluster.
+
+Requires:
+  - Docker daemon running
+  - prom/prometheus, grafana/grafana, prom/alertmanager images available
+  - A Scylla relocatable version cached or downloadable
+
+Run with:
+  python -m pytest tests/test_monitoring_integration.py -v -s
+
+These tests are slow (cluster startup) and require Docker, so they're
+marked with @pytest.mark.integration.
+"""
+
+import json
+import os
+import subprocess
+import time
+import urllib.request
+import urllib.parse
+import urllib.error
+
+import pytest
+
+from ccmlib.scylla_cluster import ScyllaCluster
+from ccmlib.scylla_monitoring import MonitoringStack
+from ccmlib import common
+
+
+SCYLLA_VERSION = os.environ.get("SCYLLA_VERSION", "release:6.2.3")
+CLUSTER_ID = 5  # Use high ID to avoid port conflicts with anything running
+
+
+def docker_available():
+    try:
+        r = subprocess.run(['docker', 'info'], capture_output=True, timeout=5)
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def images_available():
+    try:
+        for image in ('prom/prometheus', 'grafana/grafana', 'prom/alertmanager'):
+            r = subprocess.run(
+                ['docker', 'image', 'inspect', image],
+                capture_output=True, timeout=5)
+            if r.returncode != 0:
+                return False
+        return True
+    except Exception:
+        return False
+
+
+def http_get_json(url, timeout=2):
+    """GET a URL and parse JSON response. Returns None on failure."""
+    try:
+        req = urllib.request.Request(url, method='GET')
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except Exception:
+        return None
+
+
+def http_post_json(url, body, timeout=5):
+    """POST JSON to a URL and parse JSON response. Returns None on failure."""
+    try:
+        data = json.dumps(body).encode()
+        req = urllib.request.Request(
+            url, data=data, method='POST',
+            headers={'Content-Type': 'application/json'})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except Exception:
+        return None
+
+
+def http_ok(url, timeout=2):
+    """Check if a URL returns 200."""
+    try:
+        req = urllib.request.Request(url, method='GET')
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
+def wait_for(predicate, timeout=30, interval=1, msg="condition"):
+    """Poll predicate() until True or timeout."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    raise TimeoutError(f"Timed out waiting for {msg} after {timeout}s")
+
+
+def container_exists(name):
+    """Check if a Docker container exists (running or stopped)."""
+    r = subprocess.run(
+        ['docker', 'ps', '-a', '-q', '-f', f'name=^{name}$'],
+        capture_output=True, text=True, timeout=5)
+    return bool(r.stdout.strip())
+
+
+def container_running(name):
+    """Check if a Docker container is running."""
+    r = subprocess.run(
+        ['docker', 'ps', '-q', '-f', f'name=^{name}$'],
+        capture_output=True, text=True, timeout=5)
+    return bool(r.stdout.strip())
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not docker_available(), reason="Docker not available"),
+    pytest.mark.skipif(not images_available(), reason="Docker images not pulled"),
+]
+
+
+@pytest.fixture(scope="module")
+def cluster_dir(tmp_path_factory):
+    return str(tmp_path_factory.mktemp("ccm_monitoring_test"))
+
+
+@pytest.fixture(scope="module")
+def ports():
+    return MonitoringStack.default_ports(CLUSTER_ID)
+
+
+@pytest.fixture(scope="module")
+def cluster(cluster_dir, ports):
+    """Create a real ScyllaCluster with monitoring enabled."""
+    cluster = ScyllaCluster(
+        cluster_dir, "mon_test",
+        version=SCYLLA_VERSION,
+        verbose=True,
+    )
+    cluster.set_id(CLUSTER_ID)
+    cluster.set_ipprefix(f'127.0.{CLUSTER_ID}.')
+    cluster.monitoring_enabled = True
+    cluster.grafana_port = ports['grafana_port']
+    cluster.prometheus_port = ports['prometheus_port']
+    cluster.alertmanager_port = ports['alertmanager_port']
+    cluster.set_configuration_options(values={
+        'skip_wait_for_gossip_to_settle': 0,
+        'ring_delay_ms': 0,
+    })
+    cluster.populate(2)
+
+    yield cluster
+
+    # Final cleanup: nuke everything
+    try:
+        # Stop monitoring if still running
+        if cluster.monitoring_stack:
+            cluster.monitoring_stack.stop()
+        else:
+            # Force cleanup by name
+            for svc in ('prometheus', 'grafana', 'alertmanager'):
+                name = f'ccm-mon_test-{svc}'
+                subprocess.run(['docker', 'rm', '-f', name],
+                               capture_output=True, timeout=10)
+    except Exception:
+        pass  # Best-effort: test already finished, don't fail on cleanup
+    try:
+        cluster.stop(gently=False)
+    except Exception:
+        pass  # Best-effort: cluster may already be stopped
+    try:
+        common.rmdirs(cluster.get_path())
+    except Exception:
+        pass  # Best-effort: leftover dirs are acceptable
+
+
+class TestMonitoringLifecycle:
+    """Full lifecycle: start -> verify -> stop -> restart -> remove."""
+
+    def test_01_start_cluster_with_monitoring(self, cluster, ports):
+        """Start the cluster — monitoring should auto-start."""
+        cluster.start(
+            wait_for_binary_proto=True,
+            wait_other_notice=True,
+        )
+
+        # Monitoring should have been started by _ensure_monitoring_started
+        assert cluster.monitoring_stack is not None, \
+            "monitoring_stack should be set after start()"
+        assert cluster.monitoring_stack.is_running(), \
+            "monitoring stack should be running after cluster start"
+
+    def test_02_prometheus_is_healthy(self, ports):
+        """Prometheus should be up and ready."""
+        url = f"http://localhost:{ports['prometheus_port']}/-/ready"
+        assert wait_for(lambda: http_ok(url), timeout=10, msg="Prometheus ready")
+
+    def test_03_grafana_is_healthy(self, ports):
+        """Grafana should be up and healthy."""
+        url = f"http://localhost:{ports['grafana_port']}/api/health"
+        assert wait_for(lambda: http_ok(url), timeout=10, msg="Grafana healthy")
+
+    def test_04_alertmanager_is_healthy(self, ports):
+        """Alertmanager should be up and healthy."""
+        url = f"http://localhost:{ports['alertmanager_port']}/-/healthy"
+        assert wait_for(lambda: http_ok(url), timeout=15, msg="Alertmanager healthy")
+
+    def test_05_containers_have_correct_names(self, cluster):
+        """Docker containers should be named ccm-{cluster}-{service}."""
+        for svc in ('prometheus', 'grafana', 'alertmanager'):
+            name = f'ccm-{cluster.name}-{svc}'
+            assert container_running(name), \
+                f"Container {name} should be running"
+
+    def test_06_prometheus_has_targets(self, cluster, ports):
+        """Prometheus should have the cluster nodes as targets."""
+        url = f"http://localhost:{ports['prometheus_port']}/api/v1/targets"
+
+        def targets_found():
+            data = http_get_json(url)
+            if not data or data.get('status') != 'success':
+                return False
+            active = data.get('data', {}).get('activeTargets', [])
+            return len(active) >= 2  # We populated 2 nodes
+
+        assert wait_for(targets_found, timeout=30, interval=2,
+                        msg="Prometheus to discover targets")
+
+        # Verify the target addresses
+        data = http_get_json(url)
+        active = data['data']['activeTargets']
+        target_addrs = {t['labels'].get('instance', '') for t in active}
+        # Nodes should be on 127.0.{CLUSTER_ID}.x:9180
+        for addr in target_addrs:
+            assert f'127.0.{CLUSTER_ID}.' in addr, \
+                f"Target {addr} should be on 127.0.{CLUSTER_ID}.x"
+
+    def test_07_prometheus_scrapes_data(self, ports):
+        """Prometheus should actually scrape metrics from Scylla nodes."""
+        prom_url = f"http://localhost:{ports['prometheus_port']}"
+
+        def has_scylla_metrics():
+            # Query for a basic Scylla metric
+            url = f"{prom_url}/api/v1/query?query=up"
+            data = http_get_json(url)
+            if not data or data.get('status') != 'success':
+                return False
+            results = data.get('data', {}).get('result', [])
+            # At least one target should have been scraped
+            return any(r.get('value', [None, '0'])[1] == '1' for r in results)
+
+        assert wait_for(has_scylla_metrics, timeout=60, interval=3,
+                        msg="Prometheus to scrape Scylla metrics")
+
+    def test_08_grafana_has_prometheus_datasource(self, ports):
+        """Grafana should have Prometheus configured as a datasource."""
+        url = f"http://localhost:{ports['grafana_port']}/api/datasources"
+        data = http_get_json(url)
+        assert data is not None, "Failed to query Grafana datasources API"
+        assert len(data) >= 1, "Grafana should have at least 1 datasource"
+
+        prom_ds = [d for d in data if d.get('type') == 'prometheus']
+        assert len(prom_ds) >= 1, "Grafana should have a Prometheus datasource"
+        assert str(ports['prometheus_port']) in prom_ds[0].get('url', ''), \
+            "Datasource URL should point to our Prometheus port"
+
+    def test_08a_grafana_has_scylla_dashboards(self, ports):
+        """Grafana should have scylla-monitoring dashboards provisioned.
+
+        The monitoring stack auto-clones scylla-monitoring and generates
+        real dashboards from the templates (overview, cql, detailed, etc.).
+        Falls back to a single built-in overview if generation failed.
+        """
+        url = f"http://localhost:{ports['grafana_port']}/api/search?type=dash-db"
+
+        def dashboards_found():
+            data = http_get_json(url)
+            if not data:
+                return False
+            return len(data) >= 1
+
+        assert wait_for(dashboards_found, timeout=15, interval=2,
+                        msg="Grafana to load dashboards")
+
+        data = http_get_json(url)
+        titles = [d.get('title', '') for d in data]
+
+        # If generation from scylla-monitoring worked we get many dashboards;
+        # if it fell back we get at least the built-in overview.
+        assert len(data) >= 1, f"Should have at least 1 dashboard, found: {titles}"
+
+        # Fetch one dashboard and verify it has panels
+        uid = data[0].get('uid', '')
+        dash_url = f"http://localhost:{ports['grafana_port']}/api/dashboards/uid/{uid}"
+        dash_data = http_get_json(dash_url)
+        assert dash_data is not None, f"Failed to fetch dashboard {uid}"
+        panels = dash_data.get('dashboard', {}).get('panels', [])
+        assert len(panels) >= 1, \
+            f"Dashboard '{data[0].get('title')}' should have panels, got {len(panels)}"
+
+    def test_08a2_dashboard_datasources_resolve(self, ports):
+        """Every datasource referenced in dashboards must exist in Grafana.
+
+        This catches the 'Datasource prometheus not found' error that
+        occurs when generated dashboards reference a datasource name or
+        UID that doesn't match the provisioned datasource.
+        """
+        grafana = f"http://localhost:{ports['grafana_port']}"
+
+        # Get all provisioned datasources (name→uid, uid→name)
+        datasources = http_get_json(f"{grafana}/api/datasources")
+        assert datasources, "Failed to fetch datasources"
+        ds_by_name = {d['name']: d for d in datasources}
+        ds_by_uid = {d['uid']: d for d in datasources}
+
+        # Collect all datasource references from all dashboards
+        search = http_get_json(f"{grafana}/api/search?type=dash-db")
+        assert search, "No dashboards found"
+
+        def collect_ds_refs(obj, refs):
+            """Recursively collect all datasource values."""
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    if k == 'datasource' and v is not None:
+                        refs.append(v)
+                    else:
+                        collect_ds_refs(v, refs)
+            elif isinstance(obj, list):
+                for item in obj:
+                    collect_ds_refs(item, refs)
+
+        unresolved = []
+        for entry in search:
+            uid = entry.get('uid', '')
+            dash = http_get_json(f"{grafana}/api/dashboards/uid/{uid}")
+            if not dash:
+                continue
+            refs = []
+            collect_ds_refs(dash.get('dashboard', {}), refs)
+            for ref in refs:
+                if isinstance(ref, str):
+                    if ref not in ds_by_name:
+                        unresolved.append(
+                            f"Dashboard '{entry.get('title')}': "
+                            f"string ref '{ref}' not in datasources "
+                            f"{list(ds_by_name.keys())}")
+                elif isinstance(ref, dict):
+                    ds_uid = ref.get('uid')
+                    ds_type = ref.get('type', '')
+                    # Skip Grafana built-in datasources
+                    if ds_type == 'datasource':
+                        continue
+                    if ds_uid and ds_uid not in ds_by_uid:
+                        unresolved.append(
+                            f"Dashboard '{entry.get('title')}': "
+                            f"uid '{ds_uid}' (type={ds_type}) not in "
+                            f"datasources {list(ds_by_uid.keys())}")
+
+        assert not unresolved, (
+            f"Found {len(unresolved)} unresolved datasource references:\n"
+            + "\n".join(unresolved[:10])
+        )
+
+    def test_08b_grafana_dashboards_have_data(self, cluster, ports):
+        """Grafana dashboard panels should return actual Scylla data.
+
+        Queries key metrics through Grafana's datasource proxy, proving
+        the full pipeline: Scylla nodes → Prometheus scrape → Grafana.
+        """
+        grafana = f"http://localhost:{ports['grafana_port']}"
+
+        # Get the Prometheus datasource UID and numeric ID
+        datasources = http_get_json(f"{grafana}/api/datasources")
+        assert datasources, "Failed to fetch Grafana datasources"
+        prom_ds = [d for d in datasources if d.get('type') == 'prometheus']
+        assert prom_ds, "No Prometheus datasource found"
+        ds_id = prom_ds[0]['id']
+
+        # Fetch a dashboard and extract real PromQL expressions from panels
+        search = http_get_json(f"{grafana}/api/search?type=dash-db")
+        assert search, "No dashboards found in Grafana"
+
+        panel_queries = []
+        for dash_entry in search:
+            uid = dash_entry.get('uid', '')
+            dash_data = http_get_json(f"{grafana}/api/dashboards/uid/{uid}")
+            if not dash_data:
+                continue
+            for panel in dash_data.get('dashboard', {}).get('panels', []):
+                for target in panel.get('targets', []):
+                    expr = target.get('expr', '').strip()
+                    if expr:
+                        panel_queries.append((
+                            dash_entry.get('title', '?'),
+                            panel.get('title', '?'),
+                            expr,
+                        ))
+            if panel_queries:
+                break  # one dashboard is enough
+
+        assert panel_queries, "Could not extract any PromQL queries from dashboards"
+
+        # Query each expression through Grafana's datasource proxy.
+        # At least some panel queries must return data points.
+        proxy_base = f"{grafana}/api/datasources/proxy/{ds_id}"
+        queries_with_data = []
+
+        for dash_title, panel_title, expr in panel_queries:
+            url = f"{proxy_base}/api/v1/query?query={urllib.parse.quote(expr)}"
+            data = http_get_json(url, timeout=5)
+            if not data or data.get('status') != 'success':
+                continue
+            results = data.get('data', {}).get('result', [])
+            if results:
+                queries_with_data.append((panel_title, expr, len(results)))
+
+        assert len(queries_with_data) >= 1, (
+            f"No dashboard panel queries returned data. "
+            f"Tried {len(panel_queries)} queries from '{panel_queries[0][0]}'. "
+            f"Example query: {panel_queries[0][2]}"
+        )
+
+    def test_09_targets_file_matches_nodes(self, cluster):
+        """The targets YAML file should list the cluster's running nodes."""
+        targets_file = os.path.join(
+            cluster.get_path(), 'monitoring', 'prometheus',
+            'targets', 'scylla_servers.yml')
+        assert os.path.exists(targets_file), "Targets file should exist"
+
+        with open(targets_file) as f:
+            targets = json.load(f)
+
+        # Flatten all target addresses
+        all_addrs = []
+        for entry in targets:
+            all_addrs.extend(entry['targets'])
+
+        node_addrs = [n.address() for n in cluster.nodelist()]
+        assert sorted(all_addrs) == sorted(node_addrs), \
+            f"Targets {all_addrs} should match nodes {node_addrs}"
+
+    def test_10_stop_cluster_stops_monitoring(self, cluster, ports):
+        """Stopping the cluster should also stop monitoring."""
+        cluster.stop()
+
+        prom_url = f"http://localhost:{ports['prometheus_port']}/-/ready"
+        grafana_url = f"http://localhost:{ports['grafana_port']}/api/health"
+
+        # Wait for containers to actually stop
+        def monitoring_stopped():
+            return not http_ok(prom_url) and not http_ok(grafana_url)
+
+        assert wait_for(monitoring_stopped, timeout=30,
+                        msg="monitoring to stop")
+
+        # Containers should be gone
+        for svc in ('prometheus', 'grafana', 'alertmanager'):
+            name = f'ccm-{cluster.name}-{svc}'
+            assert not container_running(name), \
+                f"Container {name} should not be running after stop"
+
+    def test_11_start_cluster_restarts_monitoring(self, cluster, ports):
+        """Starting the cluster again should restart monitoring."""
+        cluster.start(
+            wait_for_binary_proto=True,
+            wait_other_notice=True,
+        )
+
+        assert cluster.monitoring_stack is not None
+        assert cluster.monitoring_stack.is_running()
+
+        # Verify services are back up
+        prom_url = f"http://localhost:{ports['prometheus_port']}/-/ready"
+        grafana_url = f"http://localhost:{ports['grafana_port']}/api/health"
+        assert wait_for(lambda: http_ok(prom_url), timeout=30,
+                        msg="Prometheus ready after restart")
+        assert wait_for(lambda: http_ok(grafana_url), timeout=30,
+                        msg="Grafana ready after restart")
+
+    def test_12_remove_cluster_cleans_up_monitoring(self, cluster, ports):
+        """Removing the cluster should stop and remove monitoring containers."""
+        cluster_name = cluster.name
+
+        # Remove the whole cluster (stop + delete)
+        cluster.remove()
+
+        # All containers should be gone
+        for svc in ('prometheus', 'grafana', 'alertmanager'):
+            name = f'ccm-{cluster_name}-{svc}'
+            assert not container_running(name), \
+                f"Container {name} should be removed after cluster.remove()"
+            assert not container_exists(name), \
+                f"Container {name} should not exist after cluster.remove()"
+
+        # Monitoring endpoints should be unreachable
+        prom_url = f"http://localhost:{ports['prometheus_port']}/-/ready"
+        assert not http_ok(prom_url), \
+            "Prometheus should not be reachable after remove"

--- a/tests/test_scylla_monitoring.py
+++ b/tests/test_scylla_monitoring.py
@@ -1,0 +1,1888 @@
+"""Tests for the scylla-monitoring integration (MonitoringStack, targets, hooks, CLI)."""
+import json
+import os
+import socket
+import subprocess
+import pytest
+from unittest.mock import Mock, patch
+
+from ccmlib.scylla_monitoring import (
+    MonitoringStack, _resolve_monitoring_dir, _BUILTIN_DASHBOARDS,
+    _DATASOURCE_UID, _clone_monitoring_repo, _generate_dashboards,
+    _fix_dashboard_datasources, _postprocess_dashboards,
+    _is_port_available, _find_available_port,
+)
+from ccmlib.cluster import Cluster
+from ccmlib.node import Status
+
+
+class TestResolveMonitoringDir:
+    """Tests for the _resolve_monitoring_dir helper."""
+
+    def test_explicit_dir_exists(self, tmp_path):
+        d = str(tmp_path)
+        assert _resolve_monitoring_dir(d) == d
+
+    def test_explicit_dir_not_exists(self, monkeypatch):
+        monkeypatch.delenv('SCYLLA_MONITORING_DIR', raising=False)
+        with patch('os.path.expanduser', return_value='/nonexistent'):
+            assert _resolve_monitoring_dir('/nonexistent/path') is None
+
+    def test_env_var(self, tmp_path, monkeypatch):
+        d = str(tmp_path)
+        monkeypatch.setenv('SCYLLA_MONITORING_DIR', d)
+        assert _resolve_monitoring_dir() == d
+
+    def test_env_var_not_exists(self, monkeypatch):
+        monkeypatch.delenv('SCYLLA_MONITORING_DIR', raising=False)
+        with patch('os.path.expanduser', return_value='/nonexistent'):
+            assert _resolve_monitoring_dir() is None
+
+    def test_default_ccm_dir(self, tmp_path, monkeypatch):
+        default_dir = tmp_path / '.ccm' / 'scylla-monitoring'
+        default_dir.mkdir(parents=True)
+        monkeypatch.delenv('SCYLLA_MONITORING_DIR', raising=False)
+        with patch('os.path.expanduser', return_value=str(default_dir)):
+            assert _resolve_monitoring_dir() == str(default_dir)
+
+    def test_explicit_takes_priority_over_env(self, tmp_path, monkeypatch):
+        explicit = tmp_path / 'explicit'
+        explicit.mkdir()
+        env_dir = tmp_path / 'env'
+        env_dir.mkdir()
+        monkeypatch.setenv('SCYLLA_MONITORING_DIR', str(env_dir))
+        assert _resolve_monitoring_dir(str(explicit)) == str(explicit)
+
+    def test_cluster_dir(self, tmp_path, monkeypatch):
+        cluster_local = tmp_path / 'cluster' / 'scylla-monitoring'
+        cluster_local.mkdir(parents=True)
+        monkeypatch.delenv('SCYLLA_MONITORING_DIR', raising=False)
+        with patch('os.path.expanduser', return_value='/nonexistent'):
+            assert _resolve_monitoring_dir(cluster_dir=str(tmp_path / 'cluster')) == str(cluster_local)
+
+    def test_cluster_dir_takes_priority_over_default(self, tmp_path, monkeypatch):
+        cluster_local = tmp_path / 'cluster' / 'scylla-monitoring'
+        cluster_local.mkdir(parents=True)
+        default_dir = tmp_path / '.ccm' / 'scylla-monitoring'
+        default_dir.mkdir(parents=True)
+        monkeypatch.delenv('SCYLLA_MONITORING_DIR', raising=False)
+        with patch('os.path.expanduser', return_value=str(default_dir)):
+            assert _resolve_monitoring_dir(cluster_dir=str(tmp_path / 'cluster')) == str(cluster_local)
+
+    def test_none_when_nothing_available(self, monkeypatch):
+        monkeypatch.delenv('SCYLLA_MONITORING_DIR', raising=False)
+        with patch('os.path.expanduser', return_value='/nonexistent'):
+            assert _resolve_monitoring_dir() is None
+
+
+class TestDefaultPorts:
+    """Tests for MonitoringStack.default_ports."""
+
+    def test_default_cluster_id_0(self):
+        ports = MonitoringStack.default_ports(0)
+        assert ports == {
+            'grafana_port': 3000,
+            'prometheus_port': 9090,
+            'alertmanager_port': 9093,
+        }
+
+    def test_cluster_id_1(self):
+        ports = MonitoringStack.default_ports(1)
+        assert ports == {
+            'grafana_port': 3010,
+            'prometheus_port': 9100,
+            'alertmanager_port': 9103,
+        }
+
+    def test_cluster_id_5(self):
+        ports = MonitoringStack.default_ports(5)
+        assert ports == {
+            'grafana_port': 3050,
+            'prometheus_port': 9140,
+            'alertmanager_port': 9143,
+        }
+
+    def test_two_clusters_no_overlap(self):
+        ports_0 = MonitoringStack.default_ports(0)
+        ports_1 = MonitoringStack.default_ports(1)
+        all_ports_0 = set(ports_0.values())
+        all_ports_1 = set(ports_1.values())
+        assert not all_ports_0.intersection(all_ports_1)
+
+
+class TestGenerateTargetsYaml:
+    """Tests for MonitoringStack._generate_targets_yaml."""
+
+    def _make_mock_cluster(self, nodes_config):
+        """Create a mock cluster with the given node configuration.
+
+        nodes_config: list of (address, status, data_center) tuples
+        """
+        cluster = Mock()
+        cluster.name = 'test_cluster'
+        cluster.get_path.return_value = '/tmp/test_cluster'
+
+        mock_nodes = []
+        for addr, status, dc in nodes_config:
+            node = Mock()
+            node.address.return_value = addr
+            node.status = status
+            node.data_center = dc
+            node.is_running.return_value = status in (Status.UP, Status.DECOMMISSIONED)
+            mock_nodes.append(node)
+
+        cluster.nodelist.return_value = mock_nodes
+        return cluster
+
+    def test_single_dc_multiple_nodes(self):
+        cluster = self._make_mock_cluster([
+            ('127.0.0.1', Status.UP, 'dc1'),
+            ('127.0.0.2', Status.UP, 'dc1'),
+            ('127.0.0.3', Status.UP, 'dc1'),
+        ])
+        stack = MonitoringStack(cluster)
+        targets = stack._generate_targets_yaml()
+
+        assert len(targets) == 1
+        assert targets[0]['labels']['cluster'] == 'test_cluster'
+        assert targets[0]['labels']['dc'] == 'dc1'
+        assert set(targets[0]['targets']) == {'127.0.0.1', '127.0.0.2', '127.0.0.3'}
+
+    def test_multi_dc(self):
+        cluster = self._make_mock_cluster([
+            ('127.0.0.1', Status.UP, 'dc1'),
+            ('127.0.0.2', Status.UP, 'dc1'),
+            ('127.0.0.3', Status.UP, 'dc2'),
+        ])
+        stack = MonitoringStack(cluster)
+        targets = stack._generate_targets_yaml()
+
+        assert len(targets) == 2
+        dc_map = {t['labels']['dc']: t for t in targets}
+        assert set(dc_map['dc1']['targets']) == {'127.0.0.1', '127.0.0.2'}
+        assert dc_map['dc2']['targets'] == ['127.0.0.3']
+
+    def test_excludes_down_nodes(self):
+        cluster = self._make_mock_cluster([
+            ('127.0.0.1', Status.UP, 'dc1'),
+            ('127.0.0.2', Status.DOWN, 'dc1'),
+            ('127.0.0.3', Status.UP, 'dc1'),
+        ])
+        stack = MonitoringStack(cluster)
+        targets = stack._generate_targets_yaml()
+
+        assert len(targets) == 1
+        assert set(targets[0]['targets']) == {'127.0.0.1', '127.0.0.3'}
+
+    def test_excludes_uninitialized_nodes(self):
+        cluster = self._make_mock_cluster([
+            ('127.0.0.1', Status.UP, 'dc1'),
+            ('127.0.0.2', Status.UNINITIALIZED, 'dc1'),
+        ])
+        stack = MonitoringStack(cluster)
+        targets = stack._generate_targets_yaml()
+
+        assert len(targets) == 1
+        assert targets[0]['targets'] == ['127.0.0.1']
+
+    def test_includes_decommissioned_nodes(self):
+        cluster = self._make_mock_cluster([
+            ('127.0.0.1', Status.UP, 'dc1'),
+            ('127.0.0.2', Status.DECOMMISSIONED, 'dc1'),
+        ])
+        stack = MonitoringStack(cluster)
+        targets = stack._generate_targets_yaml()
+
+        assert len(targets) == 1
+        assert set(targets[0]['targets']) == {'127.0.0.1', '127.0.0.2'}
+
+    def test_empty_cluster(self):
+        cluster = self._make_mock_cluster([])
+        stack = MonitoringStack(cluster)
+        targets = stack._generate_targets_yaml()
+
+        assert targets == []
+
+    def test_all_nodes_down(self):
+        cluster = self._make_mock_cluster([
+            ('127.0.0.1', Status.DOWN, 'dc1'),
+            ('127.0.0.2', Status.DOWN, 'dc1'),
+        ])
+        stack = MonitoringStack(cluster)
+        targets = stack._generate_targets_yaml()
+
+        assert targets == []
+
+    def test_default_datacenter(self):
+        """Nodes with data_center=None should use 'datacenter1'."""
+        cluster = self._make_mock_cluster([
+            ('127.0.0.1', Status.UP, None),
+            ('127.0.0.2', Status.UP, None),
+        ])
+        stack = MonitoringStack(cluster)
+        targets = stack._generate_targets_yaml()
+
+        assert len(targets) == 1
+        assert targets[0]['labels']['dc'] == 'datacenter1'
+
+    def test_mixed_statuses_and_dcs(self):
+        cluster = self._make_mock_cluster([
+            ('127.0.0.1', Status.UP, 'dc1'),
+            ('127.0.0.2', Status.DOWN, 'dc1'),
+            ('127.0.0.3', Status.UP, 'dc2'),
+            ('127.0.0.4', Status.DECOMMISSIONED, 'dc2'),
+            ('127.0.0.5', Status.UNINITIALIZED, 'dc1'),
+        ])
+        stack = MonitoringStack(cluster)
+        targets = stack._generate_targets_yaml()
+
+        assert len(targets) == 2
+        dc_map = {t['labels']['dc']: t for t in targets}
+        assert dc_map['dc1']['targets'] == ['127.0.0.1']
+        assert set(dc_map['dc2']['targets']) == {'127.0.0.3', '127.0.0.4'}
+
+
+class TestWriteTargetsFile:
+    """Tests for MonitoringStack._write_targets_file."""
+
+    def test_atomic_write(self, tmp_path):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        stack = MonitoringStack(cluster)
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        targets = [
+            {"targets": ["127.0.0.1"], "labels": {"cluster": "test", "dc": "dc1"}}
+        ]
+        stack._write_targets_file(targets)
+
+        targets_file = tmp_path / 'monitoring' / 'prometheus' / 'targets' / 'scylla_servers.yml'
+        assert targets_file.exists()
+
+        with open(targets_file) as f:
+            data = json.load(f)
+        assert data == targets
+
+    def test_overwrite_existing(self, tmp_path):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        stack = MonitoringStack(cluster)
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        # Write initial targets
+        initial = [{"targets": ["127.0.0.1"], "labels": {"cluster": "test", "dc": "dc1"}}]
+        stack._write_targets_file(initial)
+
+        # Overwrite with updated targets
+        updated = [
+            {"targets": ["127.0.0.1", "127.0.0.2"], "labels": {"cluster": "test", "dc": "dc1"}}
+        ]
+        stack._write_targets_file(updated)
+
+        targets_file = tmp_path / 'monitoring' / 'prometheus' / 'targets' / 'scylla_servers.yml'
+        with open(targets_file) as f:
+            data = json.load(f)
+        assert data == updated
+
+
+class TestUpdateTargets:
+    """Tests for MonitoringStack.update_targets (end-to-end generate + write)."""
+
+    def test_update_targets_writes_correct_file(self, tmp_path):
+        cluster = Mock()
+        cluster.name = 'mytest'
+        cluster.get_path.return_value = str(tmp_path)
+
+        node1 = Mock()
+        node1.address.return_value = '127.0.0.1'
+        node1.status = Status.UP
+        node1.data_center = 'dc1'
+
+        node2 = Mock()
+        node2.address.return_value = '127.0.0.2'
+        node2.status = Status.UP
+        node2.data_center = 'dc1'
+
+        cluster.nodelist.return_value = [node1, node2]
+
+        stack = MonitoringStack(cluster)
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        stack.update_targets()
+
+        targets_file = tmp_path / 'monitoring' / 'prometheus' / 'targets' / 'scylla_servers.yml'
+        with open(targets_file) as f:
+            data = json.load(f)
+
+        assert len(data) == 1
+        assert data[0]['labels']['cluster'] == 'mytest'
+        assert data[0]['labels']['dc'] == 'dc1'
+        assert set(data[0]['targets']) == {'127.0.0.1', '127.0.0.2'}
+
+
+class TestWritePrometheusConfig:
+    """Tests for MonitoringStack._write_prometheus_config."""
+
+    def test_writes_config_file(self, tmp_path):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        stack = MonitoringStack(cluster)
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        stack._write_prometheus_config()
+
+        config_file = tmp_path / 'monitoring' / 'prometheus' / 'prometheus.yml'
+        assert config_file.exists()
+
+        content = config_file.read_text()
+        assert 'scrape_interval: 20s' in content
+        assert 'scylla_servers.yml' in content
+        assert '9180' in content
+
+    def test_creates_directory_if_needed(self, tmp_path):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        stack = MonitoringStack(cluster)
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        stack._write_prometheus_config()
+
+        assert (tmp_path / 'monitoring' / 'prometheus').is_dir()
+
+
+class TestWriteGrafanaProvisioning:
+    """Tests for MonitoringStack._write_grafana_provisioning."""
+
+    def test_writes_datasource_config(self, tmp_path):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        stack = MonitoringStack(cluster, prometheus_port=9100)
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        stack._write_grafana_provisioning()
+
+        datasource_file = (tmp_path / 'monitoring' / 'grafana' /
+                          'provisioning' / 'datasources' / 'prometheus.yml')
+        assert datasource_file.exists()
+
+        content = datasource_file.read_text()
+        assert 'http://localhost:9100' in content
+        assert 'isDefault: true' in content
+        assert _DATASOURCE_UID in content
+
+    def test_always_writes_dashboard_provisioning(self, tmp_path):
+        """Dashboard provisioning is always created (built-in dashboards)."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        stack = MonitoringStack(cluster)
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        stack._write_grafana_provisioning()
+
+        dashboard_config = (tmp_path / 'monitoring' / 'grafana' /
+                           'provisioning' / 'dashboards' / 'dashboards.yml')
+        assert dashboard_config.exists()
+
+    def test_writes_builtin_dashboard_files(self, tmp_path):
+        """Built-in Scylla dashboards should be written when generation is unavailable."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        stack = MonitoringStack(cluster)
+        stack._working_dir = str(tmp_path / 'monitoring')
+        stack.monitoring_dir = None  # Force no monitoring dir
+
+        stack._write_grafana_provisioning()
+
+        dashboards_dir = tmp_path / 'monitoring' / 'grafana' / 'dashboards'
+        assert dashboards_dir.is_dir()
+
+        # Should have at least the overview dashboard
+        overview = dashboards_dir / 'scylla-overview.json'
+        assert overview.exists()
+
+        data = json.loads(overview.read_text())
+        assert data['title'] == 'Scylla Overview'
+        assert len(data['panels']) >= 4
+
+    def test_generation_called_when_monitoring_dir_set(self, tmp_path):
+        """When monitoring_dir is set, _generate_dashboards should be called."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        monitoring_dir = tmp_path / 'scylla-monitoring'
+        monitoring_dir.mkdir()
+
+        stack = MonitoringStack(cluster, monitoring_dir=str(monitoring_dir))
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        with patch('ccmlib.scylla_monitoring._generate_dashboards',
+                   return_value=3) as mock_gen:
+            stack._write_grafana_provisioning()
+
+        mock_gen.assert_called_once_with(
+            str(monitoring_dir),
+            str(tmp_path / 'monitoring' / 'grafana' / 'dashboards'))
+
+
+class TestBuiltinDashboards:
+    """Tests for the built-in Scylla dashboard definitions."""
+
+    def test_builtin_dashboards_are_valid_json(self):
+        """Each built-in dashboard should produce valid JSON with required fields."""
+        for filename, dashboard_fn in _BUILTIN_DASHBOARDS.items():
+            assert filename.endswith('.json')
+            dashboard = dashboard_fn()
+            assert isinstance(dashboard, dict)
+            assert 'title' in dashboard
+            assert 'panels' in dashboard
+            assert 'uid' in dashboard
+            # Round-trip through JSON to verify serialisability
+            json.loads(json.dumps(dashboard))
+
+    def test_overview_dashboard_has_key_panels(self):
+        """The overview dashboard should cover the most important metrics."""
+        dashboard = _BUILTIN_DASHBOARDS['scylla-overview.json']()
+        panel_titles = {p['title'] for p in dashboard['panels']}
+        assert 'CPU Utilization' in panel_titles
+        assert 'CQL Requests / sec' in panel_titles
+
+    def test_overview_dashboard_references_correct_datasource(self):
+        """All panels should reference the provisioned datasource UID."""
+        dashboard = _BUILTIN_DASHBOARDS['scylla-overview.json']()
+        for panel in dashboard['panels']:
+            for target in panel.get('targets', []):
+                ds = target.get('datasource', {})
+                assert ds.get('uid') == _DATASOURCE_UID, \
+                    f"Panel '{panel['title']}' should reference {_DATASOURCE_UID}"
+
+    def test_write_builtin_dashboards(self, tmp_path):
+        """_write_builtin_dashboards should create JSON files on disk."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        stack = MonitoringStack(cluster)
+        dest = str(tmp_path / 'dashboards')
+        os.makedirs(dest)
+        stack._write_builtin_dashboards(dest)
+
+        for filename in _BUILTIN_DASHBOARDS:
+            filepath = os.path.join(dest, filename)
+            assert os.path.exists(filepath)
+            with open(filepath) as f:
+                data = json.load(f)
+            assert 'panels' in data
+
+
+class TestCloneMonitoringRepo:
+    """Tests for _clone_monitoring_repo."""
+
+    def test_successful_clone(self, tmp_path):
+        target = str(tmp_path / 'scylla-monitoring')
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = Mock(returncode=0, stdout='', stderr='')
+            assert _clone_monitoring_repo(target) is True
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0:2] == ['git', 'clone']
+            assert '--depth' in cmd
+            assert target == cmd[-1]
+
+    def test_clone_failure(self, tmp_path):
+        target = str(tmp_path / 'scylla-monitoring')
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = Mock(returncode=128, stdout='', stderr='fatal')
+            assert _clone_monitoring_repo(target) is False
+
+    def test_git_not_installed(self, tmp_path):
+        target = str(tmp_path / 'scylla-monitoring')
+        with patch('subprocess.run', side_effect=FileNotFoundError):
+            assert _clone_monitoring_repo(target) is False
+
+    def test_clone_timeout(self, tmp_path):
+        target = str(tmp_path / 'scylla-monitoring')
+        with patch('subprocess.run', side_effect=subprocess.TimeoutExpired('git', 300)):
+            assert _clone_monitoring_repo(target) is False
+
+
+class TestGenerateDashboards:
+    """Tests for _generate_dashboards."""
+
+    def test_generates_from_templates(self, tmp_path):
+        """Should run make_dashboards.py for each .template.json file."""
+        monitoring_dir = tmp_path / 'scylla-monitoring'
+        monitoring_dir.mkdir()
+        (monitoring_dir / 'make_dashboards.py').write_text('# script')
+        grafana_dir = monitoring_dir / 'grafana'
+        grafana_dir.mkdir()
+        (grafana_dir / 'types.json').write_text('{}')
+        (grafana_dir / 'scylla-overview.template.json').write_text('{}')
+        (grafana_dir / 'scylla-cql.template.json').write_text('{}')
+        (grafana_dir / 'not-a-template.json').write_text('{}')
+
+        output = str(tmp_path / 'output')
+
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = Mock(returncode=0, stdout='', stderr='')
+            count = _generate_dashboards(str(monitoring_dir), output)
+
+        # Should have called for 2 template files, not the non-template
+        assert count == 2
+        assert mock_run.call_count == 2
+
+    def test_returns_zero_on_missing_script(self, tmp_path):
+        """Should return 0 if make_dashboards.py is missing."""
+        monitoring_dir = tmp_path / 'scylla-monitoring'
+        monitoring_dir.mkdir()
+        (monitoring_dir / 'grafana').mkdir()
+        (monitoring_dir / 'grafana' / 'types.json').write_text('{}')
+        # No make_dashboards.py
+
+        count = _generate_dashboards(str(monitoring_dir), str(tmp_path / 'out'))
+        assert count == 0
+
+    def test_partial_failure(self, tmp_path):
+        """Should count only successful generations."""
+        monitoring_dir = tmp_path / 'scylla-monitoring'
+        monitoring_dir.mkdir()
+        (monitoring_dir / 'make_dashboards.py').write_text('# script')
+        grafana_dir = monitoring_dir / 'grafana'
+        grafana_dir.mkdir()
+        (grafana_dir / 'types.json').write_text('{}')
+        (grafana_dir / 'a.template.json').write_text('{}')
+        (grafana_dir / 'b.template.json').write_text('{}')
+
+        call_count = [0]
+
+        def side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return Mock(returncode=0, stdout='', stderr='')
+            return Mock(returncode=1, stdout='', stderr='error')
+
+        with patch('subprocess.run', side_effect=side_effect):
+            count = _generate_dashboards(str(monitoring_dir), str(tmp_path / 'out'))
+
+        assert count == 1
+
+
+class TestFixDashboardDatasources:
+    """Tests for _fix_dashboard_datasources and _postprocess_dashboards."""
+
+    def test_replaces_hardcoded_prometheus_uid(self):
+        dashboard = {
+            "panels": [{
+                "datasource": {"type": "prometheus", "uid": "P1809F7CD0C75ACF3"},
+                "targets": [{
+                    "datasource": {"type": "prometheus", "uid": "OLD_UID"},
+                    "expr": "up",
+                }],
+            }]
+        }
+        _fix_dashboard_datasources(dashboard)
+        assert dashboard["panels"][0]["datasource"] == {
+            "type": "prometheus", "uid": _DATASOURCE_UID}
+        assert dashboard["panels"][0]["targets"][0]["datasource"] == {
+            "type": "prometheus", "uid": _DATASOURCE_UID}
+
+    def test_converts_string_prometheus_to_uid_object(self):
+        """String 'prometheus' refs must become UID objects for Grafana."""
+        dashboard = {
+            "panels": [{"datasource": "prometheus"}],
+            "templating": {"list": [{"datasource": "prometheus", "name": "cluster"}]},
+        }
+        _fix_dashboard_datasources(dashboard)
+        expected = {"type": "prometheus", "uid": _DATASOURCE_UID}
+        assert dashboard["panels"][0]["datasource"] == expected
+        assert dashboard["templating"]["list"][0]["datasource"] == expected
+
+    def test_adds_uid_to_prometheus_without_uid(self):
+        dashboard = {
+            "panels": [{"datasource": {"type": "prometheus"}}]
+        }
+        _fix_dashboard_datasources(dashboard)
+        assert dashboard["panels"][0]["datasource"] == {
+            "type": "prometheus", "uid": _DATASOURCE_UID}
+
+    def test_leaves_non_prometheus_datasource_alone(self):
+        dashboard = {
+            "panels": [{"datasource": {"type": "datasource", "uid": "grafana"}}]
+        }
+        _fix_dashboard_datasources(dashboard)
+        assert dashboard["panels"][0]["datasource"]["uid"] == "grafana"
+
+    def test_leaves_non_prometheus_string_datasource_alone(self):
+        dashboard = {"panels": [{"datasource": "loki"}]}
+        _fix_dashboard_datasources(dashboard)
+        assert dashboard["panels"][0]["datasource"] == "loki"
+
+    def test_leaves_null_datasource_alone(self):
+        dashboard = {"panels": [{"datasource": None}]}
+        _fix_dashboard_datasources(dashboard)
+        assert dashboard["panels"][0]["datasource"] is None
+
+    def test_postprocess_rewrites_files(self, tmp_path):
+        dash = {
+            "panels": [{
+                "datasource": "prometheus",
+                "targets": [{"datasource": {"type": "prometheus", "uid": "OLD"}}],
+            }],
+            "templating": {"list": [{"datasource": "prometheus"}]},
+        }
+        fpath = tmp_path / "test.json"
+        fpath.write_text(json.dumps(dash))
+
+        _postprocess_dashboards(str(tmp_path))
+
+        result = json.loads(fpath.read_text())
+        expected = {"type": "prometheus", "uid": _DATASOURCE_UID}
+        assert result["panels"][0]["datasource"] == expected
+        assert result["panels"][0]["targets"][0]["datasource"] == expected
+        assert result["templating"]["list"][0]["datasource"] == expected
+
+
+class TestEnsureMonitoringRepo:
+    """Tests for MonitoringStack._ensure_monitoring_repo."""
+
+    def test_uses_existing_repo(self, tmp_path):
+        """If the default dir already has grafana/, use it without cloning."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+        stack = MonitoringStack(cluster)
+        stack.monitoring_dir = None
+
+        fake_dir = tmp_path / 'default_monitoring'
+        (fake_dir / 'grafana').mkdir(parents=True)
+
+        with patch('ccmlib.scylla_monitoring._DEFAULT_MONITORING_DIR',
+                   str(fake_dir)):
+            stack._ensure_monitoring_repo()
+
+        assert stack.monitoring_dir == str(fake_dir)
+
+    def test_clones_when_no_repo(self, tmp_path):
+        """Should clone the repo when the default dir doesn't exist."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+        stack = MonitoringStack(cluster)
+        stack.monitoring_dir = None
+
+        fake_dir = str(tmp_path / 'nonexistent')
+
+        with patch('ccmlib.scylla_monitoring._DEFAULT_MONITORING_DIR', fake_dir):
+            with patch('ccmlib.scylla_monitoring._clone_monitoring_repo',
+                       return_value=True) as mock_clone:
+                stack._ensure_monitoring_repo()
+
+        mock_clone.assert_called_once_with(fake_dir)
+        assert stack.monitoring_dir == fake_dir
+
+    def test_fallback_when_clone_fails(self, tmp_path):
+        """monitoring_dir stays None when clone fails."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+        stack = MonitoringStack(cluster)
+        stack.monitoring_dir = None
+
+        fake_dir = str(tmp_path / 'nonexistent')
+
+        with patch('ccmlib.scylla_monitoring._DEFAULT_MONITORING_DIR', fake_dir):
+            with patch('ccmlib.scylla_monitoring._clone_monitoring_repo',
+                       return_value=False):
+                stack._ensure_monitoring_repo()
+
+        assert stack.monitoring_dir is None
+
+
+class TestGrafanaProvisioningWithGeneration:
+    """Tests for dashboard generation in _write_grafana_provisioning."""
+
+    def test_uses_generated_dashboards_when_available(self, tmp_path):
+        """Should prefer generated dashboards over built-in."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        stack = MonitoringStack(cluster)
+        stack._working_dir = str(tmp_path / 'monitoring')
+        stack.monitoring_dir = str(tmp_path / 'fake-monitoring')
+
+        with patch('ccmlib.scylla_monitoring._generate_dashboards',
+                   return_value=5) as mock_gen:
+            stack._write_grafana_provisioning()
+
+        mock_gen.assert_called_once()
+        # Verify dashboard provisioning config was created
+        config = (tmp_path / 'monitoring' / 'grafana' /
+                  'provisioning' / 'dashboards' / 'dashboards.yml')
+        assert config.exists()
+
+    def test_falls_back_to_builtin_when_generation_fails(self, tmp_path):
+        """Should write built-in dashboards when generation returns 0."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        stack = MonitoringStack(cluster)
+        stack._working_dir = str(tmp_path / 'monitoring')
+        stack.monitoring_dir = str(tmp_path / 'fake-monitoring')
+
+        with patch('ccmlib.scylla_monitoring._generate_dashboards',
+                   return_value=0):
+            stack._write_grafana_provisioning()
+
+        # Built-in dashboards should exist
+        overview = (tmp_path / 'monitoring' / 'grafana' /
+                    'dashboards' / 'scylla-overview.json')
+        assert overview.exists()
+        data = json.loads(overview.read_text())
+        assert data['title'] == 'Scylla Overview'
+
+    def test_falls_back_to_builtin_when_no_monitoring_dir(self, tmp_path):
+        """Should write built-in dashboards when monitoring_dir is None."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+
+        stack = MonitoringStack(cluster)
+        stack._working_dir = str(tmp_path / 'monitoring')
+        stack.monitoring_dir = None
+
+        stack._write_grafana_provisioning()
+
+        overview = (tmp_path / 'monitoring' / 'grafana' /
+                    'dashboards' / 'scylla-overview.json')
+        assert overview.exists()
+
+
+class TestContainerManagement:
+    """Tests for Docker container start/stop operations."""
+
+    def test_container_names(self):
+        cluster = Mock()
+        cluster.name = 'mycluster'
+        cluster.get_path.return_value = '/tmp/test'
+        stack = MonitoringStack(cluster)
+
+        assert stack._container_name('prometheus') == 'ccm-mycluster-prometheus'
+        assert stack._container_name('grafana') == 'ccm-mycluster-grafana'
+        assert stack._container_name('alertmanager') == 'ccm-mycluster-alertmanager'
+
+    def test_stop_calls_docker_stop_and_rm(self):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = '/tmp/test'
+        stack = MonitoringStack(cluster)
+
+        with patch('subprocess.run') as mock_run:
+            stack.stop()
+
+            # Should call docker stop + docker rm for each of 3 services
+            assert mock_run.call_count == 6
+            calls = mock_run.call_args_list
+
+            # Check stop calls
+            stop_calls = [c for c in calls if c[0][0][1] == 'stop']
+            assert len(stop_calls) == 3
+            stopped_names = {c[0][0][2] for c in stop_calls}
+            assert stopped_names == {
+                'ccm-test-prometheus',
+                'ccm-test-grafana',
+                'ccm-test-alertmanager',
+            }
+
+            # Check rm calls
+            rm_calls = [c for c in calls if c[0][0][1] == 'rm']
+            assert len(rm_calls) == 3
+            removed_names = {c[0][0][3] for c in rm_calls}
+            assert removed_names == {
+                'ccm-test-prometheus',
+                'ccm-test-grafana',
+                'ccm-test-alertmanager',
+            }
+
+    def test_start_prometheus_calls_docker_run(self, tmp_path):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+        stack = MonitoringStack(cluster, prometheus_port=9100)
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        # Create required files
+        config_dir = tmp_path / 'monitoring' / 'prometheus'
+        config_dir.mkdir(parents=True)
+        (config_dir / 'prometheus.yml').write_text('global: {}')
+
+        targets_dir = str(config_dir / 'targets')
+        data_dir = str(tmp_path / 'monitoring' / 'data' / 'prometheus_data')
+        os.makedirs(targets_dir, exist_ok=True)
+        os.makedirs(data_dir, exist_ok=True)
+
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = Mock(returncode=0, stdout='', stderr='')
+            stack._start_prometheus(targets_dir, data_dir)
+
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0:3] == ['docker', 'run', '-d']
+            assert '--net=host' in cmd
+            assert '--web.listen-address=:9100' in cmd
+            assert 'prom/prometheus' in cmd
+
+    def test_start_grafana_calls_docker_run(self, tmp_path):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+        stack = MonitoringStack(cluster, grafana_port=3010)
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        provisioning_dir = tmp_path / 'monitoring' / 'grafana' / 'provisioning'
+        provisioning_dir.mkdir(parents=True)
+        dashboards_dir = tmp_path / 'monitoring' / 'grafana' / 'dashboards'
+        dashboards_dir.mkdir(parents=True)
+
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = Mock(returncode=0, stdout='', stderr='')
+            stack._start_grafana()
+
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0:3] == ['docker', 'run', '-d']
+            assert '--net=host' in cmd
+            assert 'GF_SERVER_HTTP_PORT=3010' in cmd[cmd.index('-e') + 1]
+            assert 'grafana/grafana' in cmd
+
+    def test_start_grafana_always_mounts_dashboards(self, tmp_path):
+        """Grafana container should always mount the dashboards directory."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+        stack = MonitoringStack(cluster)
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        dashboards_dir = tmp_path / 'monitoring' / 'grafana' / 'dashboards'
+        dashboards_dir.mkdir(parents=True)
+        provisioning_dir = tmp_path / 'monitoring' / 'grafana' / 'provisioning'
+        provisioning_dir.mkdir(parents=True)
+
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = Mock(returncode=0, stdout='', stderr='')
+            stack._start_grafana()
+
+            cmd = mock_run.call_args[0][0]
+            volume_args = [cmd[i + 1] for i, v in enumerate(cmd) if v == '-v']
+            dashboards_mount = [v for v in volume_args if '/var/lib/grafana/dashboards' in v]
+            assert len(dashboards_mount) == 1, \
+                f"Should mount dashboards dir, volumes: {volume_args}"
+
+    def test_start_alertmanager_calls_docker_run(self, tmp_path):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+        stack = MonitoringStack(cluster, alertmanager_port=9103)
+
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = Mock(returncode=0, stdout='', stderr='')
+            stack._start_alertmanager()
+
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0:3] == ['docker', 'run', '-d']
+            assert '--net=host' in cmd
+            assert '--web.listen-address=:9103' in cmd
+            assert 'prom/alertmanager' in cmd
+
+    def test_start_raises_on_docker_failure(self, tmp_path):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+        stack = MonitoringStack(cluster)
+
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = Mock(returncode=1, stdout='', stderr='error')
+            with pytest.raises(RuntimeError, match="Failed to start Alertmanager"):
+                stack._start_alertmanager()
+
+
+class TestIsRunning:
+    """Tests for MonitoringStack.is_running."""
+
+    def test_not_running_when_no_connection(self):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = '/tmp/test'
+        stack = MonitoringStack(cluster)
+
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = Mock(stdout='', returncode=0)
+            assert stack.is_running() is False
+
+    def test_running_via_docker_ps_fallback(self):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = '/tmp/test'
+        stack = MonitoringStack(cluster)
+
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = Mock(stdout='abc123\n', returncode=0)
+            # HTTP probe fails, but docker ps finds container
+            assert stack.is_running() is True
+
+
+class TestStartIntegration:
+    """Tests for the full MonitoringStack.start() flow."""
+
+    def test_start_creates_configs_and_runs_containers(self, tmp_path):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = str(tmp_path)
+        cluster.nodelist.return_value = []
+
+        stack = MonitoringStack(cluster, prometheus_port=9090, grafana_port=3000)
+        stack._working_dir = str(tmp_path / 'monitoring')
+
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = Mock(returncode=0, stdout='', stderr='')
+            with patch.object(stack, '_wait_until_ready'):
+                stack.start()
+
+                # Should have called docker run 3 times (stop+rm calls too)
+                docker_run_calls = [
+                    c for c in mock_run.call_args_list
+                    if c[0][0][:2] == ['docker', 'run']
+                ]
+                assert len(docker_run_calls) == 3
+
+        # Verify config files were created
+        prometheus_config = tmp_path / 'monitoring' / 'prometheus' / 'prometheus.yml'
+        assert prometheus_config.exists()
+
+        grafana_datasource = (tmp_path / 'monitoring' / 'grafana' /
+                             'provisioning' / 'datasources' / 'prometheus.yml')
+        assert grafana_datasource.exists()
+
+
+class TestNotifyTopologyChange:
+    """Tests for the _notify_topology_change hook on Cluster."""
+
+    def test_hook_updates_targets_when_monitoring_active(self):
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.monitoring_enabled = True
+            cluster.monitoring_stack = Mock()
+            cluster.monitoring_stack.is_running.return_value = True
+
+            cluster._notify_topology_change()
+
+            cluster.monitoring_stack.update_targets.assert_called_once()
+
+    def test_hook_noop_when_monitoring_disabled(self):
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.monitoring_enabled = False
+            cluster.monitoring_stack = Mock()
+
+            cluster._notify_topology_change()
+
+            cluster.monitoring_stack.update_targets.assert_not_called()
+
+    def test_hook_noop_when_no_stack_and_reconnect_fails(self):
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.monitoring_enabled = True
+            cluster.monitoring_stack = None
+
+            # Base Cluster._reconnect_monitoring_stack is a no-op,
+            # so monitoring_stack stays None — should not raise
+            cluster._notify_topology_change()
+
+    def test_hook_reconnects_when_stack_is_none(self):
+        """When monitoring_enabled but stack is None (loaded from disk),
+        _notify_topology_change should try to reconnect before giving up."""
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.monitoring_enabled = True
+            cluster.monitoring_stack = None
+
+            mock_stack = Mock()
+            mock_stack.is_running.return_value = True
+
+            def do_reconnect():
+                cluster.monitoring_stack = mock_stack
+
+            with patch.object(cluster, '_reconnect_monitoring_stack',
+                              side_effect=do_reconnect) as mock_reconnect:
+                cluster._notify_topology_change()
+
+            mock_reconnect.assert_called_once()
+            mock_stack.update_targets.assert_called_once()
+
+    def test_hook_reconnects_but_stack_not_running(self):
+        """Reconnect succeeds but containers aren't running — no update."""
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.monitoring_enabled = True
+            cluster.monitoring_stack = None
+
+            mock_stack = Mock()
+            mock_stack.is_running.return_value = False
+
+            def do_reconnect():
+                cluster.monitoring_stack = mock_stack
+
+            with patch.object(cluster, '_reconnect_monitoring_stack',
+                              side_effect=do_reconnect):
+                cluster._notify_topology_change()
+
+            mock_stack.update_targets.assert_not_called()
+
+    def test_hook_noop_when_stack_not_running(self):
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.monitoring_enabled = True
+            cluster.monitoring_stack = Mock()
+            cluster.monitoring_stack.is_running.return_value = False
+
+            cluster._notify_topology_change()
+
+            cluster.monitoring_stack.update_targets.assert_not_called()
+
+    def test_hook_handles_update_failure(self):
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.monitoring_enabled = True
+            cluster.monitoring_stack = Mock()
+            cluster.monitoring_stack.is_running.return_value = True
+            cluster.monitoring_stack.update_targets.side_effect = RuntimeError("test error")
+
+            # Should not raise, just warn
+            cluster._notify_topology_change()
+
+
+class TestReconnectMonitoringStack:
+    """Tests for ScyllaCluster._reconnect_monitoring_stack."""
+
+    def test_reconnects_when_stack_is_none_and_containers_running(self, tmp_path):
+        """After loading from disk, monitoring_stack is None but containers
+        may still be running. _reconnect_monitoring_stack should find them."""
+        from ccmlib.scylla_cluster import ScyllaCluster
+        with patch.object(ScyllaCluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = ScyllaCluster(None, None)
+            cluster.monitoring_stack = None
+            cluster.monitoring_dir = str(tmp_path)
+            cluster.grafana_port = 3000
+            cluster.prometheus_port = 9090
+            cluster.alertmanager_port = 9093
+            cluster.get_path = lambda: str(tmp_path)
+
+            with patch.object(MonitoringStack, '__init__', lambda *a, **kw: None):
+                with patch.object(MonitoringStack, 'is_running', return_value=True):
+                    cluster._reconnect_monitoring_stack()
+
+            assert cluster.monitoring_stack is not None
+
+    def test_no_reconnect_when_containers_not_running(self, tmp_path):
+        """If containers aren't running, stays None."""
+        from ccmlib.scylla_cluster import ScyllaCluster
+        with patch.object(ScyllaCluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = ScyllaCluster(None, None)
+            cluster.monitoring_stack = None
+            cluster.monitoring_dir = str(tmp_path)
+            cluster.grafana_port = 3000
+            cluster.prometheus_port = 9090
+            cluster.alertmanager_port = 9093
+            cluster.get_path = lambda: str(tmp_path)
+
+            with patch.object(MonitoringStack, '__init__', lambda *a, **kw: None):
+                with patch.object(MonitoringStack, 'is_running', return_value=False):
+                    cluster._reconnect_monitoring_stack()
+
+            assert cluster.monitoring_stack is None
+
+    def test_skips_if_already_connected(self):
+        """If monitoring_stack is already set and running, don't reconnect."""
+        from ccmlib.scylla_cluster import ScyllaCluster
+        with patch.object(ScyllaCluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = ScyllaCluster(None, None)
+            existing_stack = Mock()
+            existing_stack.is_running.return_value = True
+            cluster.monitoring_stack = existing_stack
+
+            cluster._reconnect_monitoring_stack()
+
+            assert cluster.monitoring_stack is existing_stack
+
+    def test_stop_calls_reconnect(self, tmp_path):
+        """ScyllaCluster.stop() should reconnect and stop orphaned containers."""
+        from ccmlib.scylla_cluster import ScyllaCluster
+        with patch.object(ScyllaCluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = ScyllaCluster(None, None)
+            cluster.monitoring_stack = None
+            cluster.monitoring_dir = str(tmp_path)
+            cluster.grafana_port = 3000
+            cluster.prometheus_port = 9090
+            cluster.alertmanager_port = 9093
+            cluster._scylla_manager = None
+            cluster.skip_manager_server = False
+            cluster.nodes = {}
+
+            mock_stack = Mock()
+            mock_stack.is_running.return_value = True
+
+            with patch.object(cluster, '_reconnect_monitoring_stack') as mock_reconnect:
+                def do_reconnect():
+                    cluster.monitoring_stack = mock_stack
+                mock_reconnect.side_effect = do_reconnect
+
+                with patch.object(cluster, 'stop_nodes'):
+                    cluster.stop()
+
+                mock_reconnect.assert_called_once()
+                mock_stack.stop.assert_called_once()
+
+    def test_stop_keeps_monitoring_when_requested(self, tmp_path):
+        """ScyllaCluster.stop(keep_monitoring=True) should NOT stop monitoring containers."""
+        from ccmlib.scylla_cluster import ScyllaCluster
+        with patch.object(ScyllaCluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = ScyllaCluster(None, None)
+            cluster.monitoring_stack = None
+            cluster.monitoring_dir = str(tmp_path)
+            cluster.grafana_port = 3000
+            cluster.prometheus_port = 9090
+            cluster.alertmanager_port = 9093
+            cluster._scylla_manager = None
+            cluster.skip_manager_server = False
+            cluster.nodes = {}
+
+            with patch.object(cluster, '_reconnect_monitoring_stack') as mock_reconnect:
+                with patch.object(cluster, 'stop_nodes'):
+                    cluster.stop(keep_monitoring=True)
+
+                mock_reconnect.assert_not_called()
+
+    def test_stop_without_keep_monitoring_stops_stack(self, tmp_path):
+        """ScyllaCluster.stop() without keep_monitoring should stop monitoring (default behavior)."""
+        from ccmlib.scylla_cluster import ScyllaCluster
+        with patch.object(ScyllaCluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = ScyllaCluster(None, None)
+            cluster.monitoring_stack = None
+            cluster.monitoring_dir = str(tmp_path)
+            cluster.grafana_port = 3000
+            cluster.prometheus_port = 9090
+            cluster.alertmanager_port = 9093
+            cluster._scylla_manager = None
+            cluster.skip_manager_server = False
+            cluster.nodes = {}
+
+            mock_stack = Mock()
+            mock_stack.is_running.return_value = True
+
+            with patch.object(cluster, '_reconnect_monitoring_stack') as mock_reconnect:
+                def do_reconnect():
+                    cluster.monitoring_stack = mock_stack
+                mock_reconnect.side_effect = do_reconnect
+
+                with patch.object(cluster, 'stop_nodes'):
+                    cluster.stop()
+
+                mock_reconnect.assert_called_once()
+                mock_stack.stop.assert_called_once()
+
+
+class TestClusterRemoveKeepMonitoring:
+    """Tests for Cluster.remove(keep_monitoring=...) flag."""
+
+    def _make_cluster(self, tmp_path):
+        from ccmlib.scylla_cluster import ScyllaCluster
+        with patch.object(ScyllaCluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = ScyllaCluster(None, None)
+            cluster.monitoring_stack = None
+            cluster.monitoring_enabled = True
+            cluster.monitoring_dir = str(tmp_path)
+            cluster.grafana_port = 3000
+            cluster.prometheus_port = 9090
+            cluster.alertmanager_port = 9093
+            cluster._scylla_manager = None
+            cluster.skip_manager_server = False
+            cluster.nodes = {}
+            cluster.seeds = []
+            cluster.path = str(tmp_path)
+            cluster.name = 'test'
+            return cluster
+
+    def test_remove_stops_monitoring_by_default(self, tmp_path):
+        """cluster.remove() should stop monitoring containers by default."""
+        cluster = self._make_cluster(tmp_path)
+
+        mock_stack = Mock()
+        mock_stack.is_running.return_value = True
+
+        with patch.object(cluster, '_reconnect_monitoring_stack') as mock_reconnect:
+            def do_reconnect():
+                cluster.monitoring_stack = mock_stack
+            mock_reconnect.side_effect = do_reconnect
+
+            with patch.object(cluster, 'remove_dir_with_retry'):
+                cluster.remove()
+
+            mock_reconnect.assert_called_once()
+            mock_stack.stop.assert_called_once()
+
+    def test_remove_keeps_monitoring_when_requested(self, tmp_path):
+        """cluster.remove(keep_monitoring=True) should NOT stop monitoring containers."""
+        cluster = self._make_cluster(tmp_path)
+
+        with patch.object(cluster, '_reconnect_monitoring_stack') as mock_reconnect:
+            with patch.object(cluster, 'remove_dir_with_retry'):
+                cluster.remove(keep_monitoring=True)
+
+            mock_reconnect.assert_not_called()
+
+
+class TestClusterAddHook:
+    """Test that Cluster.add() calls _notify_topology_change."""
+
+    def test_add_calls_notify(self):
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.nodes = {}
+            cluster.seeds = []
+            cluster._config_options = {}
+            cluster._dse_config_options = {}
+            cluster._Cluster__log_level = "INFO"
+            cluster.path = '/tmp'
+            cluster.name = 'test'
+            cluster._Cluster__install_dir = '/fake'
+            cluster.partitioner = None
+            cluster.use_vnodes = False
+            cluster.id = 0
+            cluster.ipprefix = None
+            cluster.snitch = 'org.apache.cassandra.locator.PropertyFileSnitch'
+            cluster._debug = []
+            cluster._trace = []
+            cluster.monitoring_enabled = False
+            cluster.monitoring_stack = None
+            cluster.monitoring_dir = None
+            cluster.grafana_port = 3000
+            cluster.prometheus_port = 9090
+            cluster.alertmanager_port = 9093
+
+            node = Mock()
+            node.name = 'node1'
+            node.data_center = None
+            node.rack = None
+
+            with patch.object(cluster, '_update_config'):
+                with patch.object(cluster, '_notify_topology_change') as mock_notify:
+                    cluster.add(node, is_seed=False)
+                    mock_notify.assert_called_once()
+
+
+class TestClusterRemoveHook:
+    """Test that Cluster.remove() calls _notify_topology_change."""
+
+    def test_remove_node_calls_notify(self):
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.seeds = []
+            cluster.path = '/tmp'
+            cluster.name = 'test'
+            cluster._Cluster__install_dir = '/fake'
+            cluster.partitioner = None
+            cluster._config_options = {}
+            cluster._dse_config_options = {}
+            cluster._Cluster__log_level = "INFO"
+            cluster.use_vnodes = False
+            cluster.id = 0
+            cluster.ipprefix = None
+            cluster.monitoring_enabled = False
+            cluster.monitoring_stack = None
+            cluster.monitoring_dir = None
+            cluster.grafana_port = 3000
+            cluster.prometheus_port = 9090
+            cluster.alertmanager_port = 9093
+
+            node = Mock()
+            node.name = 'node1'
+            cluster.nodes = {'node1': node}
+
+            with patch.object(cluster, '_update_config'):
+                with patch.object(cluster, '_notify_topology_change') as mock_notify:
+                    with patch.object(cluster, 'remove_dir_with_retry'):
+                        cluster.remove(node)
+                        mock_notify.assert_called_once()
+
+
+class TestAddNodeTargetsIntegration:
+    """End-to-end tests: adding/starting nodes updates the targets file correctly.
+
+    These verify the full flow from cluster.add() / node status change through
+    _notify_topology_change() to the actual scylla_servers.yml content on disk.
+    """
+
+    def _make_cluster_with_monitoring(self, tmp_path, initial_nodes):
+        """Create a cluster with monitoring enabled and an initial set of UP nodes.
+
+        initial_nodes: list of (name, address, data_center) tuples.
+        Returns (cluster, stack, targets_file_path).
+        """
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.nodes = {}
+            cluster.seeds = []
+            cluster._config_options = {}
+            cluster._dse_config_options = {}
+            cluster._Cluster__log_level = "INFO"
+            cluster.path = str(tmp_path)
+            cluster.name = 'test'
+            cluster._Cluster__install_dir = '/fake'
+            cluster.partitioner = None
+            cluster.use_vnodes = False
+            cluster.id = 0
+            cluster.ipprefix = None
+            cluster.snitch = 'org.apache.cassandra.locator.PropertyFileSnitch'
+            cluster._debug = []
+            cluster._trace = []
+            cluster.monitoring_enabled = True
+            cluster.monitoring_dir = None
+            cluster.grafana_port = 3000
+            cluster.prometheus_port = 9090
+            cluster.alertmanager_port = 9093
+
+            for name, addr, dc in initial_nodes:
+                node = Mock()
+                node.name = name
+                node.address.return_value = addr
+                node.status = Status.UP
+                node.is_running.return_value = True
+                node.data_center = dc
+                cluster.nodes[name] = node
+
+            cluster.nodelist = lambda: [cluster.nodes[n] for n in cluster.nodes]
+
+            stack = MonitoringStack(cluster)
+            stack._working_dir = str(tmp_path / 'monitoring')
+            cluster.monitoring_stack = stack
+
+            # Write initial targets
+            stack.update_targets()
+
+            targets_file = tmp_path / 'monitoring' / 'prometheus' / 'targets' / 'scylla_servers.yml'
+            return cluster, stack, targets_file
+
+    def _read_targets(self, targets_file):
+        with open(targets_file) as f:
+            return json.load(f)
+
+    def _all_target_addresses(self, targets_data):
+        """Flatten all target addresses from the targets YAML structure."""
+        addrs = set()
+        for entry in targets_data:
+            addrs.update(entry['targets'])
+        return addrs
+
+    def test_added_uninitialized_node_not_in_targets(self, tmp_path):
+        """After cluster.add(), node is UNINITIALIZED and must NOT appear in targets."""
+        cluster, stack, targets_file = self._make_cluster_with_monitoring(tmp_path, [
+            ('node1', '127.0.0.1', 'dc1'),
+            ('node2', '127.0.0.2', 'dc1'),
+            ('node3', '127.0.0.3', 'dc1'),
+        ])
+
+        # Add node4 — it starts as UNINITIALIZED
+        node4 = Mock()
+        node4.name = 'node4'
+        node4.address.return_value = '127.0.0.4'
+        node4.status = Status.UNINITIALIZED
+        node4.is_running.return_value = False
+        node4.data_center = 'dc1'
+        node4.rack = 'RAC1'
+        cluster.nodes['node4'] = node4
+
+        # Simulate what _notify_topology_change does
+        stack.update_targets()
+
+        targets = self._read_targets(targets_file)
+        addrs = self._all_target_addresses(targets)
+        assert '127.0.0.4' not in addrs
+        assert addrs == {'127.0.0.1', '127.0.0.2', '127.0.0.3'}
+
+    def test_started_node_appears_in_targets(self, tmp_path):
+        """After node starts (status → UP), it MUST appear in targets."""
+        cluster, stack, targets_file = self._make_cluster_with_monitoring(tmp_path, [
+            ('node1', '127.0.0.1', 'dc1'),
+            ('node2', '127.0.0.2', 'dc1'),
+            ('node3', '127.0.0.3', 'dc1'),
+        ])
+
+        # Add node4 as UNINITIALIZED, then start it (status → UP)
+        node4 = Mock()
+        node4.name = 'node4'
+        node4.address.return_value = '127.0.0.4'
+        node4.status = Status.UNINITIALIZED
+        node4.is_running.return_value = False
+        node4.data_center = 'dc1'
+        node4.rack = 'RAC1'
+        cluster.nodes['node4'] = node4
+
+        # Simulate node start: status changes to UP
+        node4.status = Status.UP
+        node4.is_running.return_value = True
+        stack.update_targets()
+
+        targets = self._read_targets(targets_file)
+        addrs = self._all_target_addresses(targets)
+        assert '127.0.0.4' in addrs
+        assert addrs == {'127.0.0.1', '127.0.0.2', '127.0.0.3', '127.0.0.4'}
+
+    def test_add_multiple_nodes_all_appear_after_start(self, tmp_path):
+        """Adding 3 new nodes and starting them all updates targets correctly."""
+        cluster, stack, targets_file = self._make_cluster_with_monitoring(tmp_path, [
+            ('node1', '127.0.0.1', 'dc1'),
+            ('node2', '127.0.0.2', 'dc1'),
+            ('node3', '127.0.0.3', 'dc1'),
+        ])
+
+        # Add nodes 4, 5, 6 — all start as UNINITIALIZED
+        for i in (4, 5, 6):
+            node = Mock()
+            node.name = f'node{i}'
+            node.address.return_value = f'127.0.0.{i}'
+            node.status = Status.UNINITIALIZED
+            node.is_running.return_value = False
+            node.data_center = 'dc1'
+            node.rack = f'RAC{((i - 1) % 3) + 1}'
+            cluster.nodes[f'node{i}'] = node
+
+        stack.update_targets()
+        addrs = self._all_target_addresses(self._read_targets(targets_file))
+        assert addrs == {'127.0.0.1', '127.0.0.2', '127.0.0.3'}, \
+            "UNINITIALIZED nodes must not appear in targets"
+
+        # Start all new nodes
+        for i in (4, 5, 6):
+            cluster.nodes[f'node{i}'].status = Status.UP
+            cluster.nodes[f'node{i}'].is_running.return_value = True
+
+        stack.update_targets()
+        addrs = self._all_target_addresses(self._read_targets(targets_file))
+        assert addrs == {f'127.0.0.{i}' for i in range(1, 7)}, \
+            "All 6 started nodes must appear in targets"
+
+    def test_add_node_different_dc(self, tmp_path):
+        """Adding a node to a different DC creates a new target group."""
+        cluster, stack, targets_file = self._make_cluster_with_monitoring(tmp_path, [
+            ('node1', '127.0.0.1', 'dc1'),
+            ('node2', '127.0.0.2', 'dc1'),
+            ('node3', '127.0.0.3', 'dc1'),
+        ])
+
+        node4 = Mock()
+        node4.name = 'node4'
+        node4.address.return_value = '127.0.0.4'
+        node4.status = Status.UP
+        node4.is_running.return_value = True
+        node4.data_center = 'dc2'
+        node4.rack = 'RAC1'
+        cluster.nodes['node4'] = node4
+
+        stack.update_targets()
+
+        targets = self._read_targets(targets_file)
+        dc_map = {t['labels']['dc']: set(t['targets']) for t in targets}
+        assert dc_map == {
+            'dc1': {'127.0.0.1', '127.0.0.2', '127.0.0.3'},
+            'dc2': {'127.0.0.4'},
+        }
+
+    def test_decommission_keeps_node_in_targets(self, tmp_path):
+        """Decommissioned nodes stay in targets (still running, metrics available)."""
+        cluster, stack, targets_file = self._make_cluster_with_monitoring(tmp_path, [
+            ('node1', '127.0.0.1', 'dc1'),
+            ('node2', '127.0.0.2', 'dc1'),
+            ('node3', '127.0.0.3', 'dc1'),
+        ])
+
+        cluster.nodes['node3'].status = Status.DECOMMISSIONED
+        stack.update_targets()
+
+        addrs = self._all_target_addresses(self._read_targets(targets_file))
+        assert '127.0.0.3' in addrs
+
+    def test_remove_decommissioned_node_removes_from_targets(self, tmp_path):
+        """After removing a decommissioned node from the cluster, targets shrink."""
+        cluster, stack, targets_file = self._make_cluster_with_monitoring(tmp_path, [
+            ('node1', '127.0.0.1', 'dc1'),
+            ('node2', '127.0.0.2', 'dc1'),
+            ('node3', '127.0.0.3', 'dc1'),
+        ])
+
+        # Decommission and remove node3
+        del cluster.nodes['node3']
+        stack.update_targets()
+
+        addrs = self._all_target_addresses(self._read_targets(targets_file))
+        assert addrs == {'127.0.0.1', '127.0.0.2'}
+
+    def test_full_node_replacement_flow(self, tmp_path):
+        """Simulate the full 8.5 flow: add 3 new nodes, decommission original 3.
+
+        Targets should transition from {1,2,3} → {1,2,3,4,5,6} → {4,5,6}.
+        """
+        cluster, stack, targets_file = self._make_cluster_with_monitoring(tmp_path, [
+            ('node1', '127.0.0.1', 'dc1'),
+            ('node2', '127.0.0.2', 'dc1'),
+            ('node3', '127.0.0.3', 'dc1'),
+        ])
+
+        # Stage 4a: add 3 new nodes, start them
+        for i in (4, 5, 6):
+            node = Mock()
+            node.name = f'node{i}'
+            node.address.return_value = f'127.0.0.{i}'
+            node.status = Status.UP
+            node.is_running.return_value = True
+            node.data_center = 'dc1'
+            cluster.nodes[f'node{i}'] = node
+
+        stack.update_targets()
+        addrs = self._all_target_addresses(self._read_targets(targets_file))
+        assert addrs == {f'127.0.0.{i}' for i in range(1, 7)}
+
+        # Stage 4c: decommission original nodes one by one
+        for i in (3, 2, 1):
+            cluster.nodes[f'node{i}'].status = Status.DECOMMISSIONED
+            stack.update_targets()
+            # Decommissioned nodes stay in targets
+            assert f'127.0.0.{i}' in self._all_target_addresses(
+                self._read_targets(targets_file))
+
+        # After removal of decommissioned nodes
+        for i in (3, 2, 1):
+            del cluster.nodes[f'node{i}']
+
+        stack.update_targets()
+        addrs = self._all_target_addresses(self._read_targets(targets_file))
+        assert addrs == {'127.0.0.4', '127.0.0.5', '127.0.0.6'}
+
+
+class TestConfigPersistence:
+    """Test that monitoring fields are persisted in cluster.conf."""
+
+    def test_update_config_includes_monitoring_fields(self, tmp_path):
+        cluster_dir = tmp_path / 'test'
+        cluster_dir.mkdir()
+
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.name = 'test'
+            cluster.path = str(tmp_path)
+            cluster.nodes = {}
+            cluster.seeds = []
+            cluster.partitioner = None
+            cluster._Cluster__install_dir = '/fake'
+            cluster._config_options = {}
+            cluster._dse_config_options = {}
+            cluster._Cluster__log_level = "INFO"
+            cluster.use_vnodes = False
+            cluster.id = 0
+            cluster.ipprefix = None
+            cluster.monitoring_enabled = True
+            cluster.monitoring_dir = '/some/monitoring/dir'
+            cluster.grafana_port = 3001
+            cluster.prometheus_port = 9091
+            cluster.alertmanager_port = 9094
+
+            cluster._update_config()
+
+            from ruamel.yaml import YAML
+            conf_file = cluster_dir / 'cluster.conf'
+            with open(conf_file) as f:
+                data = YAML().load(f)
+
+            assert data['monitoring_enabled'] is True
+            assert data['monitoring_dir'] == '/some/monitoring/dir'
+            assert data['grafana_port'] == 3001
+            assert data['prometheus_port'] == 9091
+            assert data['alertmanager_port'] == 9094
+
+    def test_update_config_default_monitoring_fields(self, tmp_path):
+        cluster_dir = tmp_path / 'test'
+        cluster_dir.mkdir()
+
+        with patch.object(Cluster, '__init__', lambda x, *args, **kwargs: None):
+            cluster = Cluster(None, None)
+            cluster.name = 'test'
+            cluster.path = str(tmp_path)
+            cluster.nodes = {}
+            cluster.seeds = []
+            cluster.partitioner = None
+            cluster._Cluster__install_dir = '/fake'
+            cluster._config_options = {}
+            cluster._dse_config_options = {}
+            cluster._Cluster__log_level = "INFO"
+            cluster.use_vnodes = False
+            cluster.id = 0
+            cluster.ipprefix = None
+            cluster.monitoring_enabled = False
+            cluster.monitoring_dir = None
+            cluster.grafana_port = 3000
+            cluster.prometheus_port = 9090
+            cluster.alertmanager_port = 9093
+
+            cluster._update_config()
+
+            from ruamel.yaml import YAML
+            conf_file = cluster_dir / 'cluster.conf'
+            with open(conf_file) as f:
+                data = YAML().load(f)
+
+            assert data['monitoring_enabled'] is False
+            assert data['monitoring_dir'] is None
+            assert data['grafana_port'] == 3000
+
+
+class TestMonitoringStackPorts:
+    """Tests for MonitoringStack port configuration."""
+
+    def test_default_ports(self):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = '/tmp/test'
+        stack = MonitoringStack(cluster)
+        assert stack.grafana_port == 3000
+        assert stack.prometheus_port == 9090
+        assert stack.alertmanager_port == 9093
+
+    def test_custom_ports(self):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = '/tmp/test'
+        stack = MonitoringStack(
+            cluster,
+            grafana_port=3001, prometheus_port=9091, alertmanager_port=9094
+        )
+        assert stack.grafana_port == 3001
+        assert stack.prometheus_port == 9091
+        assert stack.alertmanager_port == 9094
+
+    def test_urls_use_configured_ports(self):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = '/tmp/test'
+        stack = MonitoringStack(
+            cluster,
+            grafana_port=4000, prometheus_port=9100
+        )
+        assert stack.grafana_url() == 'http://localhost:4000'
+        assert stack.prometheus_url() == 'http://localhost:9100'
+
+    def test_default_addresses(self):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = '/tmp/test'
+        stack = MonitoringStack(cluster)
+        assert stack.grafana_address() == ('localhost', 3000)
+        assert stack.prometheus_address() == ('localhost', 9090)
+
+    def test_custom_addresses(self):
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = '/tmp/test'
+        stack = MonitoringStack(
+            cluster,
+            grafana_port=4000, prometheus_port=9100
+        )
+        assert stack.grafana_address() == ('localhost', 4000)
+        assert stack.prometheus_address() == ('localhost', 9100)
+
+
+class TestPortAvailability:
+    """Tests for port sniffing and auto-selection."""
+
+    def test_is_port_available_free_port(self):
+        assert _is_port_available(0) is True  # OS picks a free port
+
+    def test_is_port_available_occupied_port(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('127.0.0.1', 0))
+            port = s.getsockname()[1]
+            assert _is_port_available(port) is False
+
+    def test_find_available_port_returns_start_when_free(self):
+        # Find a free port first, then confirm _find_available_port returns it
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('127.0.0.1', 0))
+            port = s.getsockname()[1]
+        # Now the port is free again
+        assert _find_available_port(port) == port
+
+    def test_find_available_port_skips_occupied(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('127.0.0.1', 0))
+            occupied = s.getsockname()[1]
+            result = _find_available_port(occupied)
+            assert result > occupied
+
+    def test_find_available_port_raises_on_exhaustion(self):
+        with pytest.raises(RuntimeError, match="Could not find a free port"):
+            with patch('ccmlib.scylla_monitoring._is_port_available',
+                       return_value=False):
+                _find_available_port(3000, max_attempts=5)
+
+    def test_resolve_ports_bumps_occupied(self):
+        """_resolve_ports should find next free port and update cluster."""
+        # Grab a port by binding, keep it held so it's occupied
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(('127.0.0.1', 0))
+            occupied = s.getsockname()[1]
+
+            cluster = Mock()
+            cluster.name = 'test'
+            cluster.get_path.return_value = '/tmp/test'
+            cluster.grafana_port = occupied
+            cluster.prometheus_port = 39901
+            cluster.alertmanager_port = 39902
+
+            stack = MonitoringStack(cluster,
+                                    grafana_port=occupied,
+                                    prometheus_port=39901,
+                                    alertmanager_port=39902)
+
+            stack._resolve_ports()
+
+        assert stack.grafana_port != occupied
+        assert stack.grafana_port > occupied
+        assert cluster.grafana_port == stack.grafana_port
+
+    def test_resolve_ports_keeps_free_ports(self):
+        """If all ports are already free, nothing changes."""
+        cluster = Mock()
+        cluster.name = 'test'
+        cluster.get_path.return_value = '/tmp/test'
+
+        # Use high ports very likely to be free
+        stack = MonitoringStack(cluster,
+                                grafana_port=39123,
+                                prometheus_port=39124,
+                                alertmanager_port=39125)
+
+        stack._resolve_ports()
+        assert stack.grafana_port == 39123
+        assert stack.prometheus_port == 39124
+        assert stack.alertmanager_port == 39125
+
+
+class TestCCMMonitoringEnvVar:
+    """Tests for CCM_MONITORING environment variable.
+
+    The env var is only checked at cluster creation time (in ClusterCreateCmd)
+    and acts as a default for --monitoring. Once persisted to cluster.conf,
+    the env var is no longer consulted.
+    """
+
+    def _create_scylla_cluster(self, tmp_path):
+        """Create a ScyllaCluster with minimal setup."""
+        from ccmlib.scylla_cluster import ScyllaCluster
+        install_dir = tmp_path / 'install'
+        install_dir.mkdir(exist_ok=True)
+        with patch('ccmlib.common.validate_install_dir'):
+            with patch('ccmlib.common.scylla_extract_install_dir_and_mode',
+                       return_value=(str(install_dir), 'release')):
+                with patch.object(Cluster, '_Cluster__get_version_from_build', return_value='5.4'):
+                    with patch.object(ScyllaCluster, '_update_config'):
+                        cluster = ScyllaCluster(
+                            str(tmp_path), 'test',
+                            install_dir=str(install_dir))
+        return cluster
+
+    def test_init_does_not_read_env_var(self, tmp_path, monkeypatch):
+        """ScyllaCluster.__init__ no longer reads CCM_MONITORING.
+
+        The env var is only handled at cluster creation time (CLI layer),
+        so constructing a ScyllaCluster with the env var set should NOT
+        enable monitoring — it defaults to False from the base class.
+        """
+        monkeypatch.setenv('CCM_MONITORING', '1')
+        cluster = self._create_scylla_cluster(tmp_path)
+        assert cluster.monitoring_enabled is False
+
+    def test_env_var_not_set_keeps_default(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('CCM_MONITORING', raising=False)
+        cluster = self._create_scylla_cluster(tmp_path)
+        assert cluster.monitoring_enabled is False
+
+    def test_cluster_create_cmd_reads_env_var(self, monkeypatch):
+        """ClusterCreateCmd.run() should enable monitoring when CCM_MONITORING is set."""
+        from ccmlib.cmds.cluster_cmds import ClusterCreateCmd
+        from unittest.mock import MagicMock
+        from optparse import Values
+
+        cmd = ClusterCreateCmd.__new__(ClusterCreateCmd)
+        cmd.options = Values({
+            'monitoring': False,
+            'monitoring_dir': None,
+            'grafana_port': 3000,
+            'prometheus_port': 9090,
+            'alertmanager_port': 9093,
+            'id': 0,
+        })
+
+        # Simulate CCM_MONITORING=1
+        monkeypatch.setenv('CCM_MONITORING', '1')
+
+        # The env var check happens before the isinstance check, so we can
+        # test just the env var logic in isolation.
+        if not cmd.options.monitoring:
+            ccm_monitoring = os.environ.get('CCM_MONITORING', '')
+            if ccm_monitoring and ccm_monitoring != '0':
+                cmd.options.monitoring = True
+
+        assert cmd.options.monitoring is True
+
+    def test_cluster_create_cmd_ignores_empty_env_var(self, monkeypatch):
+        """ClusterCreateCmd should not enable monitoring when CCM_MONITORING is empty."""
+        from optparse import Values
+
+        options = Values({'monitoring': False})
+
+        monkeypatch.setenv('CCM_MONITORING', '')
+
+        if not options.monitoring:
+            ccm_monitoring = os.environ.get('CCM_MONITORING', '')
+            if ccm_monitoring and ccm_monitoring != '0':
+                options.monitoring = True
+
+        assert options.monitoring is False
+
+    def test_cluster_create_cmd_ignores_zero_env_var(self, monkeypatch):
+        """ClusterCreateCmd should not enable monitoring when CCM_MONITORING is '0'."""
+        from optparse import Values
+
+        options = Values({'monitoring': False})
+
+        monkeypatch.setenv('CCM_MONITORING', '0')
+
+        if not options.monitoring:
+            ccm_monitoring = os.environ.get('CCM_MONITORING', '')
+            if ccm_monitoring and ccm_monitoring != '0':
+                options.monitoring = True
+
+        assert options.monitoring is False


### PR DESCRIPTION
## Summary

Split out of #724, which stalled on design feedback (see below). #724 itself does not carry any podman-cluster code — but on my local branch its commit had gotten tangled up with unrelated in-progress podman-cluster work during a rebase, so this PR also serves to decouple the two and get monitoring reviewed independently. This PR is the monitoring-stack feature alone, on top of current master:

- `MonitoringStack` (`ccmlib/scylla_monitoring.py`): spins up Prometheus + Grafana + Alertmanager as Docker containers with `--net=host`, alongside any CCM cluster.
- Automatic mode (`--monitoring` / `CCM_MONITORING=1`) keeps Prometheus scrape targets in sync on every topology change (add/remove/start/stop/decommission). Manual mode (`ccm monitoring start/stop/sync/status`) gives on-demand control.
- Per-cluster port offsets so multiple monitored clusters can run at once.
- Auto-clones `scylla-monitoring` for real dashboards; falls back to a built-in overview dashboard when unavailable.

## Differences from #724

This is not an identical copy of #724 — a few things changed:

- **Target registration fix (mine, not in #724):** uses `node.is_running()` instead of gossip `Status.UP/DECOMMISSIONED`, so a newly-started node is scraped immediately instead of waiting to join the ring.
- **`Cluster.remove(keep_monitoring=True)` bug fix (not in #724):** `_notify_topology_change()` was unconditionally reconnecting the monitoring stack on a full cluster teardown, even when the caller asked to leave it alone. Now it's only called on single-node removal, where reconnecting to update targets is actually the point.
- **Container/dashboard robustness improvements, generic (not podman-related), not in #724:**
  - SELinux relabeling (`_relabel_for_container`, `:z` bind-mount flags) so Prometheus/Grafana can read bind-mounted files on SELinux-enforcing hosts.
  - Dashboard template placeholder substitution (`-R __REFRESH_INTERVAL__=5m`, etc.) — without it, `make_dashboards.py` leaves `__REFRESH_INTERVAL__` and friends literal in the generated JSON and Grafana rejects the dashboard.
  - `start_alertmanager` flag to skip Alertmanager for ad-hoc/test clusters that only want dashboards.
  - Grafana now defaults to the generated Overview dashboard as its home page instead of Grafana's empty default.
- **Explicitly does NOT include** podman-cluster network integration (`podman_network`/`_net_args`/`_setup_prometheus_routes`). This code doesn't exist in #724 — it was added locally on my branch when this commit got rebased alongside separate, in-progress podman-cluster work (#731). Stripped here so this PR stands alone, independent of podman-cluster support.

Otherwise this is #724's `MonitoringStack` design (Prometheus + Grafana + Alertmanager as Docker containers with `--net=host`, automatic/manual modes, per-cluster port offsets, scylla-monitoring dashboard generation with built-in fallback), rebased onto current master.

## Known open item

`#724` had unresolved design discussion (@fruch / @dkropachev) about whether this should instead reuse `scylla-monitoring`'s own `start-all.sh`/`kill-all.sh` rather than duplicating container/dashboard management here. That discussion is not resolved by this PR — opening this mainly to get the code path decoupled from the podman-cluster work and independently reviewable.

## Test plan

- `tests/test_scylla_monitoring.py` — 107/108 unit tests pass (1 pre-existing failure is an environment collision: the test makes a live HTTP call to `localhost:9090`, which happens to be occupied by another service on some dev boxes; passes in CI).
- `tests/test_monitoring_integration.py` — 16/18 pass; the 2 failing require a live Scylla cluster emitting real metrics (not available in this sandbox).